### PR TITLE
Manually add `dynatrace-dql` workspace to commit `v2.1.5` for backstage `1.32.2` on branch `release-1.4`

### DIFF
--- a/workspaces/dynatrace-dql/plugins-list.yaml
+++ b/workspaces/dynatrace-dql/plugins-list.yaml
@@ -1,0 +1,2 @@
+plugins/dql:
+plugins/dql-backend: 

--- a/workspaces/dynatrace-dql/source.json
+++ b/workspaces/dynatrace-dql/source.json
@@ -1,1 +1,1 @@
-{ "repo": "https://github.com/Dynatrace/backstage-plugin", "repo-ref": "v2.1.5" }
+{ "repo": "https://github.com/Dynatrace/backstage-plugin", "repo-ref": "v2.1.5", "repo-flat": true }

--- a/workspaces/dynatrace-dql/source.json
+++ b/workspaces/dynatrace-dql/source.json
@@ -1,1 +1,1 @@
-{ "repo": "https://github.com/Dynatrace/backstage-plugin", "repo-ref": "v2.1.5", "repo-flat": true }
+{ "repo": "https://github.com/Dynatrace/backstage-plugin", "repo-ref": "b2a5b1f83d73d849b459394f5192c76618439c12", "repo-flat": true }

--- a/workspaces/dynatrace-dql/source.json
+++ b/workspaces/dynatrace-dql/source.json
@@ -1,0 +1,1 @@
+{ "repo": "https://github.com/Dynatrace/backstage-plugin", "repo-ref": "v2.1.5" }

--- a/workspaces/dynatrace-dql/source.json
+++ b/workspaces/dynatrace-dql/source.json
@@ -1,1 +1,1 @@
-{ "repo": "https://github.com/Dynatrace/backstage-plugin", "repo-ref": "b2a5b1f83d73d849b459394f5192c76618439c12", "repo-flat": true }
+{ "repo": "https://github.com/Dynatrace/backstage-plugin", "repo-ref": "v2.2.0", "repo-flat": true }


### PR DESCRIPTION
Add `dynatrace-dql` at commit `v2.1.5` for backstage `1.32.2` on branch `release-1.4`.

  This PR was created manually.
  You might need to complete it with additional dynamic plugin export information, like:
  - the associated `app-config.dynamic.yaml` file for frontend plugins,
  - optionally the `scalprum-config.json` file for frontend plugins,
  - optionally some overlay source files for backend or frontend plugins.
  
  Before merging, you need to export the workspace dynamic plugins as OCI images,
  and test them inside a RHDH instance.

  To do so, you can use the `/publish` instruction in a PR review comment.
  This will start a PR check workflow to:
  - export the workspace plugins as dynamic plugins,
  - publish then as OCI images
  - push the oci-images in the GitHub container registry with a PR-specific tag.
  
  Followup of PR #192
  