### PR TITLE
[release-1.5] feat(npm): add backend

### DIFF
--- a/workspaces/npm/plugins-list.yaml
+++ b/workspaces/npm/plugins-list.yaml
@@ -1,1 +1,2 @@
 plugins/npm:
+plugins/npm-backend:

--- a/workspaces/npm/plugins/npm-backend/app-config.example.yaml
+++ b/workspaces/npm/plugins/npm-backend/app-config.example.yaml
@@ -1,0 +1,9 @@
+npm:
+  defaultRegistry: npmjs
+  registries:
+    - name: npmjs
+      url: https://registry.npmjs.com
+    - name: github
+      url: https://npm.pkg.github.com
+    - name: gitlab
+      url: https://gitlab.com/api/v4/packages/npm


### PR DESCRIPTION
The backend was already available in the current picked version for release-1.5

https://github.com/backstage/community-plugins/tree/335037a9f57eef5a989363cb9779cfaeb8c81f9b/workspaces/npm/plugins