### PR TITLE
[release-1.5] chore: add first version of a codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,41 @@
+# This file registers ownership for certain parts of the rhdh-plugin-export-overlays repo.
+# Review from a member of the corresponding code owner is required to merge pull requests.
+#
+# The last matching pattern takes precedence.
+# https://help.github.com/articles/about-codeowners/
+#
+# The list is alphabetical ordered.
+# In VS code: select the lines and select ">Sort Lines Ascending" from the Commands menu.
+
+*                                                                       @davidfestal @gashcrumb @kadel
+/workspaces/3scale                                                      @04kash @AndrienkoAleksandr
+/workspaces/acr                                                         @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff
+/workspaces/adoption-insights                                           @rohitkrai03 @karthikjeeyar 
+/workspaces/ai-integrations                                             @johnmcollier @gabemontero @rohitkrai03 @karthikjeeyar @eswaraiahsapram @lucifergene
+/workspaces/analytics/plugins/analytics-provider-segment                @AndrienkoAleksandr @PatAKnight @dzemanov
+/workspaces/bulk-import                                                 @christoph-jerolimov @debsmita1 @rm3l
+/workspaces/global-floating-action-button                               @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
+/workspaces/global-header                                               @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
+/workspaces/homepage                                                    @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
+/workspaces/jfrog-artifactory                                           @BethGriggs
+/workspaces/keycloak                                                    @AndrienkoAleksandr @schultzp2020 @dzemanov
+/workspaces/lightspeed                                                  @karthikjeeyar @yangcao77 @rohitkrai03
+/workspaces/marketplace                                                 @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff @karthikjeeyar
+/workspaces/nexus-repository-manager                                    @schultzp2020
+/workspaces/npm                                                         @christoph-jerolimov @ciiay @karthikjeeyar
+/workspaces/ocm                                                         @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff
+/workspaces/odo                                                         @rm3l
+/workspaces/openshift-image-registry                                    @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff @karthikjeeyar
+/workspaces/orchestrator                                                @batzionb @mareklibra @gciavarrini
+/workspaces/pingidentity                                                @jessicajhee
+/workspaces/rbac                                                        @AndrienkoAleksandr @christoph-jerolimov @divyanshiGupta @PatAKnight @dzemanov
+/workspaces/redhat-resource-optimization                                @christoph-jerolimov
+/workspaces/sandbox                                                     @lucifergene @rohitkrai03 @karthikjeeyar @xcoulon @alexeykazakov @mfrancisc
+/workspaces/scaffolder-backend-module-annotator                         @BethGriggs @debsmita1
+/workspaces/scaffolder-backend-module-kubernetes                        @BethGriggs @debsmita1
+/workspaces/scaffolder-backend-module-regex                             @04kash
+/workspaces/scaffolder-backend-module-servicenow                        @schultzp2020
+/workspaces/scaffolder-backend-module-sonarqube                         @04kash @schultzp2020
+/workspaces/scaffolder-relation-processor                               @04kash
+/workspaces/theme                                                       @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
+/workspaces/topology                                                    @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff


### PR DESCRIPTION
Adds a codeowners file with a fallback to @redhat-developer/rhdh-plugins-maintainers and @davidfestal 

Afaik: Users must still have write access. So users who are not part of our org or have write access don't matter.

The last matching pattern takes precedence. See https://help.github.com/articles/about-codeowners/

The initial version is based on https://github.com/backstage/community-plugins/blob/main/.github/CODEOWNERS and https://github.com/redhat-developer/rhdh-plugins/blob/main/.github/CODEOWNERS