### PR TITLE
fix(rbac): remove the static rbac backend plugin

### DIFF
--- a/workspaces/rbac/plugins-list.yaml
+++ b/workspaces/rbac/plugins-list.yaml
@@ -1,2 +1,1 @@
 plugins/rbac:
-plugins/rbac-backend:


### PR DESCRIPTION
Removes the static rbac backend plugin from the plugin list

Updates PR #958 