### PR TITLE
fix(bulk-import): add scalprum config to remove janus-idp from name

### DIFF
--- a/workspaces/bulk-import/plugins/bulk-import/scalprum-config.json
+++ b/workspaces/bulk-import/plugins/bulk-import/scalprum-config.json
@@ -1,0 +1,6 @@
+{
+  "name": "red-hat-developer-hub.backstage-plugin-bulk-import",
+  "exposedModules": {
+    "PluginRoot": "./src/index.ts"
+  }
+}


### PR DESCRIPTION
Adds the scalprum config to replace the error in the bulk import package json. Looks like whenever the plugin was migrated, the original [package.json](https://github.com/redhat-developer/rhdh-plugins/blob/ca96fed05c3bcbecc052bc4372e3c13e57f842f0/workspaces/bulk-import/plugins/bulk-import/package.json#L84) wasn't updated. Also, updates the `exposedModules` from `BulkImportPlugin` to `PluginRoot` to match the [packages.json](https://github.com/redhat-developer/rhdh/blob/release-1.5/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import/package.json#L47) within the wrapper.

Updates PR #903 