### PR TITLE
fix(azure-devops): add embed-package for azure-annotator-processor

### DIFF
--- a/workspaces/azure-devops/plugins-list.yaml
+++ b/workspaces/azure-devops/plugins-list.yaml
@@ -1,4 +1,4 @@
 plugins/azure-devops:
 plugins/azure-devops-backend:
-plugins/catalog-backend-module-azure-devops-annotator-processor:
+plugins/catalog-backend-module-azure-devops-annotator-processor: --embed-package @backstage-community/plugin-azure-devops-common
 plugins/scaffolder-backend-module-azure-devops:


### PR DESCRIPTION
Adds the embedded package `@backstage-community/plugin-azure-devops-common`  to the `@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor`

Fixes: #982 

Updates: #897 