### PR TITLE
Support patterns to identify active release branches...

### DIFF
--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -53,7 +53,7 @@ jobs:
     with:
       regexps: ${{ needs.prepare.outputs.regexps }}
       overlay-repo: ${{ github.repository }}      
-      release-branch-prefix: release-
+      release-branch-pattern: ^release-(1\.5|1\.6|1\.7)$
       verbose: ${{ inputs.verbose != '' && inputs.verbose }}
       debug: ${{ inputs.debug != '' && inputs.debug }}
     permissions:


### PR DESCRIPTION
Support patterns to identify active release branches and remove the old `release 1.4` branch from watched branches.