### PR TITLE
fix(lighthouse): add missing icon for lighthouse plugin

### DIFF
--- a/workspaces/lighthouse/plugins/lighthouse/overlay/src/index.ts
+++ b/workspaces/lighthouse/plugins/lighthouse/overlay/src/index.ts
@@ -14,4 +14,4 @@ export {
 export * from "./api";
 export * from "./components/Cards";
 
-export { default as LighthouseIcon } from "@mui/icons-material/Assessment";
+export { default as LighthouseIcon } from "@material-ui/icons/Assessment";

--- a/workspaces/lighthouse/plugins/lighthouse/overlay/src/index.ts
+++ b/workspaces/lighthouse/plugins/lighthouse/overlay/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  lighthousePlugin,
+  lighthousePlugin as plugin,
+  LighthousePage,
+  EntityLighthouseContent,
+  EntityLastLighthouseAuditCard,
+} from "./plugin";
+export {
+  Router,
+  isLighthouseAvailable as isPluginApplicableToEntity,
+  isLighthouseAvailable,
+  EmbeddedRouter,
+} from "./Router";
+export * from "./api";
+export * from "./components/Cards";
+
+export { default as LighthouseIcon } from "@mui/icons-material/Assessment";


### PR DESCRIPTION
Adds the missing LighthouseIcon to the `Lighthouse` plugin

Updates PR https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/939