### PR TITLE
feat: added announcement plugin

### DIFF
--- a/workspaces/announcements/plugins-list.yaml
+++ b/workspaces/announcements/plugins-list.yaml
@@ -1,0 +1,3 @@
+plugins/announcements:
+plugins/announcements-backend: --embed-package @backstage-community/plugin-search-backend-module-announcements --embed-package @backstage/plugin-signals-node
+plugins/search-backend-module-announcements: --embed-package @backstage-community/plugin-announcements-common --embed-package @backstage-community/plugin-announcements-node

--- a/workspaces/announcements/plugins/announcements/overlay/src/index.ts
+++ b/workspaces/announcements/plugins/announcements/overlay/src/index.ts
@@ -1,0 +1,8 @@
+export * from './plugin';
+
+export type {
+  AnnouncementsTimelineProps,
+  AnnouncementSearchResultProps,
+} from './components';
+
+export { default as RecordVoiceOverIcon } from '@material-ui/icons/RecordVoiceOver';

--- a/workspaces/announcements/source.json
+++ b/workspaces/announcements/source.json
@@ -1,0 +1,1 @@
+{"repo":"https://github.com/backstage/community-plugins","repo-ref":"34e46734ed250c3973cd510136aa18003e151b05","repo-flat":false}


### PR DESCRIPTION
Adds the Announcement plugin (backend, frontend and search)

EDIT:

* Adds the embedded package `@backstage-community/plugin-search-backend-module-announcements` and `@backstage/plugin-signals-node` to the `announcements-backend`
* Adds the embedded package `@backstage-community/plugin-announcements-common` and `@backstage-community/plugin-announcements-node` to `search-backend-module-announcements`

