### PR TITLE
Cancel pr actions when identical.

### DIFF
--- a/.github/workflows/pr-actions.yaml
+++ b/.github/workflows/pr-actions.yaml
@@ -4,7 +4,8 @@ on:
     types: [created, edited]
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.ref }}-${{ github.event.issue.id }}
+  group: ${{ github.workflow_ref }}-${{ github.ref_name }}-${{ github.event.issue.number }}-${{ github.event.comment.body }}
+  cancel-in-progress: true
 
 jobs:  
   prepare:
@@ -262,7 +263,7 @@ jobs:
           script: |
             const path = 'versions.json';
             const releaseBranch = core.getInput('target_branch');
-            if (! releaseBranch?.startsWith('release-')) {
+            if (! releaseBranch?.startsWith('release-') && ! releaseBranch?.startsWith('main') ) {
               core.notice(`Current PR is not based on a release branch.`);
               return;
             }


### PR DESCRIPTION
Cancel pr actions when identical and also check backstage version consistency on PRs against the main target branch.