### PR TITLE
Update `marketplace` workspace to commit `c2157bd` for backstage `1.39.1` on branch `main`

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,6 @@
 {
     "backstage": "1.39.1",
     "node": "22.16.0",
-    "cli": "3.6.1"
+    "cli": "1.7.0",
+    "cliPackage": "@red-hat-developer-hub/cli"
 }

--- a/workspaces/marketplace/source.json
+++ b/workspaces/marketplace/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"8c20449cbd7f55316597576d9636105050dcd06f","repo-flat":false,"repo-backstage-version":"1.39.1"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"7696ea8391bd2d7e39a3eee0c4df1cda948bdb68","repo-flat":false,"repo-backstage-version":"1.39.1"}

--- a/workspaces/marketplace/source.json
+++ b/workspaces/marketplace/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"7696ea8391bd2d7e39a3eee0c4df1cda948bdb68","repo-flat":false,"repo-backstage-version":"1.39.1"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"b1d89e69b4379f300f62ce9f4b7a0e63f02d6ace","repo-flat":false,"repo-backstage-version":"1.39.1"}

--- a/workspaces/marketplace/source.json
+++ b/workspaces/marketplace/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"b1d89e69b4379f300f62ce9f4b7a0e63f02d6ace","repo-flat":false,"repo-backstage-version":"1.39.1"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"c2157bddc28612926fb2e4b9d335a3e84acef113","repo-flat":false,"repo-backstage-version":"1.39.1"}

--- a/workspaces/marketplace/source.json
+++ b/workspaces/marketplace/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"50f23889940f905a747ed02b4e02dd8eb4b6c805","repo-flat":false,"repo-backstage-version":"1.36.1"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"8c20449cbd7f55316597576d9636105050dcd06f","repo-flat":false,"repo-backstage-version":"1.39.1"}


### PR DESCRIPTION
Update [marketplace](/redhat-developer/rhdh-plugins/tree/c2157bddc28612926fb2e4b9d335a3e84acef113/workspaces/marketplace) workspace at commit redhat-developer/rhdh-plugins@c2157bddc28612926fb2e4b9d335a3e84acef113 for backstage `1.39.1` on branch `main`.

This PR was created automatically.
Click on the following link to see the source diff it introduces: https://github.com/redhat-developer/rhdh-plugins/compare/50f23889940f905a747ed02b4e02dd8eb4b6c805...c2157bddc28612926fb2e4b9d335a3e84acef113.

Before merging, you need to export the workspace dynamic plugins as OCI images,
and if possible test them inside a RHDH instance.

To do so, you can use the `/publish` instruction in a PR review comment.
This will start a PR check workflow to:
- export the workspace plugins as dynamic plugins,
- publish them as OCI images
- push the oci-images in the GitHub container registry with a PR-specific tag.
