### PR TITLE
Set compatible version to `1.39.1` on `scaffolder-backend-module-azure-repositories`...

### DIFF
--- a/workspaces/scaffolder-backend-module-azure-repositories/source.json
+++ b/workspaces/scaffolder-backend-module-azure-repositories/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/Parfuemerie-Douglas/scaffolder-backend-module-azure-repositories","repo-ref":"0.3.0","repo-flat":true}
+{"repo":"https://github.com/Parfuemerie-Douglas/scaffolder-backend-module-azure-repositories","repo-ref":"0.3.0","repo-flat":true,"repo-backstage-version":"1.39.1"}


### PR DESCRIPTION
... based on the content of the corresponding RHDH 1.7 wrapper.