### PR TITLE
Update `acs` workspace to commit `ec085f8` for backstage `1.39.1` on branch `main`

### DIFF
--- a/workspaces/acs/source.json
+++ b/workspaces/acs/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/backstage/community-plugins","repo-ref":"19ddb7837c6823a253c87af9524f8aef26a90b35","repo-flat":false,"repo-backstage-version":"1.39.1"}
+{"repo":"https://github.com/backstage/community-plugins","repo-ref":"ec085f8cf8d4980ebaaa7130e627d4dd6dd1933e","repo-flat":false,"repo-backstage-version":"1.39.1"}


### PR DESCRIPTION
## Summary
- Updates ACS workspace repo-ref to track the latest changes from backstage/community-plugins
- Changes reference from `19ddb7837c6823a253c87af9524f8aef26a90b35` to `ec085f8cf8d4980ebaaa7130e627d4dd6dd1933e`

## Test plan
- [ ] Verify ACS plugins build successfully with updated reference
- [ ] Test generated OCI images work with RHDH instance