### PR TITLE
add github-notifications plugin (1.36.1 for release-1.6)

### DIFF
--- a/workspaces/github-notifications/plugins-list.yaml
+++ b/workspaces/github-notifications/plugins-list.yaml
@@ -1,0 +1,1 @@
+plugins/github-notifications-backend:

--- a/workspaces/github-notifications/source.json
+++ b/workspaces/github-notifications/source.json
@@ -1,0 +1,1 @@
+{"repo":"https://github.com/proberaum/backstage-plugins","repo-ref":"02075a9f5453a78ab459db4ed26dd5f8a524c465","repo-flat":false,"repo-backstage-version":"1.36.1"}


### PR DESCRIPTION
* what plugin? see: https://github.com/proberaum/backstage-plugins/pull/17
* includes now https://github.com/proberaum/backstage-plugins/pull/20
* repo-ref refers merge of https://github.com/proberaum/backstage-plugins/pull/27