### PR TITLE
add github-notifications plugin (1.35.1 for release-1.5)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 /workspaces/ai-integrations                                             @johnmcollier @gabemontero @rohitkrai03 @karthikjeeyar @eswaraiahsapram @lucifergene
 /workspaces/analytics/plugins/analytics-provider-segment                @AndrienkoAleksandr @PatAKnight @dzemanov
 /workspaces/bulk-import                                                 @christoph-jerolimov @debsmita1 @rm3l
+/workspaces/github-notifications                                        @christoph-jerolimov
 /workspaces/global-floating-action-button                               @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
 /workspaces/global-header                                               @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
 /workspaces/homepage                                                    @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff

--- a/workspaces/github-notifications/plugins-list.yaml
+++ b/workspaces/github-notifications/plugins-list.yaml
@@ -1,0 +1,1 @@
+plugins/github-notifications-backend:

--- a/workspaces/github-notifications/source.json
+++ b/workspaces/github-notifications/source.json
@@ -1,0 +1,1 @@
+{"repo":"https://github.com/proberaum/backstage-plugins","repo-ref":"17e69bb78d844270462ea9cb6bb64396701f8f9e","repo-flat":false,"repo-backstage-version":"1.35.1"}


### PR DESCRIPTION
* what plugin? see: https://github.com/proberaum/backstage-plugins/pull/17
* includes now https://github.com/proberaum/backstage-plugins/pull/20
* repo-ref refers merge of https://github.com/proberaum/backstage-plugins/pull/24