### PR TITLE
chore(repo): update ownersfile

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,42 +4,73 @@
 # The last matching pattern takes precedence.
 # https://help.github.com/articles/about-codeowners/
 #
-# The list is alphabetical ordered.
+# One or multiple RHDH teams or (external) individuals are responsible to package a plugin.
+# Related frontend and backend plugins, or modules, are mostly grouped here in workspaces.
+# 
+# In some cases individuals from a team are mentioned as 'point of contact' behind a team.
+#
+# External or other maintainers are mentioned explicitely and seperated with three spaces.
+#
+# The workspace list is alphabetical ordered.
 # In VS code: select the lines and select ">Sort Lines Ascending" from the Commands menu.
 
-*                                                                       @davidfestal @gashcrumb @kadel
-/workspaces/*                                                           @christoph-jerolimov @PatAKnight
+*                                                                       @redhat-developer/rhdh-cope @gashcrumb @kadel
+
 /workspaces/3scale                                                      @04kash @AndrienkoAleksandr
-/workspaces/acr                                                         @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff
-/workspaces/adoption-insights                                           @rohitkrai03 @karthikjeeyar 
-/workspaces/ai-integrations                                             @johnmcollier @gabemontero @rohitkrai03 @karthikjeeyar @eswaraiahsapram @lucifergene
-/workspaces/analytics/plugins/analytics-provider-segment                @AndrienkoAleksandr @PatAKnight @dzemanov
-/workspaces/bulk-import                                                 @christoph-jerolimov @debsmita1 @rm3l
-/workspaces/github-notifications                                        @christoph-jerolimov
-/workspaces/global-floating-action-button                               @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
-/workspaces/global-header                                               @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
-/workspaces/homepage                                                    @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
-/workspaces/jfrog-artifactory                                           @BethGriggs
+/workspaces/acr                                                         @redhat-developer/rhdh-ui
+# /workspaces/acs
+/workspaces/adoption-insights                                           @redhat-developer/rhdh-ui @rohitkrai03 @karthikjeeyar @eswaraiahsapram
+/workspaces/ai-integrations                                             @redhat-developer/rhdh-ui @rohitkrai03 @karthikjeeyar @lucifergene   @johnmcollier @gabemontero
+/workspaces/analytics                                                   @redhat-developer/rhdh-plugins   @redhat-developer/rhdh-ui
+/workspaces/analytics/plugins/analytics-provider-segment                @redhat-developer/rhdh-ui   @AndrienkoAleksandr @PatAKnight @dzemanov
+/workspaces/announcements                                               @redhat-developer/rhdh-plugins
+# /workspaces/apiconnect
+# /workspaces/azure-devops
+/workspaces/backstage                                                   @redhat-developer/rhdh-cope
+/workspaces/bulk-import                                                 @redhat-developer/rhdh-plugins @rm3l   @redhat-developer/rhdh-ui @debsmita1 @its-mitesh-kumar
+# /workspaces/dynatrace
+# /workspaces/dynatrace-dql
+# /workspaces/github-actions
+/workspaces/github-issues                                               @redhat-developer/rhdh-ui @divyanshiGupta
+/workspaces/github-notifications                                        @redhat-developer/rhdh-ui @christoph-jerolimov
+# /workspaces/gitlab
+/workspaces/global-floating-action-button                               @redhat-developer/rhdh-ui @debsmita1 @divyanshiGupta
+/workspaces/global-header                                               @redhat-developer/rhdh-ui @ciiay @divyanshiGupta
+/workspaces/homepage                                                    @redhat-developer/rhdh-ui @eswaraiahsapram
+# /workspaces/jenkins
+/workspaces/jfrog-artifactory                                           @redhat-developer/rhdh-ui @its-mitesh-kumar   @BethGriggs
 /workspaces/keycloak                                                    @AndrienkoAleksandr @schultzp2020 @dzemanov
-/workspaces/lightspeed                                                  @karthikjeeyar @yangcao77 @rohitkrai03
-/workspaces/marketplace                                                 @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff @karthikjeeyar
-/workspaces/nexus-repository-manager                                    @ciiay @debsmita1 @jessicajhee
-/workspaces/npm                                                         @christoph-jerolimov @ciiay @karthikjeeyar
-/workspaces/ocm                                                         @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff
+# /workspaces/kiali
+# /workspaces/lighthouse
+/workspaces/lightspeed                                                  @redhat-developer/rhdh-ui @karthikjeeyar @rohitkrai03   @yangcao77
+/workspaces/marketplace                                                 @redhat-developer/rhdh-ui
+/workspaces/nexus-repository-manager                                    @redhat-developer/rhdh-ui @debsmita1 @ciiay   @jessicajhee
+/workspaces/npm                                                         @redhat-developer/rhdh-ui @christoph-jerolimov
+/workspaces/ocm                                                         @redhat-developer/rhdh-plugins   @redhat-developer/rhdh-ui
 /workspaces/odo                                                         @rm3l
-/workspaces/openshift-image-registry                                    @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff @karthikjeeyar
+/workspaces/openshift-image-registry                                    @redhat-developer/rhdh-ui @divyanshiGupta @its-mitesh-kumar
 /workspaces/orchestrator                                                @batzionb @mareklibra @gciavarrini
+# /workspaces/pagerduty-backend
+# /workspaces/pagerduty-frontend
 /workspaces/pingidentity                                                @jessicajhee
-/workspaces/quickstart                                                  @divyanshiGupta @christoph-jerolimov @ciiay @debsmita1 @its-mitesh-kumar @logonoff
-/workspaces/rbac                                                        @AndrienkoAleksandr @christoph-jerolimov @divyanshiGupta @PatAKnight @dzemanov
-/workspaces/redhat-resource-optimization                                @christoph-jerolimov
+/workspaces/quay                                                        @caugello @cryptorodeo
+/workspaces/quickstart                                                  @redhat-developer/rhdh-ui @divyanshiGupta @its-mitesh-kumar
+/workspaces/rbac                                                        @redhat-developer/rhdh-plugins @PatAKnight @dzemanov @AndrienkoAleksandr   @redhat-developer/rhdh-ui @divyanshiGupta @its-mitesh-kumar
+/workspaces/redhat-argocd                                               @caugello @cryptorodeo
+# /workspaces/roadie-backstage-plugins
 /workspaces/sandbox                                                     @lucifergene @rohitkrai03 @karthikjeeyar @xcoulon @alexeykazakov @mfrancisc
 /workspaces/scaffolder-backend-module-annotator                         @debsmita1
+# /workspaces/scaffolder-backend-module-azure-repositories
 /workspaces/scaffolder-backend-module-kubernetes                        @debsmita1
 /workspaces/scaffolder-backend-module-regex                             @04kash
 /workspaces/scaffolder-backend-module-servicenow                        @schultzp2020
 /workspaces/scaffolder-backend-module-sonarqube                         @04kash @schultzp2020
 /workspaces/scaffolder-relation-processor                               @04kash
-/workspaces/servicenow                                                  @AndrienkoAleksandr @ciiay @PatAKnight @christoph-jerolimov
-/workspaces/theme                                                       @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @gashcrumb @its-mitesh-kumar @logonoff
-/workspaces/topology                                                    @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff
+/workspaces/servicenow                                                  @redhat-developer/rhdh-plugins @AndrienkoAleksandr   @redhat-developer/rhdh-ui @ciiay
+# /workspaces/sonarqube
+# /workspaces/tech-insights
+# /workspaces/tech-radar
+/workspaces/tekton                                                      @caugello @cryptorodeo
+/workspaces/theme                                                       @redhat-developer/rhdh-ui @ciiay   @logonoff
+# /workspaces/todo
+/workspaces/topology                                                    @redhat-developer/rhdh-ui


### PR DESCRIPTION
This PR

1. replaces mostly individuals with teams, when we have a responsible rhdh team for a workspace.
2. adds all workspaces here, incl the gaps that we have at the moment.
3. I kept or updated some items where the UI team has define a point of contact for a workspace so that the GitHub team is specified, but also this POC (point of contact). I hope its possible that the GitHub notifications goes then just to these individuals and not the complete team...
4. And finally I've added @caugello @cryptorodeo for the workspaces quay, redhat-argocd and tekton.

I've done my best to kept the lists accurate. Let me know or raise another PR if something was incorrect. :smirk: 