### PR TITLE
Update versions for RHDH 1.8

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
-    "backstage": "1.39.1",
-    "node": "22.16.0",
-    "cli": "1.7.0",
+    "backstage": "1.42.5",
+    "node": "22.19.0",
+    "cli": "1.7.2",
     "cliPackage": "@red-hat-developer-hub/cli"
 }


### PR DESCRIPTION
Updated version numbers for backstage, node, and cli for RHDH 1.8.
This changes the backstage version to `1.42.5`