### PR TITLE
servicenow: expose the alpha module

### DIFF
--- a/workspaces/servicenow/plugins/servicenow/scalprum-config.json
+++ b/workspaces/servicenow/plugins/servicenow/scalprum-config.json
@@ -1,0 +1,7 @@
+{
+  "name": "backstage-community.plugin-servicenow",
+  "exposedModules": {
+    "PluginRoot": "./src/index.ts",
+    "alpha": "./src/alpha.ts"
+  }
+}


### PR DESCRIPTION
Expose the alpha module for all plugins where I found a src/alpha.tsx? file.

First round for in Backstage Community plugins. Others will follow.

Not all of them supports the translations api, but this was the primary reason for exposing the alpha module.