### PR TITLE
tech-radar: expose the alpha module

### DIFF
--- a/workspaces/tech-radar/plugins/tech-radar/scalprum-config.json
+++ b/workspaces/tech-radar/plugins/tech-radar/scalprum-config.json
@@ -1,0 +1,7 @@
+{
+  "name": "backstage-community.plugin-tech-radar",
+  "exposedModules": {
+    "PluginRoot": "./src/index.ts",
+    "alpha": "./src/alpha.tsx"
+  }
+}


### PR DESCRIPTION
Expose the alpha module for all plugins where I found a src/alpha.tsx? file.

First round for in Backstage Community plugins. Others will follow.

Not all of them supports the translations api, but this was the primary reason for exposing the alpha module.