### PR TITLE
Update `marketplace` workspace to commit `9b0fe10` for backstage `1.41.1` on branch `main`

### DIFF
--- a/workspaces/marketplace/source.json
+++ b/workspaces/marketplace/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"02987ead5ece8c65a6d8607ec54fb84e05ca59bd","repo-flat":false,"repo-backstage-version":"1.41.1"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"9b0fe10fef44f559b2c75da797bfd4ac5fdac53e","repo-flat":false,"repo-backstage-version":"1.41.1"}


### PR DESCRIPTION
Update [marketplace](/redhat-developer/rhdh-plugins/tree/9b0fe10fef44f559b2c75da797bfd4ac5fdac53e/workspaces/marketplace) workspace at commit redhat-developer/rhdh-plugins@9b0fe10fef44f559b2c75da797bfd4ac5fdac53e for backstage `1.41.1` on branch `main`.

This PR was created automatically.

⚠️ Manual approval required
This proposal is a Best-Effort Backstage compatibility match. Plugin sources are built for Backstage `1.41.1`. Please review and test before merging.

If you have tested and confirmed compatibility, you should add a `backstage.json` file in the workspace folder to override the known Backstage compatibility to be the target Backstage version.
**Don't forget to also update the `repo-backstage-version` field in `source.json` accordingly.**

Click on the following link to see the source diff it introduces: https://github.com/redhat-developer/rhdh-plugins/compare/49fec0a2eaf856e7fbd7c839962c0a7277847172...9b0fe10fef44f559b2c75da797bfd4ac5fdac53e.

Before merging, you need to export the workspace dynamic plugins as OCI images,
and if possible test them inside a RHDH instance.

To do so, you can use the `/publish` instruction in a PR review comment.
This will start a PR check workflow to:
- export the workspace plugins as dynamic plugins,
- publish them as OCI images
- push the oci-images in the GitHub container registry with a PR-specific tag.
