### PR TITLE
Pull in plugins/techdocs-mcp-tool to mcp-integrations

### DIFF
--- a/workspaces/mcp-integrations/plugins-list.yaml
+++ b/workspaces/mcp-integrations/plugins-list.yaml
@@ -1,1 +1,2 @@
 plugins/software-catalog-mcp-tool:
+plugins/techdocs-mcp-tool:

--- a/workspaces/mcp-integrations/source.json
+++ b/workspaces/mcp-integrations/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"84399b0291300412c7fe1bb6a987d3af629fc531","repo-flat":false,"repo-backstage-version":"1.42.1"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"7a85a65d51e6143ced5050b7da755cccfa8a3415","repo-flat":false,"repo-backstage-version":"1.42.1"}


### PR DESCRIPTION
plugins/techdocs-mcp-tool was added to the rhdh-plugins workspace, so adding it here