### PR TITLE
Add entity-feedback workspace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@
 # /workspaces/dynatrace
 # /workspaces/dynatrace-dql
 /workspaces/env-viewer                                                  @redhat-developer/rhdh-ui @christoph-jerolimov
+/workspaces/entity-feedback                                             @durandom
 /workspaces/extensions                                                 @redhat-developer/rhdh-ui @redhat-developer/rhdh-plugins
 # /workspaces/github-actions
 /workspaces/github-issues                                               @redhat-developer/rhdh-ui @divyanshiGupta

--- a/catalog-entities/extensions/plugins/all.yaml
+++ b/catalog-entities/extensions/plugins/all.yaml
@@ -25,6 +25,7 @@ spec:
     - ./datadog.yaml
     - ./dynatrace-commercial.yaml
     - ./dynatrace-community.yaml
+    - ./entity-feedback.yaml
     - ./extensions.yaml
     - ./gerrit-scaffolder-actions.yaml
     - ./github-actions.yaml

--- a/catalog-entities/extensions/plugins/entity-feedback.yaml
+++ b/catalog-entities/extensions/plugins/entity-feedback.yaml
@@ -1,0 +1,119 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/redhat-developer/rhdh-plugins/refs/heads/main/workspaces/extensions/json-schema/plugins.json
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Plugin
+metadata:
+  name: entity-feedback
+  namespace: community
+  title: Entity Feedback
+  annotations:
+    extensions.backstage.io/pre-installed: 'true'
+  description: |
+    Collect and view user feedback on catalog entities with like/dislike or star ratings.
+    Provides rating buttons, aggregated views, and feedback collection for entity owners.
+  tags:
+    - feedback
+    - ratings
+    - collaboration
+    - user-experience
+  links:
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/entity-feedback
+      title: Homepage
+    - url: https://github.com/backstage/community-plugins/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/entity-feedback/plugins
+    - title: Documentation
+      url: https://github.com/backstage/community-plugins/blob/main/workspaces/entity-feedback/plugins/entity-feedback/README.md
+spec:
+  authors:
+    - name: Backstage Community
+      url: https://backstage.io/
+
+  publisher: Backstage Community
+  support:
+    provider: Community
+    level: community
+  lifecycle: active
+
+  categories:
+    - Collaboration
+
+  highlights:
+    - Like/Dislike or Star-based rating systems
+    - Collect detailed feedback on poorly-rated entities
+    - Aggregated rating views for entity owners
+    - Customizable response categories
+    - Rating breakdown analytics
+
+  description: |
+    The Entity Feedback plugin enables users to rate and provide feedback on catalog entities
+    within Backstage. It helps teams understand how useful and accurate their catalog entries
+    are by collecting structured user feedback.
+
+    ## Key Features
+
+    * **Flexible Rating Systems**: Choose between like/dislike toggles or 5-star ratings
+    * **Feedback Collection**: Automatically prompt for detailed feedback on poor ratings
+    * **Owner Dashboards**: Aggregated views showing ratings for owned entities
+    * **Customizable Prompts**: Configure response categories and dialog text
+    * **Rating Analytics**: View rating breakdowns and trends
+
+    ## Adding The Plugin To Red Hat Developer Hub
+
+    This plugin consists of both frontend and backend components that work together.
+
+    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub)
+    for further instructions on how to add, enable, configure, and remove plugins in your instance.
+
+    ## Configuring The Plugin
+
+    ### Rating Variant
+
+    Configure the rating style in `app-config.yaml`:
+
+    ```yaml
+    entityFeedback:
+      ratings:
+        - variant: starred  # or 'like-dislike' (default)
+    ```
+
+    ### Feedback Collection
+
+    Customize feedback prompts:
+
+    ```yaml
+    entityFeedback:
+      ratings:
+        - requireResponse: true
+          dialogTitle: "Help us improve"
+          dialogResponses:
+            - Incorrect information
+            - Missing details
+            - Outdated content
+            - Other
+    ```
+
+    ### Mount Points
+
+    The plugin provides several UI components:
+
+    * **EntityLikeDislikeRatingsCard**: Rating buttons for entity pages
+    * **EntityFeedbackResponseContent**: Feedback tab showing collected responses
+    * **UserEntitiesRatingsCard**: Aggregated ratings for user/group pages
+
+    ## Prerequisites
+
+    * **Authentication Required**: This plugin requires user authentication. The guest identity
+      provider is not supported as the plugin needs to identify who submitted each rating.
+    * **Backend Plugin**: The backend plugin must be installed for the frontend to function.
+    * **Notifications (Optional)**: Integrates with Backstage Notifications to alert entity
+      owners of new feedback.
+
+    For more detailed configuration instructions, see the [plugin documentation](https://github.com/backstage/community-plugins/blob/main/workspaces/entity-feedback/plugins/entity-feedback/README.md).
+
+  packages:
+    - backstage-community-plugin-entity-feedback
+    - backstage-community-plugin-entity-feedback-backend
+
+  history:
+    added: '2026-01-14'

--- a/workspaces/entity-feedback/metadata/backstage-community-plugin-entity-feedback-backend.yaml
+++ b/workspaces/entity-feedback/metadata/backstage-community-plugin-entity-feedback-backend.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/redhat-developer/rhdh-plugins/refs/heads/main/workspaces/extensions/json-schema/packages.json
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-entity-feedback-backend
+  namespace: rhdh
+  title: "@backstage-community/plugin-entity-feedback-backend"
+  links:
+    - url: https://github.com/backstage/community-plugins/blob/main/workspaces/entity-feedback/plugins/entity-feedback-backend/README.md
+      title: Plugin Overview (README)
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/entity-feedback/plugins/entity-feedback-backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/entity-feedback
+  tags:
+    - feedback
+    - ratings
+spec:
+  packageName: "@backstage-community/plugin-entity-feedback-backend"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-entity-feedback-backend:bs_1.45.3__0.14.0!backstage-community-plugin-entity-feedback-backend
+  version: 0.14.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.45.3
+  author: Backstage Community
+  support: community
+  lifecycle: active
+  partOf:
+    - entity-feedback

--- a/workspaces/entity-feedback/metadata/backstage-community-plugin-entity-feedback.yaml
+++ b/workspaces/entity-feedback/metadata/backstage-community-plugin-entity-feedback.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/redhat-developer/rhdh-plugins/refs/heads/main/workspaces/extensions/json-schema/packages.json
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-entity-feedback
+  namespace: rhdh
+  title: "@backstage-community/plugin-entity-feedback"
+  links:
+    - url: https://github.com/backstage/community-plugins/blob/main/workspaces/entity-feedback/plugins/entity-feedback/README.md
+      title: Plugin Overview (README)
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/entity-feedback/plugins/entity-feedback
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/entity-feedback
+  tags:
+    - feedback
+    - ratings
+spec:
+  packageName: "@backstage-community/plugin-entity-feedback"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-entity-feedback:bs_1.45.3__0.12.0!backstage-community-plugin-entity-feedback
+  version: 0.12.0
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.45.3
+  author: Backstage Community
+  support: community
+  lifecycle: active
+  partOf:
+    - entity-feedback
+  appConfigExamples:
+    - title: Like/Dislike rating (default)
+      content:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-entity-feedback:
+              mountPoints:
+                - mountPoint: entity.page.overview/cards
+                  importName: EntityFeedbackResponseContent
+                  config:
+                    layout:
+                      gridColumn: 1 / -1
+    - title: Star rating variant
+      content:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-entity-feedback:
+              appConfig:
+                entityFeedback:
+                  ratings:
+                    - variant: starred
+              mountPoints:
+                - mountPoint: entity.page.overview/cards
+                  importName: EntityFeedbackResponseContent
+                  config:
+                    layout:
+                      gridColumn: 1 / -1

--- a/workspaces/entity-feedback/plugins-list.yaml
+++ b/workspaces/entity-feedback/plugins-list.yaml
@@ -1,0 +1,2 @@
+plugins/entity-feedback:
+plugins/entity-feedback-backend:

--- a/workspaces/entity-feedback/plugins-list.yaml
+++ b/workspaces/entity-feedback/plugins-list.yaml
@@ -1,2 +1,2 @@
 plugins/entity-feedback:
-plugins/entity-feedback-backend:
+plugins/entity-feedback-backend: --embed-package @backstage/plugin-notifications-node

--- a/workspaces/entity-feedback/source.json
+++ b/workspaces/entity-feedback/source.json
@@ -1,0 +1,1 @@
+{"repo":"https://github.com/backstage/community-plugins","repo-ref":"8f9b3b0f695304e674f2457352bd60df1271c781","repo-flat":false,"repo-backstage-version":"1.45.3"}


### PR DESCRIPTION
## Summary

Adds Entity Feedback plugin from backstage/community-plugins to RHDH Extensions Catalog.

- **Upstream:** https://github.com/backstage/community-plugins/tree/main/workspaces/entity-feedback
- **License:** Apache 2.0
- **Upstream Backstage version:** 1.45.3 (exact match with RHDH target)

### Plugins

| Plugin | Package | Version |
|--------|---------|---------|
| Frontend | `@backstage-community/plugin-entity-feedback` | 0.12.0 |
| Backend | `@backstage-community/plugin-entity-feedback-backend` | 0.14.0 |

### Plugin Features

- Like/Dislike or Star rating system for catalog entities
- Feedback collection with customizable response categories
- Aggregated rating displays on entity pages
- Requires authentication (not compatible with guest users)

## Checklist

- [x] `source.json` created (commit `8f9b3b0`)
- [x] `plugins-list.yaml` created (with `--embed-package @backstage/plugin-notifications-node`)
- [x] CODEOWNERS updated
- [x] `/publish` triggered - images published
- [x] Metadata files added
- [x] Plugin entity created
- [x] Local verification with RHDH Local

## Verification

Tested locally with [RHDH Local](https://github.com/redhat-developer/rhdh-local) using PR artifacts:

- ✅ Both plugins load without errors in container logs
- ✅ Backend initializes: `Initializing Entity Feedback backend`
- ✅ Frontend loaded: `Loaded dynamic frontend plugin '@backstage-community/plugin-entity-feedback-dynamic'`
- ⚠️ Full rating functionality requires authentication (guest mode won't work)

<img width="906" height="1183" alt="Screenshot 2026-01-15 at 08 56 41" src="https://github.com/user-attachments/assets/d2aa96d6-8da1-4f42-b80c-9e5d8b0972c7" />
<img width="763" height="1025" alt="Screenshot 2026-01-15 at 08 56 08" src="https://github.com/user-attachments/assets/febc2247-e451-4410-97a7-577eea51e4e0" />


### Published Images

```
ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-entity-feedback:pr_1790__0.12.0
ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-entity-feedback-backend:pr_1790__0.14.0
```

## Notes

- Backend requires `@backstage/plugin-notifications-node` embedded (for owner notifications feature)
- Plugin integrates with Backstage Notifications system

## Related

- Parent feature: RHDHPLAN-272 (1.9 candidates)