### PR TITLE
chore(tech-radar): add new frontend system e2e test

### DIFF
--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.41",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/playwright.config.ts
+++ b/workspaces/tech-radar/e2e-tests/playwright.config.ts
@@ -2,12 +2,19 @@ import { defineConfig } from "@red-hat-developer-hub/e2e-test-utils/playwright-c
 
 /**
  * Tech Radar plugin e2e test configuration.
- * Extends the base config from @red-hat-developer-hub/e2e-test-utils.
+ *
+ * Projects:
+ * - tech-radar — legacy app shell (default RHIDP merge layers).
+ * - tech-radar-app-next — namespace ends with -app-next, so e2e-test-utils merges
+ *   NFS (app-next) secrets and default app-auth / app-integrations automatically.
  */
 export default defineConfig({
   projects: [
     {
       name: "tech-radar",
+    },
+    {
+      name: "tech-radar-app-next",
     },
   ],
 });

--- a/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
+++ b/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
@@ -10,7 +10,9 @@ const setupScript = path.join(
 test.describe("Test tech-radar plugin", () => {
   test.beforeAll(async ({ rhdh }) => {
     const project = rhdh.deploymentConfig.namespace;
-    await rhdh.configure({ auth: "keycloak" });
+    await rhdh.configure({
+      auth: "keycloak",
+    });
     await $`bash ${setupScript} ${project}`;
     process.env.TECH_RADAR_DATA_URL = (
       await rhdh.k8sClient.getRouteLocation(

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.41":
+  version: 1.1.41
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.41"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/906713b3fb1ecce4b95cdca7620fbf69be22518fe47be131454f9e310fb80b4059e11cc8008ed127d22792e7d876ebdf00e6d4d2a437a1eb777eacb2d6cadd78
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.41"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
This change adds an additional test project that runs RHDH with app-next instead of app to test the plugin in the new frontend system.

Assisted-by: Cursor

fixes [RHIDP-12360](https://redhat.atlassian.net/browse/RHIDP-12360)