### PR TITLE
chore(e2e): migrate techdocs plugins e2e tests

### DIFF
--- a/workspaces/backstage/e2e-tests/playwright.config.ts
+++ b/workspaces/backstage/e2e-tests/playwright.config.ts
@@ -1,7 +1,4 @@
 import { defineConfig } from "@red-hat-developer-hub/e2e-test-utils/playwright-config";
-import dotenv from "dotenv";
-
-dotenv.config({ path: `${import.meta.dirname}/.env` });
 
 /**
  * Backstage workspace e2e test configuration.
@@ -10,19 +7,19 @@ dotenv.config({ path: `${import.meta.dirname}/.env` });
 export default defineConfig({
   projects: [
     {
-      name: 'backstage-github-org-discovery',
+      name: "backstage-github-org-discovery",
       testMatch: /tests\/specs\/github-org-discovery\.spec\.ts/,
     },
     {
-      name: 'backstage-github-discovery',
+      name: "backstage-github-discovery",
       testMatch: /tests\/specs\/github-discovery\.spec\.ts/,
     },
     {
-      name: 'backstage-gitlab-discovery',
+      name: "backstage-gitlab-discovery",
       testMatch: /tests\/specs\/gitlab-discovery\.spec\.ts/,
     },
     {
-      name: 'backstage-github-events',
+      name: "backstage-github-events",
       testMatch: /tests\/specs\/github-events-module\.spec\.ts/,
     },
     {

--- a/workspaces/backstage/e2e-tests/playwright.config.ts
+++ b/workspaces/backstage/e2e-tests/playwright.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from '@red-hat-developer-hub/e2e-test-utils/playwright-config';
-import dotenv from 'dotenv';
+import { defineConfig } from "@red-hat-developer-hub/e2e-test-utils/playwright-config";
+import dotenv from "dotenv";
 
 dotenv.config({ path: `${import.meta.dirname}/.env` });
 
@@ -26,15 +26,15 @@ export default defineConfig({
       testMatch: /tests\/specs\/github-events-module\.spec\.ts/,
     },
     {
-      name: 'backstage-kubernetes',
+      name: "backstage-kubernetes",
       testMatch: /tests\/specs\/kubernetes-rbac\.spec\.ts/,
     },
     {
-      name: 'backstage-notifications',
+      name: "backstage-notifications",
       testMatch: /tests\/specs\/notifications\.spec\.ts/,
     },
     {
-      name: 'backstage-techdocs',
+      name: "backstage-techdocs",
       testMatch: /tests\/specs\/techdocs\.spec\.ts/,
     },
   ],

--- a/workspaces/backstage/e2e-tests/playwright.config.ts
+++ b/workspaces/backstage/e2e-tests/playwright.config.ts
@@ -1,4 +1,7 @@
-import { defineConfig } from "@red-hat-developer-hub/e2e-test-utils/playwright-config";
+import { defineConfig } from '@red-hat-developer-hub/e2e-test-utils/playwright-config';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: `${import.meta.dirname}/.env` });
 
 /**
  * Backstage workspace e2e test configuration.
@@ -7,28 +10,32 @@ import { defineConfig } from "@red-hat-developer-hub/e2e-test-utils/playwright-c
 export default defineConfig({
   projects: [
     {
-      name: "backstage-github-org-discovery",
+      name: 'backstage-github-org-discovery',
       testMatch: /tests\/specs\/github-org-discovery\.spec\.ts/,
     },
     {
-      name: "backstage-github-discovery",
+      name: 'backstage-github-discovery',
       testMatch: /tests\/specs\/github-discovery\.spec\.ts/,
     },
     {
-      name: "backstage-gitlab-discovery",
+      name: 'backstage-gitlab-discovery',
       testMatch: /tests\/specs\/gitlab-discovery\.spec\.ts/,
     },
     {
-      name: "backstage-github-events",
+      name: 'backstage-github-events',
       testMatch: /tests\/specs\/github-events-module\.spec\.ts/,
     },
     {
-      name: "backstage-kubernetes",
+      name: 'backstage-kubernetes',
       testMatch: /tests\/specs\/kubernetes-rbac\.spec\.ts/,
     },
     {
-      name: "backstage-notifications",
+      name: 'backstage-notifications',
       testMatch: /tests\/specs\/notifications\.spec\.ts/,
+    },
+    {
+      name: 'backstage-techdocs',
+      testMatch: /tests\/specs\/techdocs\.spec\.ts/,
     },
   ],
 });

--- a/workspaces/backstage/e2e-tests/tests/config/techdocs/app-config-rhdh.yaml
+++ b/workspaces/backstage/e2e-tests/tests/config/techdocs/app-config-rhdh.yaml
@@ -1,0 +1,9 @@
+catalog:
+  import:
+    entityFilename: catalog-info.yaml
+    pullRequestBranchName: backstage-integration
+  rules:
+    - allow: [API, Component, Group, Location, Resource, System, Template]
+  locations:
+    - type: url
+      target: https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml

--- a/workspaces/backstage/e2e-tests/tests/config/techdocs/dynamic-plugins.yaml
+++ b/workspaces/backstage/e2e-tests/tests/config/techdocs/dynamic-plugins.yaml
@@ -1,0 +1,7 @@
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
+    disabled: false
+  - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
+    disabled: false
+  - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib
+    disabled: false

--- a/workspaces/backstage/e2e-tests/tests/config/techdocs/dynamic-plugins.yaml
+++ b/workspaces/backstage/e2e-tests/tests/config/techdocs/dynamic-plugins.yaml
@@ -1,7 +1,7 @@
 plugins:
   - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
-    disabled: false
+    disabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
-    disabled: false
+    disabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib
-    disabled: false
+    disabled: true

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -2,7 +2,6 @@ import { expect, Page, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 
 test.describe("TechDocs", () => {
   test.beforeAll(async ({ rhdh }) => {
-    test.setTimeout(600_000);
     await rhdh.configure({
       auth: "keycloak",
       appConfig: "tests/config/techdocs/app-config-rhdh.yaml",
@@ -33,7 +32,6 @@ test.describe("TechDocs", () => {
   });
 
   test("Verify that TechDocs is visible in sidebar", async ({ uiHelper }) => {
-    await uiHelper.openSidebarButton("Favorites");
     await uiHelper.openSidebar("Docs");
   });
 
@@ -41,7 +39,6 @@ test.describe("TechDocs", () => {
     page,
     uiHelper,
   }) => {
-    await uiHelper.openSidebarButton("Favorites");
     await uiHelper.openSidebar("Docs");
     await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
     await uiHelper.waitForTitle("Getting Started running RHDH", 1);
@@ -61,7 +58,6 @@ test.describe("TechDocs", () => {
     page,
     uiHelper,
   }) => {
-    await uiHelper.openSidebarButton("Favorites");
     await uiHelper.openSidebar("Docs");
     await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
     await page.waitForSelector("article a");

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -2,6 +2,7 @@ import { expect, Page, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 
 test.describe("TechDocs", () => {
   test.beforeAll(async ({ rhdh }) => {
+    test.setTimeout(600_000);
     await rhdh.configure({
       auth: "keycloak",
       appConfig: "tests/config/techdocs/app-config-rhdh.yaml",

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -1,0 +1,85 @@
+import { expect, Page, test } from "@red-hat-developer-hub/e2e-test-utils/test";
+
+test.describe("TechDocs", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    await rhdh.configure({
+      auth: "keycloak",
+      appConfig: "tests/config/techdocs/app-config-rhdh.yaml",
+    });
+
+    await rhdh.deploy();
+  });
+
+  async function docsTextHighlight(page: Page) {
+    await page.evaluate(() => {
+      const host = document.querySelector(
+        '[data-testid="techdocs-native-shadowroot"]',
+      );
+      const element = host?.shadowRoot?.querySelector("article p")?.firstChild;
+      if (!element) return;
+      const range = document.createRange();
+      const selection = window.getSelection();
+      range.setStart(element, 0);
+      range.setEnd(element, 20);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      document.dispatchEvent(new Event("selectionchange"));
+    });
+  }
+
+  test.beforeEach(async ({ loginHelper }) => {
+    await loginHelper.loginAsKeycloakUser();
+  });
+
+  test("Verify that TechDocs is visible in sidebar", async ({ uiHelper }) => {
+    await uiHelper.openSidebarButton("Favorites");
+    await uiHelper.openSidebar("Docs");
+  });
+
+  test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.openSidebarButton("Favorites");
+    await uiHelper.openSidebar("Docs");
+    await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
+    await uiHelper.waitForTitle("Getting Started running RHDH", 1);
+  });
+
+  test("Verify that TechDocs entity tab page for Red Hat Developer Hub works", async ({
+    uiHelper,
+  }) => {
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.selectMuiBox("Kind", "Component");
+    await uiHelper.clickLink("Red Hat Developer Hub");
+    await uiHelper.clickTab("Docs");
+    await uiHelper.waitForTitle("Getting Started running RHDH", 1);
+  });
+
+  test("Verify that TechDocs Docs page for ReportIssue addon works", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.openSidebarButton("Favorites");
+    await uiHelper.openSidebar("Docs");
+    await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
+    await page.waitForSelector("article a");
+    await docsTextHighlight(page);
+    const link = await page.waitForSelector("text=Open new Github issue");
+    expect(await link?.isVisible()).toBeTruthy();
+  });
+
+  test("Verify that TechDocs entity tab page for ReportIssue addon works", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.selectMuiBox("Kind", "Component");
+    await uiHelper.clickLink("Red Hat Developer Hub");
+    await uiHelper.clickTab("Docs");
+    await page.waitForSelector("article a");
+    await docsTextHighlight(page);
+    const link = await page.waitForSelector("text=Open new Github issue");
+    expect(await link?.isVisible()).toBeTruthy();
+  });
+});

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -1,5 +1,22 @@
 import { expect, Page, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 
+async function docsTextHighlight(page: Page) {
+  await page.evaluate(() => {
+    const host = document.querySelector(
+      '[data-testid="techdocs-native-shadowroot"]',
+    );
+    const element = host?.shadowRoot?.querySelector("article p")?.firstChild;
+    if (!element) return;
+    const range = document.createRange();
+    const selection = globalThis.getSelection();
+    range.setStart(element, 0);
+    range.setEnd(element, 20);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    document.dispatchEvent(new Event("selectionchange"));
+  });
+}
+
 test.describe("TechDocs", () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({
@@ -9,23 +26,6 @@ test.describe("TechDocs", () => {
 
     await rhdh.deploy();
   });
-
-  async function docsTextHighlight(page: Page) {
-    await page.evaluate(() => {
-      const host = document.querySelector(
-        '[data-testid="techdocs-native-shadowroot"]',
-      );
-      const element = host?.shadowRoot?.querySelector("article p")?.firstChild;
-      if (!element) return;
-      const range = document.createRange();
-      const selection = window.getSelection();
-      range.setStart(element, 0);
-      range.setEnd(element, 20);
-      selection?.removeAllRanges();
-      selection?.addRange(range);
-      document.dispatchEvent(new Event("selectionchange"));
-    });
-  }
 
   test.beforeEach(async ({ loginHelper }) => {
     await loginHelper.loginAsKeycloakUser();

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -25,6 +25,7 @@ test.describe("TechDocs", () => {
     await rhdh.configure({
       auth: "keycloak",
       appConfig: "tests/config/techdocs/app-config-rhdh.yaml",
+      dynamicPlugins: "tests/config/techdocs/dynamic-plugins.yaml",
     });
 
     await rhdh.deploy();

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -19,6 +19,9 @@ async function docsTextHighlight(page: Page) {
 
 test.describe("TechDocs", () => {
   test.beforeAll(async ({ rhdh }) => {
+    // Allow time for deployment + 1 min provider refresh delay + browser setup
+    test.setTimeout(10 * 60 * 1000);
+
     await rhdh.configure({
       auth: "keycloak",
       appConfig: "tests/config/techdocs/app-config-rhdh.yaml",

--- a/workspaces/backstage/e2e-tests/tsconfig.json
+++ b/workspaces/backstage/e2e-tests/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@red-hat-developer-hub/e2e-test-utils/tsconfig",
   "compilerOptions": {
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "lib": ["dom", "es2022"]
   },
   "include": ["**/*.ts", "eslint.config.js"]
 }


### PR DESCRIPTION
## Description

Moves the techdocs plugins e2e tests over from the RHDH repo to the overlays repo.

Updates the scaffolder backend module azure plugin to point to the OCI artifact since we no longer include it as a dynamic plugin wrapper within RHDH.

## Which issue(s) does this PR fix

- Fixes [RHIDP-11387](https://redhat.atlassian.net/browse/RHIDP-11387)