### PR TITLE
fix(tekton): e2e nightly failure

### DIFF
--- a/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
+++ b/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
@@ -42,7 +42,9 @@ test.describe("Test Tekton plugin", () => {
   }) => {
     const tekton = new TektonSupportHelper(page);
     await tekton.goToBackstageJanusProjectCITab();
-    await tekton.clickOnExpandRowFromPipelineRunsTable();
+    await tekton.clickOnExpandRowFromPipelineRunsTable(
+      "hello-world-pipeline-run",
+    );
     await tekton.openModalEchoHelloWorld();
     await tekton.verifyModalOpened();
     await tekton.checkPipelineStages(["echo-hello-world", "echo-bye"]);

--- a/workspaces/tekton/e2e-tests/tests/support/tekton-support-helper.ts
+++ b/workspaces/tekton/e2e-tests/tests/support/tekton-support-helper.ts
@@ -48,12 +48,11 @@ export class TektonSupportHelper {
     return ["NAME", "STATUS", "TASK STATUS", "STARTED", "DURATION"];
   }
 
-  async clickOnExpandRowFromPipelineRunsTable(): Promise<void> {
+  async clickOnExpandRowFromPipelineRunsTable(runName: string): Promise<void> {
     await this.page
-      .locator(
-        'table[aria-labelledby="Pipeline Runs"] button[aria-label="expand row"]',
-      )
-      .first()
+      .getByRole("row")
+      .filter({ hasText: runName })
+      .getByRole("button", { name: "expand row" })
       .click();
   }
 

--- a/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
+++ b/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
@@ -29,6 +29,8 @@ async function getResourceType(page: Page): Promise<"ingress" | "route"> {
 }
 
 test.describe("Test Topology plugin", () => {
+  const deploymentLocator = `[data-test-id="topology-test"]`;
+
   test.beforeAll(async ({ rhdh }) => {
     test.setTimeout(800_000);
     const project = rhdh.deploymentConfig.namespace;
@@ -75,7 +77,9 @@ test.describe("Test Topology plugin", () => {
       await uiHelper.verifyText(/\d{1,5} (Succeeded|Failed|Cancelled|Running)/);
     }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
     await topology.verifyDeployment("topology-test");
-    await uiHelper.verifyButtonURL("Open URL", "topology-test-route");
+    await uiHelper.verifyButtonURL("Open URL", "topology-test-route", {
+      locator: deploymentLocator,
+    });
     await uiHelper.clickTab("Details");
     await uiHelper.verifyText("Status");
     await uiHelper.verifyText("Active");
@@ -115,6 +119,7 @@ test.describe("Test Topology plugin", () => {
     await uiHelper.verifyButtonURL(
       "Edit source code",
       "https://github.com/janus-idp/backstage-showcase",
+      { locator: deploymentLocator },
     );
     await uiHelper.clickTab("Resources");
     await uiHelper.verifyText("P");


### PR DESCRIPTION
fixes nightly fail for when additional pipeline runs are created by other tests

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/redhat-developer_rhdh-plugin-export-overlays/2232/pull-ci-redhat-developer-rhdh-plugin-export-overlays-main-e2e-ocp-helm-nightly/2042245515625631744/artifacts/e2e-ocp-helm-nightly/redhat-developer-rhdh-plugin-export-overlays-ocp-helm/artifacts/playwright-report/index.html#?testId=c825e6b30631aa3f6b33-de30a657deab8a710e10