### PR TITLE
fix(adoption-insights): update docs link

### DIFF
--- a/catalog-entities/extensions/plugins/adoption-insights.yaml
+++ b/catalog-entities/extensions/plugins/adoption-insights.yaml
@@ -18,7 +18,7 @@ metadata:
     - title: "Report issues here. Note: Customers of Red Hat Developer Hub should raise a Red Hat support case instead."
       url: https://issues.redhat.com/browse/RHDHBUGS
     - title: Documentation
-      url: https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6/html-single/adoption_insights_in_red_hat_developer_hub/index
+      url: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html-single/adoption_insights_in_red_hat_developer_hub/index
     - title: Source Code
       url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/adoption-insights/plugins/adoption-insights
 


### PR DESCRIPTION
### Fix:- https://redhat.atlassian.net/browse/RHDHBUGS-2205

### What
Updates the Adoption Insights documentation link in the `release-1.9` branch from 1.6 to the latest (1.9).

### Why
The current link in the `release-1.9` branch still points to 1.6 documentation, which causes users running RHDH 1.9 to be redirected to outdated docs.