### PR TITLE
chore: bump Backstage to version 1.49.4

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-    "backstage": "1.48.3",
+    "backstage": "1.49.4",
     "node": "22.22.0",
     "cli": "1.10.4",
     "cliPackage": "@red-hat-developer-hub/cli"


### PR DESCRIPTION
Bumps the Backstage version to 1.49.4, which is the latest adopted version on RHDH (see https://github.com/redhat-developer/rhdh/pull/4354).