### PR TITLE
chore: add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Adds a `.github/dependabot.yml` config to keep GitHub Actions dependencies up to date
- Monitors the `github-actions` package ecosystem with weekly checks
- Groups all action updates into a single PR to reduce noise
- All workflows already pin actions to commit SHAs (e.g., `actions/checkout@de0fac2e...`); Dependabot will bump those SHAs and version comments when new releases are available

## Details

Actions currently pinned and covered by this config:

| Action | Current version |
|--------|----------------|
| `actions/checkout` | v6.0.2 |
| `actions/github-script` | v8.0.0 |
| `actions/setup-node` | v6.3.0 |
| `actions/download-artifact` | v7.0.0 |
| `actions/upload-artifact` | v6.0.0 |
| `actions/stale` | v10.2.0 |
| `docker/login-action` | v4.1.0 |
| `dawidd6/action-download-artifact` | v20 |

References to `redhat-developer/rhdh-plugin-export-utils@main` (reusable workflows/actions pinned to a branch) are intentionally not covered, as those are internal and follow `main` by design.


Made with [Cursor](https://cursor.com)