### PR TITLE
chore(orchestrator): bump rhdh-plugins ref and sync package metadata

### DIFF
--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend-module-loki.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend-module-loki.yaml
@@ -19,10 +19,10 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki"
   # Tag: 1.10.0--1.0.1, Build date: 2026-01-29T15:52:02Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend-module-loki@sha256:4690f183eff37c90ffc893d385cbd04757c922a533035a7ae99674b633b41274"
-  version: 1.0.1
+  version: 1.2.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.3
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend.yaml
@@ -19,10 +19,10 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-backend"
   # Tag: 1.10.0--8.6.1, Build date: 2026-01-29T16:13:22Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend@sha256:3a3d10258d1da0529ba853f82742cb55740ce8799599a41f1c5fff6a76d8d84d"
-  version: 8.6.1
+  version: 8.8.2
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.3
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-form-widgets.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-form-widgets.yaml
@@ -19,10 +19,10 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets"
   # Tag: 1.10.0--1.6.2, Build date: 2026-01-29T16:08:58Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets@sha256:692afe6b19aabf47a4ea02177d7637083db0adfeb7240b5321d64ee39d5cd040"
-  version: 1.6.2
+  version: 1.10.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.3
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator.yaml
@@ -19,10 +19,10 @@ spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-orchestrator'
   # Tag: 1.10.0--5.4.1, Build date: 2026-01-29T16:08:22Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator@sha256:f40d39fb7599d2cbfa8f64d6f4703d69539e4a4b0e49518499f47ca986fbd814"
-  version: 5.4.1
+  version: 5.7.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.3
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-scaffolder-backend-module-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-scaffolder-backend-module-orchestrator.yaml
@@ -20,10 +20,10 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator"
   # Tag: 1.10.0--1.3.3, Build date: 2026-01-29T16:21:53Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator@sha256:566c09637572fe80c3769d92e6847f1def5b8a7e2a7fc52e046b55cfc6dcea4f"
-  version: 1.3.3
+  version: 1.5.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.3
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/orchestrator/source.json
+++ b/workspaces/orchestrator/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"8b96efcfe86638baa49f6f6a8685cf3d8e002df7","repo-flat":false,"repo-backstage-version":"1.45.2"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"26ce797d7aac1965c03a45a7ac6a63a542d18620","repo-flat":false,"repo-backstage-version":"1.49.3"}


### PR DESCRIPTION

Updates the orchestrator workspace to a newer `redhat-developer/rhdh-plugins` commit and aligns overlay metadata with the upstream packages at that revision.
