### PR TITLE
chore(user-guide): Add docs for more commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ On a PR, comment:
 - `/publish` — Build and publish test OCI images (tagged `pr_<number>__<version>`)
 - `/smoketest` — Run smoke tests against last published artifacts (requires prior `/publish`)
 - `/override-backstage` — Override workspace Backstage compatibility version (creates `backstage.json` and rewrites metadata OCI tags)
+- `/update-versions` — Copy `versions.json` from the PR base branch onto the PR branch (release-line alignment)
+- `/update-commit` — Re-run automatic plugin repo ref discovery for the single touched workspace and update the PR
 - `/test` or `/test e2e-tests` — Run e2e tests. Only relevant for PRs that modify workspaces containing an `e2e-tests/` directory (e.g., the `backstage` workspace)
 
 ### Important Workflows (`.github/workflows/`)
@@ -64,7 +66,7 @@ On a PR, comment:
 |----------|---------|---------|
 | `update-plugins-repo-refs.yaml` | Daily + manual | Auto-generates PRs for plugin version updates |
 | `publish-workspace-plugins.yaml` | Push to release branches | Publishes final OCI images |
-| `pr-actions.yaml` | PR comments | Handles `/publish` and `/smoketest` commands |
+| `pr-actions.yaml` | PR comments | Handles `/publish`, `/smoketest`, `/override-backstage`, `/update-versions`, and `/update-commit` commands |
 | `run-workspace-smoke-tests.yaml` | After publish | Verifies plugins load in RHDH container |
 | `check-backstage-compatibility.yaml` | Push + PRs | Gates release branch creation on compatibility |
 | `sync-user-guide-to-wiki.yaml` | Weekly + manual | Syncs `user-guide/` to GitHub Wiki with placeholder injection |

--- a/user-guide/02-export-tools.md
+++ b/user-guide/02-export-tools.md
@@ -113,13 +113,22 @@ gh workflow run export-workspaces-as-dynamic.yaml \
 
 ## PR Commands
 
-When working with Pull Requests, use these comment commands:
+When working with Pull Requests, use these comment commands on the PR (handled by [`pr-actions.yaml`](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/.github/workflows/pr-actions.yaml)).
+
+**Requirements (all commands in this section):**
+
+- The PR must touch **exactly one** workspace (files under `workspaces/<name>/...`), or the head branch must match `workspaces/release-*__<name>` so the workspace can be inferred.
+- Use **one** slash command per comment (multiple commands in one comment are rejected).
 
 | Command | Action |
 |---------|--------|
 | `/publish` | Build and publish test OCI artifacts |
 | `/smoketest` | Re-run smoke tests with the default branch-derived RHDH image (requires prior `/publish`) |
 | `/smoketest <tag>` | Re-run smoke tests with `quay.io/rhdh-community/rhdh:<tag>` (allowlisted tag formats, requires prior `/publish`) |
+| `/update-versions` | Copy [`versions.json`](../versions.json) from the PR base branch onto the PR branch so it matches the release line |
+| `/update-commit` | Re-run automatic plugin repo ref discovery for that workspace and update the PR branch |
+
+Use `/update-versions` when CI reports that `versions.json` on your PR does not match the release branch you are targeting. Use `/update-commit` when you want refreshed upstream refs (for example `source.json`) from discovery without editing them by hand.
 
 ### What `/publish` Does
 
@@ -132,6 +141,22 @@ When working with Pull Requests, use these comment commands:
 7. Packages as OCI containers
 8. Publishes to `ghcr.io` with tag `pr_<number>__<version>`
 9. Posts OCI references as a PR comment
+
+### What `/update-versions` Does
+
+1. Reads the root `versions.json` file from the **PR base branch** (for example `release-1.5`).
+2. Writes that same content onto your **PR head branch** so the PR’s `versions.json` matches the release line.
+3. Runs with **force** enabled: if your branch had local edits to `versions.json`, they can be **overwritten**—resolve intentional differences elsewhere (for example follow up with a separate commit only if policy allows).
+
+Workflow: [`update-prs-with-release-branch-commits.yaml`](https://github.com/redhat-developer/rhdh-plugin-export-overlays/actions/workflows/update-prs-with-release-branch-commits.yaml).
+
+### What `/update-commit` Does
+
+1. Resolves the single workspace for the PR (same rules as `/publish`).
+2. Invokes the **update plugins repository references** pipeline for that workspace only, scoped to the PR (same automation family as the scheduled discovery workflow, with `allow-workspace-addition` disabled so new workspaces are not created from the comment path).
+3. Updates discovery-managed inputs on the PR branch (such as `source.json` **repo-ref** / discovery outputs for that workspace)—not `versions.json` (use `/update-versions` for that).
+
+Workflow: [`update-plugins-repo-refs.yaml`](https://github.com/redhat-developer/rhdh-plugin-export-overlays/actions/workflows/update-plugins-repo-refs.yaml).
 
 ---
 

--- a/user-guide/05-version-updates.md
+++ b/user-guide/05-version-updates.md
@@ -19,6 +19,8 @@ The version of Backstage that the target platform is built on. Defined in `versi
 }
 ```
 
+If an open PR targets a release branch and `versions.json` on the PR branch is behind the base branch, you can align it by commenting **`/update-versions`** on the PR (see [PR Commands](./02-export-tools.md#pr-commands) in the export tools guide).
+
 ### Supported Versions (in metadata)
 
 The Backstage version your plugin is compatible with:


### PR DESCRIPTION
This change adds notes for the /update-commit and /update-versions bot commands to the user guide.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED