### PR TITLE
feat: auto-derive skip tags from JOB_NAME in run-e2e.sh

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -79,11 +79,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Skip tag — auto-derived from JOB_NAME for --grep-invert (e.g., @skip-ocp-helm).
-# Uses negative lookahead (?!-) for exact matching: the pattern @skip-ocp-helm(?!-)
-# will match the tag @skip-ocp-helm but won't match @skip-ocp-helm-nightly,
-# keeping PR check and nightly tags isolated from each other.
-# Prepended to PLAYWRIGHT_ARGS so user-provided --grep-invert takes precedence (last wins).
+# Auto-skip tests tagged @skip-<job-suffix> based on JOB_NAME.
+# (?!-) ensures exact match — @skip-ocp-helm won't match @skip-ocp-helm-nightly.
 if [[ -n "$JOB_NAME" ]]; then
     JOB_SUFFIX=$(echo "$JOB_NAME" | sed -n 's/.*-e2e-//p')
     if [[ -n "$JOB_SUFFIX" ]]; then

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -79,6 +79,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Skip tag — auto-derived from JOB_NAME for --grep-invert (e.g., @skip-ocp-helm).
+# Prepended to PLAYWRIGHT_ARGS so user-provided --grep-invert takes precedence (last wins).
+if [[ -n "$JOB_NAME" ]]; then
+    JOB_SUFFIX=$(echo "$JOB_NAME" | sed -n 's/.*-e2e-//p')
+    if [[ -n "$JOB_SUFFIX" ]]; then
+        E2E_SKIP_TAG="@skip-${JOB_SUFFIX}"
+        PLAYWRIGHT_ARGS=("--grep-invert" "$E2E_SKIP_TAG" "${PLAYWRIGHT_ARGS[@]}")
+        echo "[INFO] Skip tag: $E2E_SKIP_TAG (derived from JOB_NAME)"
+    fi
+fi
+
 GENERATED_FILES=()
 
 # ── Prerequisites ─────────────────────────────────────────────────────────────

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -80,11 +80,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Skip tag — auto-derived from JOB_NAME for --grep-invert (e.g., @skip-ocp-helm).
+# Uses negative lookahead (?!-) so @skip-ocp-helm only matches that exact tag,
+# not @skip-ocp-helm-nightly. This lets tests skip in PR check without skipping nightly.
 # Prepended to PLAYWRIGHT_ARGS so user-provided --grep-invert takes precedence (last wins).
 if [[ -n "$JOB_NAME" ]]; then
     JOB_SUFFIX=$(echo "$JOB_NAME" | sed -n 's/.*-e2e-//p')
     if [[ -n "$JOB_SUFFIX" ]]; then
-        E2E_SKIP_TAG="@skip-${JOB_SUFFIX}"
+        E2E_SKIP_TAG="@skip-${JOB_SUFFIX}(?!-)"
         PLAYWRIGHT_ARGS=("--grep-invert" "$E2E_SKIP_TAG" "${PLAYWRIGHT_ARGS[@]}")
         echo "[INFO] Skip tag: $E2E_SKIP_TAG (derived from JOB_NAME)"
     fi

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -80,8 +80,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Skip tag — auto-derived from JOB_NAME for --grep-invert (e.g., @skip-ocp-helm).
-# Uses negative lookahead (?!-) so @skip-ocp-helm only matches that exact tag,
-# not @skip-ocp-helm-nightly. This lets tests skip in PR check without skipping nightly.
+# Uses negative lookahead (?!-) for exact matching: the pattern @skip-ocp-helm(?!-)
+# will match the tag @skip-ocp-helm but won't match @skip-ocp-helm-nightly,
+# keeping PR check and nightly tags isolated from each other.
 # Prepended to PLAYWRIGHT_ARGS so user-provided --grep-invert takes precedence (last wins).
 if [[ -n "$JOB_NAME" ]]; then
     JOB_SUFFIX=$(echo "$JOB_NAME" | sed -n 's/.*-e2e-//p')


### PR DESCRIPTION
JIRA : https://redhat.atlassian.net/browse/RHIDP-13048

## Summary
- Auto-derive Playwright skip tags from OpenShift CI `JOB_NAME` in `run-e2e.sh`
- Extracts job suffix from `JOB_NAME` (e.g., `ocp-helm`, `ocp-helm-nightly`) and injects `--grep-invert "@skip-<suffix>"` into Playwright args
- Allows test authors to skip tests in specific CI jobs using standard Playwright tags (e.g., `{ tag: "@skip-ocp-helm-nightly" }`)
- Works from workspace dirs too via manual `--grep-invert`

Documentation : https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/88

## How it works

| JOB_NAME suffix | Derived tag |
|-----------------|-------------|
| `e2e-ocp-helm` | `@skip-ocp-helm` |
| `e2e-ocp-helm-nightly` | `@skip-ocp-helm-nightly` |
| `e2e-ocp-operator` | `@skip-ocp-operator` |
| `e2e-ocp-operator-nightly` | `@skip-ocp-operator-nightly` |


🤖 Generated with [Claude Code](https://claude.com/claude-code)