### PR TITLE
chore(lightspeed): Update metadata to GA status

### DIFF
--- a/catalog-entities/extensions/plugins/lightspeed.yaml
+++ b/catalog-entities/extensions/plugins/lightspeed.yaml
@@ -25,7 +25,7 @@ spec:
   author: Red Hat
   support:
     provider: Red Hat
-    level: dev-preview
+    level: generally-available
   lifecycle: active
   publisher: Red Hat
 

--- a/workspaces/lightspeed/metadata/red-hat-developer-hub-backstage-plugin-lightspeed-backend.yaml
+++ b/workspaces/lightspeed/metadata/red-hat-developer-hub-backstage-plugin-lightspeed-backend.yaml
@@ -22,7 +22,7 @@ spec:
     role: backend-plugin
     supportedVersions: 1.45.3
   author: Red Hat
-  support: dev-preview
+  support: generally-available
   lifecycle: active
   partOf:
     - lightspeed

--- a/workspaces/lightspeed/metadata/red-hat-developer-hub-backstage-plugin-lightspeed.yaml
+++ b/workspaces/lightspeed/metadata/red-hat-developer-hub-backstage-plugin-lightspeed.yaml
@@ -22,7 +22,7 @@ spec:
     role: frontend-plugin
     supportedVersions: 1.45.3
   author: Red Hat
-  support: dev-preview
+  support: generally-available
   lifecycle: active
   partOf:
     - lightspeed


### PR DESCRIPTION
ref: https://redhat.atlassian.net/browse/RHIDP-11297

## Description

Updates the Lightspeed package metadata to GA status. Already in supported state since https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2010.