### PR TITLE
fix(github): e2e test config paths

### DIFF
--- a/workspaces/github/e2e-tests/tests/specs/github-actions.spec.ts
+++ b/workspaces/github/e2e-tests/tests/specs/github-actions.spec.ts
@@ -3,10 +3,14 @@ import {
   APIHelper,
   GITHUB_API_ENDPOINTS,
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
+import { WorkspacePaths } from "@red-hat-developer-hub/e2e-test-utils/utils";
 
 test.describe("Test github-actions", () => {
   test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({ auth: "github" });
+    await rhdh.configure({
+      auth: "github",
+      appConfig: `${WorkspacePaths.configDir}/github-actions/app-config-rhdh.yaml`,
+    });
     await rhdh.deploy();
   });
 

--- a/workspaces/github/e2e-tests/tests/specs/github-issues.spec.ts
+++ b/workspaces/github/e2e-tests/tests/specs/github-issues.spec.ts
@@ -3,6 +3,7 @@ import {
   APIHelper,
   GITHUB_API_ENDPOINTS,
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
+import { WorkspacePaths } from "@red-hat-developer-hub/e2e-test-utils/utils";
 
 interface GHIssue {
   pull_request: boolean; // eslint-disable-line @typescript-eslint/naming-convention
@@ -11,7 +12,10 @@ interface GHIssue {
 
 test.describe("Test github-issues", () => {
   test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({ auth: "github" });
+    await rhdh.configure({
+      auth: "github",
+      appConfig: `${WorkspacePaths.configDir}/github-issues/app-config-rhdh.yaml`,
+    });
     await rhdh.deploy();
   });
 


### PR DESCRIPTION
point the tests to the appropriate app config files, since they got moved out of the default location