### PR TITLE
chore: add and update github workspace plugin metadata

### DIFF
--- a/workspaces/github/metadata/backstage-community-plugin-github-deployments.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-deployments.yaml
@@ -1,0 +1,43 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-github-deployments
+  namespace: rhdh
+  title: "GitHub Deployments"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/community-plugins/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-deployments
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/github
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-github-deployments"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-deployments:bs_1.49.4__0.18.0!backstage-community-plugin-github-deployments
+  version: 0.18.0
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.45.3
+  author: Red Hat
+  support: community
+  lifecycle: active
+  partOf:
+    - github-deployments
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-github-deployments:
+              mountPoints:
+                - mountPoint: entity.page.overview/cards
+                  importName: EntityGithubDeploymentsCard
+                  config:
+                    layout:
+                      gridColumn: 1 / -1
+                    if:
+                      allOf:
+                        - isGithubDeploymentsAvailable

--- a/workspaces/github/metadata/backstage-community-plugin-github-discussions.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-discussions.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-github-discussions
+  namespace: rhdh
+  title: "GitHub Discussions"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/community-plugins/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-discussions
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/github
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-github-discussions"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-discussions:bs_1.49.4__0.10.0!backstage-community-plugin-github-discussions
+  version: 0.10.0
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.45.3
+  author: Red Hat
+  support: community
+  lifecycle: active
+  partOf:
+    - github-discussions
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-github-discussions:
+              mountPoints:
+                - mountPoint: search.page.results
+                  importName: GithubDiscussionsSearchResultListItem

--- a/workspaces/github/metadata/backstage-community-plugin-github-pull-requests-board.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-pull-requests-board.yaml
@@ -30,7 +30,7 @@ spec:
       content:
         dynamicPlugins:
           frontend:
-            backstage-community.plugin-pull-requests-board:
+            backstage-community.plugin-github-pull-requests-board:
               entityTabs:
                 - mountPoint: entity.page.pull-requests-board
                   path: /pull-requests-board

--- a/workspaces/github/metadata/backstage-community-plugin-search-backend-module-github-discussions.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-search-backend-module-github-discussions.yaml
@@ -1,0 +1,33 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-search-backend-module-github-discussions
+  namespace: rhdh
+  title: "GitHub Discussions Search Backend Module"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/community-plugins/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/search-backend-module-github-discussions
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/github
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-search-backend-module-github-discussions"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-search-backend-module-github-discussions:bs_1.49.4__0.11.0!backstage-community-plugin-search-backend-module-github-discussions
+  version: 0.11.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.45.3
+  author: Red Hat
+  support: community
+  lifecycle: active
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        search:
+          collators:
+            githubDiscussions:
+              url: ${GITHUB_DISCUSSIONS_REPO_URL}


### PR DESCRIPTION
### Description
Updates `github` workspace plugin metadata to add new plugins in `github` workspace so smoketests will trigger.

Also fixes the default app config for the pull request board plugin

Continuation of https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2298