### PR TITLE
chore: metadata should have 'support:...

### DIFF
--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-gitlab-org.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-gitlab-org.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin-module
     supportedVersions: 1.48.3
   author: Red Hat
-  support: production
+  support: generally-available
   lifecycle: active
   partOf:
     - gitlab-org-catalog-integration

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-gitlab.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-gitlab.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin-module
     supportedVersions: 1.48.3
   author: Red Hat
-  support: production
+  support: generally-available
   lifecycle: active
   partOf:
     - gitlab-catalog-integration


### PR DESCRIPTION
### What does this PR do?

chore: metadata should have 'support: generally-available' not 'support: production' ([RHIDP-13267](https://redhat.atlassian.net/browse/RHIDP-13267))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.