### PR TITLE
[Konflux] bump to 0.1.7

### DIFF
--- a/workspaces/konflux/metadata/red-hat-developer-hub-backstage-plugin-konflux-backend.yaml
+++ b/workspaces/konflux/metadata/red-hat-developer-hub-backstage-plugin-konflux-backend.yaml
@@ -16,11 +16,11 @@ metadata:
     - cicd
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-konflux-backend"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-konflux-backend:bs_1.49.4__0.1.6!red-hat-developer-hub-backstage-plugin-konflux-backend
-  version: 0.1.6
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-konflux-backend:bs_1.49.4__0.1.7!red-hat-developer-hub-backstage-plugin-konflux-backend
+  version: 0.1.7
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/konflux/metadata/red-hat-developer-hub-backstage-plugin-konflux.yaml
+++ b/workspaces/konflux/metadata/red-hat-developer-hub-backstage-plugin-konflux.yaml
@@ -16,11 +16,11 @@ metadata:
     - cicd
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-konflux"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-konflux:bs_1.49.4__0.1.6!red-hat-developer-hub-backstage-plugin-konflux
-  version: 0.1.6
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-konflux:bs_1.49.4__0.1.7!red-hat-developer-hub-backstage-plugin-konflux
+  version: 0.1.7
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/konflux/source.json
+++ b/workspaces/konflux/source.json
@@ -1,6 +1,6 @@
 {
   "repo": "https://github.com/redhat-developer/rhdh-plugins",
-  "repo-ref": "2d0d82c5d8c07d992967528e047e2ee0aa841459",
+  "repo-ref": "cb70fc5e702abf95c4299dbf3d34398bee91ec5f",
   "repo-flat": false,
-  "repo-backstage-version": "1.45.2"
+  "repo-backstage-version": "1.49.4"
 }


### PR DESCRIPTION
In this PR we're bumping the konflux related plugins to 0.1.7 version. This is the [commit](cb70fc5e702abf95c4299dbf3d34398bee91ec5f) reference from rhdh-plugins repo :coffee: