### PR TITLE
fix: pin RHDH_VERSION to 1.10-114-CI due to RHDHBUGS-3030

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -32,7 +32,8 @@ cd "$SCRIPT_DIR"
 # These use defaults that can be overridden via environment variables.
 
 # RHDH deployment
-export RHDH_VERSION="${RHDH_VERSION:-1.10}"             # RHDH version to deploy (e.g., "1.10", "next")
+# export RHDH_VERSION="${RHDH_VERSION:-1.10}"             # RHDH version to deploy (e.g., "1.10", "next")
+export RHDH_VERSION="1.10-114-CI"                       # Pinned due to RHDHBUGS-3030
 export INSTALLATION_METHOD="${INSTALLATION_METHOD:-helm}" # "helm" or "operator"
 
 # Playwright

--- a/workspaces/rbac/e2e-tests/support/pages/rbac-po.ts
+++ b/workspaces/rbac/e2e-tests/support/pages/rbac-po.ts
@@ -528,7 +528,7 @@ export class RbacPO {
     await this.selectOption("scaffolder");
 
     // Close the plugins dropdown to access the permissions table
-    await this.page.getByRole("button", { name: "Close" }).click();
+    await this.page.getByRole("button", { name: "Close", exact: true }).click();
 
     // Expand the Scaffolder row to access its permissions
     await this.page


### PR DESCRIPTION
## Summary
- Pin RHDH Helm chart version to `1.10-114-CI` in `run-e2e.sh` to work around [RHDHBUGS-3030](https://redhat.atlassian.net/browse/RHDHBUGS-3030)