### PR TITLE
Add scorecard-backend-module-filecheck

### DIFF
--- a/catalog-entities/extensions/plugins/scorecard.yaml
+++ b/catalog-entities/extensions/plugins/scorecard.yaml
@@ -8,8 +8,8 @@ metadata:
   description: |
     Track the health, security, and compliance of your components with customizable KPIs.
   annotations:
-    extensions.backstage.io/pre-installed: 'true' # this means the plugin yaml is preinstalled, not the plugin itself, all other plugins are marked as 'custom'
-  tags: 
+    extensions.backstage.io/pre-installed: "true" # this means the plugin yaml is preinstalled, not the plugin itself, all other plugins are marked as 'custom'
+  tags:
     - analytics
 
   links:
@@ -23,7 +23,6 @@ metadata:
       url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/scorecard
 
 spec:
-
   author: Red Hat
   support:
     provider: Red Hat
@@ -63,5 +62,6 @@ spec:
   packages:
     - rhdh-backstage-plugin-scorecard-backend-module-github
     - rhdh-backstage-plugin-scorecard-backend-module-jira
+    - rhdh-backstage-plugin-scorecard-backend-module-filecheck
     - rhdh-backstage-plugin-scorecard-backend
     - rhdh-backstage-plugin-scorecard

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-filecheck.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-filecheck.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: rhdh-backstage-plugin-scorecard-backend-module-filecheck
+  namespace: rhdh
+  title: "Scorecard Backend Module for Filechecks"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://issues.redhat.com/browse/RHDHBUGS
+      title:
+        "Report issues here. Note: Customers of Red Hat Developer Hub should
+        raise a Red Hat support case instead."
+    - title: Source Code
+      url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/scorecard/plugins/scorecard-backend-module-filecheck
+  annotations:
+    backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/scorecard/plugins/scorecard-backend-module-filecheck
+  tags:
+    - analytics
+spec:
+  packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-filecheck"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-filecheck:bs_1.49.4__0.1.0!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-filecheck
+  version: 0.1.0
+  backstage:
+    role: backend-plugin-module
+    supportedVersions: 1.45.3
+  author: Red Hat
+  support: tech-preview
+  lifecycle: active
+  partOf:
+    - scorecard
+  appConfigExamples: []

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
@@ -8,7 +8,8 @@ metadata:
     - url: https://red.ht/rhdh
       title: Homepage
     - url: https://issues.redhat.com/browse/RHDHBUGS
-      title: "Report issues here. Note: Customers of Red Hat Developer Hub should
+      title:
+        "Report issues here. Note: Customers of Red Hat Developer Hub should
         raise a Red Hat support case instead."
     - title: Source Code
       url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/scorecard/plugins/scorecard-backend-module-github
@@ -18,7 +19,7 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-github"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.49.4__2.5.2!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.49.4__2.6.0!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github
   version: 2.5.2
   backstage:
     role: backend-plugin-module

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-github"
   dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.49.4__2.6.0!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github
-  version: 2.5.2
+  version: 2.6.0
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.45.3

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
@@ -8,7 +8,8 @@ metadata:
     - url: https://red.ht/rhdh
       title: Homepage
     - url: https://issues.redhat.com/browse/RHDHBUGS
-      title: "Report issues here. Note: Customers of Red Hat Developer Hub should
+      title:
+        "Report issues here. Note: Customers of Red Hat Developer Hub should
         raise a Red Hat support case instead."
     - title: Source Code
       url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/scorecard/plugins/scorecard-backend-module-jira
@@ -18,7 +19,7 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-jira"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.49.4__2.5.2!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.49.4__2.6.0!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira
   version: 2.5.2
   backstage:
     role: backend-plugin-module
@@ -36,12 +37,12 @@ spec:
           proxyPath: /jira/api
         proxy:
           endpoints:
-            '/jira/api':
+            "/jira/api":
               target: ${JIRA_URL}
               headers:
-                Accept: 'application/json'
-                Content-Type: 'application/json'
-                X-Atlassian-Token: 'no-check'
+                Accept: "application/json"
+                Content-Type: "application/json"
+                X-Atlassian-Token: "no-check"
                 # Required: (For cloud use 'Basic email:tokenInBase64', for datacenter use 'Bearer YourJiraToken')
                 Authorization: ${JIRA_TOKEN}
     - title: Direct cloud configuration
@@ -86,8 +87,8 @@ spec:
                 thresholds:
                   rules:
                     - key: success
-                      expression: '<50'
+                      expression: "<50"
                     - key: warning
-                      expression: '50-100'
+                      expression: "50-100"
                     - key: error
-                      expression: '>100'
+                      expression: ">100"

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-jira"
   dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.49.4__2.6.0!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira
-  version: 2.5.2
+  version: 2.6.0
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.45.3

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-openssf.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-openssf.yaml
@@ -17,7 +17,7 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-openssf"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf:bs_1.49.4__0.2.2!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf:bs_1.49.4__0.2.3!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf
   version: 0.2.2
   backstage:
     role: backend-plugin-module

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-openssf.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-openssf.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-openssf"
   dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf:bs_1.49.4__0.2.3!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf
-  version: 0.2.2
+  version: 0.2.3
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.45.3

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend"
   dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.49.4__2.6.0!red-hat-developer-hub-backstage-plugin-scorecard-backend
-  version: 2.5.2
+  version: 2.6.0
   backstage:
     role: backend-plugin
     supportedVersions: 1.45.3

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
@@ -8,7 +8,8 @@ metadata:
     - url: https://red.ht/rhdh
       title: Homepage
     - url: https://issues.redhat.com/browse/RHDHBUGS
-      title: "Report issues here. Note: Customers of Red Hat Developer Hub should
+      title:
+        "Report issues here. Note: Customers of Red Hat Developer Hub should
         raise a Red Hat support case instead."
     - title: Source Code
       url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/scorecard/plugins/scorecard-backend
@@ -18,7 +19,7 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.49.4__2.5.2!red-hat-developer-hub-backstage-plugin-scorecard-backend
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.49.4__2.6.0!red-hat-developer-hub-backstage-plugin-scorecard-backend
   version: 2.5.2
   backstage:
     role: backend-plugin

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
@@ -8,7 +8,8 @@ metadata:
     - url: https://red.ht/rhdh
       title: Homepage
     - url: https://issues.redhat.com/browse/RHDHBUGS
-      title: "Report issues here. Note: Customers of Red Hat Developer Hub should
+      title:
+        "Report issues here. Note: Customers of Red Hat Developer Hub should
         raise a Red Hat support case instead."
     - title: Source Code
       url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/scorecard/plugins/scorecard
@@ -18,7 +19,7 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.49.4__2.5.2!red-hat-developer-hub-backstage-plugin-scorecard
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.49.4__2.6.0!red-hat-developer-hub-backstage-plugin-scorecard
   version: 2.5.2
   backstage:
     role: frontend-plugin
@@ -35,7 +36,7 @@ spec:
           frontend:
             red-hat-developer-hub.backstage-plugin-scorecard:
               entityTabs:
-                - path: '/scorecard'
+                - path: "/scorecard"
                   title: Scorecard
                   mountPoint: entity.page.scorecard
               mountPoints:

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard"
   dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.49.4__2.6.0!red-hat-developer-hub-backstage-plugin-scorecard
-  version: 2.5.2
+  version: 2.6.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.45.3

--- a/workspaces/scorecard/plugins-list.yaml
+++ b/workspaces/scorecard/plugins-list.yaml
@@ -4,3 +4,4 @@ plugins/scorecard-backend-module-github:
 plugins/scorecard-backend-module-jira:
 plugins/scorecard-backend-module-openssf:
 plugins/scorecard-backend-module-dependabot:
+plugins/scorecard-backend-module-filecheck:

--- a/workspaces/scorecard/source.json
+++ b/workspaces/scorecard/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"c9b67adaebf635bfd576e87ef82abbeb7f8b8753","repo-flat":false,"repo-backstage-version":"1.49.3"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"948d2247ba92b8348e332588fee9fcfbecf0eb59","repo-flat":false,"repo-backstage-version":"1.49.3"}


### PR DESCRIPTION
Adds the new `scorecard-backend-module-filecheck` where needed based on how the other scorecard backend modules are configured.