### PR TITLE
Remove RHDH_SKIP_PLUGIN_METADATA_INJECTION from global header tests

### DIFF
--- a/workspaces/global-header/e2e-tests/tests/specs/default-global-header.spec.ts
+++ b/workspaces/global-header/e2e-tests/tests/specs/default-global-header.spec.ts
@@ -7,13 +7,9 @@ import { NotificationPage } from "@red-hat-developer-hub/e2e-test-utils/pages";
 
 test.describe("Default Global Header", () => {
   test.beforeAll(async ({ rhdh }) => {
-    process.env.RHDH_SKIP_PLUGIN_METADATA_INJECTION = "true";
-
     await rhdh.configure({
       auth: "keycloak",
-      appConfig: "tests/config/app-config-rhdh.yaml",
-      dynamicPlugins: "tests/config/dynamic-plugins.yaml",
-      valueFile: "tests/config/value_file.yaml",
+      disableWrappers: ["red-hat-developer-hub-backstage-plugin-global-header"],
     });
     await rhdh.deploy();
   });

--- a/workspaces/global-header/e2e-tests/tests/specs/header-mount-points.spec.ts
+++ b/workspaces/global-header/e2e-tests/tests/specs/header-mount-points.spec.ts
@@ -2,8 +2,10 @@ import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 
 test.describe("Header mount points", () => {
   test.beforeAll(async ({ rhdh }) => {
-    process.env.RHDH_SKIP_PLUGIN_METADATA_INJECTION = "true";
-    await rhdh.configure({ auth: "keycloak" });
+    await rhdh.configure({
+      auth: "keycloak",
+      disableWrappers: ["red-hat-developer-hub-backstage-plugin-global-header"],
+    });
     await rhdh.deploy();
   });
 


### PR DESCRIPTION
Remove RHDH_SKIP_PLUGIN_METADATA_INJECTION from global header e2e tests