### PR TITLE
chore: update "catalog integration" extensions metadata titles and descriptions

### DIFF
--- a/catalog-entities/extensions/plugins/github-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/github-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: backstage-plugin-catalog-backend-module-github
   namespace: rhdh
-  title: Catalog Backend Module GitHub
+  title: GitHub Catalog Entity Discovery
   description: |
     Provides a GitHub integration for the Software Catalog. Searches your
     GitHub organization and registers catalog files matching the configured path.

--- a/catalog-entities/extensions/plugins/github-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/github-catalog-integration.yaml
@@ -4,11 +4,10 @@ kind: Plugin
 metadata:
   name: backstage-plugin-catalog-backend-module-github
   namespace: rhdh
-  title: GitHub Software Catalog Integration
+  title: Catalog Backend Module GitHub
   description: |
     Provides a GitHub integration for the Software Catalog. Searches your
-    GitHub account and registers catalog files matching the configured path.
-    It can also import your users and groups from GitHub.
+    GitHub organization and registers catalog files matching the configured path.
 
   annotations:
     extensions.backstage.io/pre-installed: 'true' # this means the plugin yaml is preinstalled, not the plugin itself, all other plugins are marked as 'custom'
@@ -36,37 +35,28 @@ spec:
   publisher: Red Hat
 
   highlights:
-    - Provides a GitHub integration for the Software Catalog
-    - Extracts software repositories from GitHub Orgs
-    - Ingests org data (users and groups) from GitHub.
+    - Registers catalog entities from GitHub organizations
 
   categories:
     - Software Catalog
 
   description: |
-    Discovers catalog files, users, and groups located in [GitHub](https://github.com). The provider will search your
-    GitHub account and register catalog files matching the configured path as Location entity and via
-    following processing steps add all contained catalog entities. This can be useful as an
-    alternative to static locations or manually adding things to the catalog.
-
-    The plugin also extracts software repositories from GitHub Orgs and ingests org data (users and groups) from GitHub.
+    Discovers catalog entities within a [GitHub](https://github.com) organization. The provider will search your
+    GitHub organization and register catalog files matching the configured path as a Location entity
 
     Features include:
 
     * Discovers catalog files located in [GitHub](https://github.com).
-    * Extracts software repositories from GitHub Orgs
-    * Ingests org data (users and groups) from GitHub.
-    * Provides a GitHub integration for the Software Catalog
 
     ## Adding The Plugin To Red Hat Developer Hub
 
-    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-extensions-plugins_assembly-install-third-party-plugins-rhdh)
+    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_your_git_provider/integrate-with-github_integrating-rhdh-with-your-git-provider#enable-github-repository-discovery_integrate-with-github)
     for further instructions on how to add, enable, configure, and remove plugins in your instance.
 
     ## Configuring The Plugin ##
 
     Plugins often need additional configuration to work correctly - particularly those that integrate with other
-    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub)
+    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_your_git_provider/integrate-with-github_integrating-rhdh-with-your-git-provider#enable-github-repository-discovery_integrate-with-github)
     for further details regarding the configuration required.
 
   packages:

--- a/catalog-entities/extensions/plugins/github-org-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/github-org-catalog-integration.yaml
@@ -4,10 +4,9 @@ kind: Plugin
 metadata:
   name: backstage-plugin-catalog-backend-module-github-org
   namespace: rhdh
-  title: GitHub Org Software Catalog Integration
+  title: Catalog Backend Module GitHub Organization
   description: |
-    Provides a GitHub integration for the Software Catalog. 
-    Searches your GitHub account and imports your users and groups from GitHub.
+    This is an extension module to the plugin-catalog-backend plugin, that can be used to ingest organization data like users and groups from Github. 
   annotations:
     extensions.backstage.io/pre-installed: 'true' # this means the plugin yaml is preinstalled, not the plugin itself, all other plugins are marked as 'custom'
     extensions.backstage.io/verified-by: Red Hat
@@ -34,27 +33,23 @@ spec:
   publisher: Red Hat
 
   highlights:
-    - Provides a GitHub integration for the Software Catalog
-    - Ingests org data (users and groups) from GitHub.
+    - Ingests data (users and groups) from your GitHub Organization.
 
   categories:
     - Software Catalog
 
   description: |
-    Discovers users and groups located in [GitHub](https://github.com). The provider will search your
-    GitHub account and register catalog files matching the configured path as Location entity and via
-    following processing steps add all contained catalog entities. This can be useful as an
-    alternative to static locations or manually adding things to the catalog.
+    Ingest data (users and groups) from your [GitHub](https://github.com) Organization to establish identities required for Github Authentication
 
     ## Adding The Plugin To Red Hat Developer Hub
 
-    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-extensions-plugins_assembly-install-third-party-plugins-rhdh)
+    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/import-users-and-groups-from-your-identity-provider_authentication-in-rhdh#import-users-and-groups-from-github_import-users-and-groups-from-your-identity-provider)
     for further instructions on how to add, enable, configure, and remove plugins in your instance.
 
     ## Configuring The Plugin ##
 
     Plugins often need additional configuration to work correctly - particularly those that integrate with other
-    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub)
+    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/import-users-and-groups-from-your-identity-provider_authentication-in-rhdh#import-users-and-groups-from-github_import-users-and-groups-from-your-identity-provider)
     for further details regarding the configuration required.
 
   packages:

--- a/catalog-entities/extensions/plugins/github-org-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/github-org-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: backstage-plugin-catalog-backend-module-github-org
   namespace: rhdh
-  title: Catalog Backend Module GitHub Organization
+  title: GitHub Organizational Data Provider
   description: |
     This is an extension module to the plugin-catalog-backend plugin, that can be used to ingest organization data like users and groups from Github. 
   annotations:

--- a/catalog-entities/extensions/plugins/gitlab-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/gitlab-catalog-integration.yaml
@@ -7,8 +7,7 @@ metadata:
   title: GitLab Catalog Integration
   description: |
     This plugin provides GitLab catalog integration for the Red Hat Developer Hub. Searches your
-    GitLab account and registers catalog files matching the configured path.
-    It can also import your users and groups from GitLab.
+    GitLab organization and registers catalog files matching the configured path.
   annotations:
     extensions.backstage.io/pre-installed: 'true' # this means the plugin yaml is preinstalled, not the plugin itself, all other plugins are marked as 'custom'
   links:
@@ -40,19 +39,19 @@ spec:
     - Provides GitLab catalog integration
 
   description: |
-    This plugin provides GitLab catalog integration for the Red Hat Developer Hub. This is an
-    extension module to the plugin-catalog-backend plugin that provides group and user entities
-    by scrapping or receiving events from a GitLab instance.
+    This plugin provides GitLab catalog integration for the Red Hat Developer Hub. Searches your
+    Gitlab organization and registers catalog files matching the configured path.
+
 
     ## Adding The Plugin To Red Hat Developer Hub
 
-    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-extensions-plugins_assembly-install-third-party-plugins-rhdh)
+    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_your_git_provider/integrate-with-gitlab_integrate-with-github)
     for further instructions on how to add, enable, configure, and remove plugins in your instance.
 
     ## Configuring The Plugin ##
 
     Plugins often need additional configuration to work correctly - particularly those that integrate with other
-    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub)
+    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_your_git_provider/integrate-with-gitlab_integrate-with-github)
     for further details regarding the configuration required.
 
   packages:

--- a/catalog-entities/extensions/plugins/gitlab-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/gitlab-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: gitlab-catalog-integration
   namespace: rhdh
-  title: GitLab Catalog Integration
+  title: GitLab Catalog Discovery
   description: |
     This plugin provides GitLab catalog integration for the Red Hat Developer Hub. Searches your
     GitLab organization and registers catalog files matching the configured path.

--- a/catalog-entities/extensions/plugins/gitlab-org-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/gitlab-org-catalog-integration.yaml
@@ -6,8 +6,7 @@ metadata:
   namespace: rhdh
   title: GitLab Org Catalog Integration
   description: |
-    This plugin provides GitLab catalog integration for the Red Hat Developer Hub.
-    Searches your GitLab account and imports your users and groups from GitLab.
+    This is an extension module to the plugin-catalog-backend plugin, that can be used to ingest organization data like users and groups from Github. 
   annotations:
     extensions.backstage.io/pre-installed: 'true' # this means the plugin yaml is preinstalled, not the plugin itself, all other plugins are marked as 'custom'
   links:
@@ -29,29 +28,27 @@ spec:
   publisher: Red Hat
   support:
     provider: Red Hat
-    level: tech-preview
+    level: generally-available
   lifecycle: active
 
   categories:
     - Software Catalog
 
   highlights:
-    - Provides GitLab catalog integration
+    - Ingests data (users and groups) from your GitLab Organization.
 
   description: |
-    This plugin provides GitLab catalog integration for the Red Hat Developer Hub. This is an
-    extension module to the plugin-catalog-backend plugin that provides group and user entities
-    by scrapping or receiving events from a GitLab instance.
+    Ingest data (users and groups) from your GitLab Organization to establish identities required for GitLab Authentication
 
     ## Adding The Plugin To Red Hat Developer Hub
 
-    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-extensions-plugins_assembly-install-third-party-plugins-rhdh)
+    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/enable-authentication-with-your-identity-provider_authentication-in-rhdh#enable-authentication-with-gitlab_enable-authentication-with-your-identity-provider)
     for further instructions on how to add, enable, configure, and remove plugins in your instance.
 
     ## Configuring The Plugin ##
 
     Plugins often need additional configuration to work correctly - particularly those that integrate with other
-    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub)
+    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/enable-authentication-with-your-identity-provider_authentication-in-rhdh#enable-authentication-with-gitlab_enable-authentication-with-your-identity-provider)
     for further details regarding the configuration required.
 
   packages:

--- a/catalog-entities/extensions/plugins/gitlab-org-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/gitlab-org-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: gitlab-org-catalog-integration
   namespace: rhdh
-  title: GitLab Org Catalog Integration
+  title: GitLab Organizational Data Provider
   description: |
     This is an extension module to the plugin-catalog-backend plugin, that can be used to ingest organization data like users and groups from Github. 
   annotations:

--- a/catalog-entities/extensions/plugins/keycloak-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/keycloak-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: keycloak-catalog-integration
   namespace: rhdh
-  title: Keycloak Catalog Integration
+  title: Catalog Backend Module Keycloak
   description: |
     Automatically import Keycloak users and groups into Red Hat Developer Hub for enterprise ready authentication and authorization.
   annotations:

--- a/catalog-entities/extensions/plugins/keycloak-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/keycloak-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: keycloak-catalog-integration
   namespace: rhdh
-  title: Catalog Backend Module Keycloak
+  title: Keycloak Data Provider 
   description: |
     Automatically import Keycloak users and groups into Red Hat Developer Hub for enterprise ready authentication and authorization.
   annotations:

--- a/catalog-entities/extensions/plugins/ldap-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/ldap-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: ldap-catalog-integration
   namespace: rhdh
-  title: LDAP Catalog Integration
+  title: Catalog Backend Module LDAP
   description: |
     This is an extension module to the plugin-catalog-backend plugin, providing an `LdapOrgReaderProcessor` that
     can be used to ingest organization data from an LDAP server. This processor is useful if you want to import
@@ -46,13 +46,13 @@ spec:
 
     ## Adding The Plugin To Red Hat Developer Hub
 
-    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/rhdh-extensions-plugins_assembly-install-third-party-plugins-rhdh)
+    See the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/import-users-and-groups-from-your-identity-provider_authentication-in-rhdh#enable-user-provisioning-with-ldap_import-users-and-groups-from-your-identity-provider)
     for further instructions on how to add, enable, configure, and remove plugins in your instance.
 
     ## Configuring The Plugin ##
 
     Plugins often need additional configuration to work correctly - particularly those that integrate with other
-    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub)
+    systems. See the original source code repository, the software vendor, or the [Red Hat Developer Hub documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/import-users-and-groups-from-your-identity-provider_authentication-in-rhdh#enable-user-provisioning-with-ldap_import-users-and-groups-from-your-identity-provider)
     for further details regarding the configuration required.
 
   packages:

--- a/catalog-entities/extensions/plugins/ldap-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/ldap-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: ldap-catalog-integration
   namespace: rhdh
-  title: Catalog Backend Module LDAP
+  title: LDAP Organizational Data Provider
   description: |
     This is an extension module to the plugin-catalog-backend plugin, providing an `LdapOrgReaderProcessor` that
     can be used to ingest organization data from an LDAP server. This processor is useful if you want to import

--- a/catalog-entities/extensions/plugins/microsoft-graph-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/microsoft-graph-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: microsoft-graph-catalog-integration
   namespace: rhdh
-  title: Catalog Backend Module for Microsoft Graph
+  title: Microsoft Entra Tenant Data Provider
   description: |
     This is an extension module to the `plugin-catalog-backend` plugin, providing a `MicrosoftGraphOrgEntityProvider`
     that can be used to ingest organization data from the Microsoft Graph API.

--- a/catalog-entities/extensions/plugins/scaffolder-relation-processor-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/scaffolder-relation-processor-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: scaffolder-relation-processor-catalog-integration
   namespace: rhdh
-  title: Catalog Backend Module Scaffolder Relation Processor
+  title: Scaffolder Relation Processor
   description: |
     This is an extension module to the catalog-backend plugin, providing an additional catalog entity processor that adds a new relation that depends on the `spec.scaffoldedFrom` field
     to link scaffolder templates and the catalog entities they generated.

--- a/catalog-entities/extensions/plugins/scaffolder-relation-processor-catalog-integration.yaml
+++ b/catalog-entities/extensions/plugins/scaffolder-relation-processor-catalog-integration.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: scaffolder-relation-processor-catalog-integration
   namespace: rhdh
-  title: Scaffolder Relation Processor Catalog Integration
+  title: Catalog Backend Module Scaffolder Relation Processor
   description: |
     This is an extension module to the catalog-backend plugin, providing an additional catalog entity processor that adds a new relation that depends on the `spec.scaffoldedFrom` field
     to link scaffolder templates and the catalog entities they generated.


### PR DESCRIPTION
Fixes: https://redhat.atlassian.net/browse/RHDHPLAN-365 and https://redhat.atlassian.net/browse/RHIDP-13267

* Update the metadata yaml titles to match the titles in the workspace metadata
* Corrected the plugin descriptions
* Corrected the docs URL (they were broken)