### PR TITLE
chore: update azure scaffolder module from wrapper to oci artifact

### DIFF
--- a/workspaces/backstage/metadata/backstage-plugin-scaffolder-backend-module-azure.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-scaffolder-backend-module-azure.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-templates
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-azure"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-azure-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-azure:bs_1.45.3__0.2.15!backstage-plugin-scaffolder-backend-module-azure
   version: 0.2.15
   backstage:
     role: backend-plugin-module


### PR DESCRIPTION
### Description

The generated `dynamic-plugins.default.yaml` in 1.9 refers to the azure scaffolder backend module wrapper despite it being removed in 1.9. Updates to use the OCI artifact built in the overlays instead.

Follow-up for https://github.com/redhat-developer/rhdh/pull/4665