### PR TITLE
chore: transitioning plugins from GA to TP requires to keep them wrapped in 1.9

### DIFF
--- a/catalog-entities/extensions/plugins/argocd-scaffolder-actions.yaml
+++ b/catalog-entities/extensions/plugins/argocd-scaffolder-actions.yaml
@@ -29,7 +29,7 @@ spec:
   publisher: Red Hat
   support:
     provider: Red Hat
-    level: community
+    level: tech-preview
   lifecycle: active
 
   categories:

--- a/catalog-entities/extensions/plugins/backstage-community-plugin-quay.yaml
+++ b/catalog-entities/extensions/plugins/backstage-community-plugin-quay.yaml
@@ -26,7 +26,7 @@ spec:
   author: Red Hat
   support:
     provider: Red Hat
-    level: community
+    level: generally-available
   lifecycle: active
   publisher: Red Hat
 

--- a/catalog-entities/extensions/plugins/quay-scaffolder-actions.yaml
+++ b/catalog-entities/extensions/plugins/quay-scaffolder-actions.yaml
@@ -28,7 +28,7 @@ spec:
 
   support:
     provider: Red Hat
-    level: community
+    level: generally-available
   lifecycle: active
   publisher: Red Hat
 

--- a/catalog-entities/extensions/plugins/roadie-argocd.yaml
+++ b/catalog-entities/extensions/plugins/roadie-argocd.yaml
@@ -25,7 +25,7 @@ spec:
   publisher: Red Hat
   support:
     provider: Red Hat
-    level: community
+    level: generally-available
   lifecycle: active
 
   categories:

--- a/catalog-entities/extensions/plugins/tekton.yaml
+++ b/catalog-entities/extensions/plugins/tekton.yaml
@@ -29,7 +29,7 @@ spec:
   author: Red Hat
   support:
     provider: Red Hat
-    level: community
+    level: generally-available
   lifecycle: active
   publisher: Red Hat
 

--- a/workspaces/quay/metadata/backstage-community-plugin-quay.yaml
+++ b/workspaces/quay/metadata/backstage-community-plugin-quay.yaml
@@ -22,7 +22,7 @@ spec:
     role: frontend-plugin
     supportedVersions: 1.45.3
   author: Red Hat
-  support: community
+  support: generally-available
   lifecycle: active
   partOf:
     - backstage-community-plugin-quay

--- a/workspaces/quay/metadata/backstage-community-plugin-quay.yaml
+++ b/workspaces/quay/metadata/backstage-community-plugin-quay.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage-community/plugin-quay"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:bs_1.45.3__1.28.1!backstage-community-plugin-quay
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-quay
   version: 1.28.1
   backstage:
     role: frontend-plugin

--- a/workspaces/quay/metadata/backstage-community-plugin-scaffolder-backend-module-quay.yaml
+++ b/workspaces/quay/metadata/backstage-community-plugin-scaffolder-backend-module-quay.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-templates
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-quay"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.45.3__2.14.0!backstage-community-plugin-scaffolder-backend-module-quay
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-quay-dynamic
   version: 2.14.0
   backstage:
     role: backend-plugin-module

--- a/workspaces/quay/metadata/backstage-community-plugin-scaffolder-backend-module-quay.yaml
+++ b/workspaces/quay/metadata/backstage-community-plugin-scaffolder-backend-module-quay.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin-module
     supportedVersions: 1.45.3
   author: Red Hat
-  support: community
+  support: generally-available
   lifecycle: active
   partOf:
     - quay-scaffolder-actions

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd-backend.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd-backend.yaml
@@ -22,7 +22,7 @@ spec:
     role: backend-plugin
     supportedVersions: 1.42.5
   author: Roadie
-  support: community
+  support: generally-available
   lifecycle: active
   partOf:
     - roadie-argocd

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd-backend.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@roadiehq/backstage-plugin-argo-cd-backend"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-argo-cd-backend:bs_1.45.3__4.6.0!roadiehq-backstage-plugin-argo-cd-backend
+  dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend
   version: 4.6.0
   backstage:
     role: backend-plugin

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-argocd.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-argocd.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin-module
     supportedVersions: 1.42.5
   author: Roadie
-  support: community
+  support: tech-preview
   lifecycle: active
   partOf:
     - roadiehq-scaffolder-backend-argocd

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-argocd.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-argocd.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-templates
 spec:
   packageName: "@roadiehq/scaffolder-backend-argocd"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-argocd:bs_1.45.3__1.8.1!roadiehq-scaffolder-backend-argocd
+  dynamicArtifact: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
   version: 1.8.1
   backstage:
     role: backend-plugin-module

--- a/workspaces/tekton/metadata/backstage-community-plugin-tekton.yaml
+++ b/workspaces/tekton/metadata/backstage-community-plugin-tekton.yaml
@@ -22,7 +22,7 @@ spec:
     role: frontend-plugin
     supportedVersions: 1.45.3
   author: Red Hat
-  support: community
+  support: generally-available
   lifecycle: active
   partOf:
   - tekton

--- a/workspaces/tekton/metadata/backstage-community-plugin-tekton.yaml
+++ b/workspaces/tekton/metadata/backstage-community-plugin-tekton.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@backstage-community/plugin-tekton'
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-tekton:bs_1.45.3__3.33.3!backstage-community-plugin-tekton
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tekton
   version: 3.33.3
   backstage:
     role: frontend-plugin


### PR DESCRIPTION
In order to support the transition of plugins from GA to TP, we decided to keep them wrapped in 1.9.

The plugins are listed at https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/dynamic_plugins_reference/community-plugins-migration-to-the-github-container-registry_dynamic-plugins-reference#plugins-remaining-bundled-in-rhdh-1-9

https://redhat.atlassian.net/browse/RHDHBUGS-3037