### PR TITLE
fix types errors in orchestrator plugin

### DIFF
--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-form-widgets.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-form-widgets.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets"
   # Tag: 1.9.2--1.6.4, Build date: 2026-03-18T10:58:45Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets@sha256:90ad03763a07ab8f49f48a0eaafdb73f792eab033089637a37d8b7a259cf75a9"
-  version: 1.6.8
+  version: 1.6.9
   backstage:
     role: frontend-plugin
     supportedVersions: 1.45.3

--- a/workspaces/orchestrator/source.json
+++ b/workspaces/orchestrator/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"95a4c1f19e4da851ce6602f68e5e8fcc41a1dc58","repo-flat":false,"repo-backstage-version":"1.45.2"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"86db18c0d24cc0ecd7a76753ce77247dc17fefa9","repo-flat":false,"repo-backstage-version":"1.45.2"}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHDHBUGS-3061

Replaceimport … from '@backstage/types/index' with import … from '@backstage/types'. The /index subpath isn’t exposed in the package exports, so strict CI resolution failed while local checks could still