### PR TITLE
Disable scripts to prevent Node 24 build errors

### DIFF
--- a/workspaces/roadie-backstage-plugins/patches/1-disable-script-to-avoid-node-24-native-build-errors.patch
+++ b/workspaces/roadie-backstage-plugins/patches/1-disable-script-to-avoid-node-24-native-build-errors.patch
@@ -1,0 +1,5 @@
+diff --git a/.yarnrc.yml b/.yarnrc.yml
+--- a/.yarnrc.yml
++++ b/.yarnrc.yml
+@@ -0,0 +1 @@
++enableScripts: false


### PR DESCRIPTION
Disable scripts in .yarnrc.yml to avoid Node 24 native build errors.