### PR TITLE
chore(metadata): update orchestrator metadata yaml digests

### DIFF
--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend-module-loki.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend-module-loki.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki"
   # Tag: 1.9.2--1.0.4, Build date: 2026-03-18T10:58:35Z
-  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend-module-loki@sha256:47105a25335b7b81b70f1a94d59ef36d8f7fc00652e881c59235b7529db422a3"
+  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend-module-loki@sha256:a2916c03911a87098754d18661a113f70894d685e360ee48d5638278c37da0d9"
   version: 1.0.6
   backstage:
     role: backend-plugin-module

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-backend"
   # Tag: 1.9.2--8.6.4, Build date: 2026-03-18T10:56:40Z
-  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend@sha256:65dff6b447257b469005be8e882a4b53db182c901e216b67953a2ce9f1c58a18"
+  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend@sha256:45838850237e5e076f11eeb4d0b6c50ac077186517627a7a9c0c0dba0b5f7991"
   version: 8.6.7
   backstage:
     role: backend-plugin

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-form-widgets.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-form-widgets.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets"
   # Tag: 1.9.2--1.6.4, Build date: 2026-03-18T10:58:45Z
-  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets@sha256:90ad03763a07ab8f49f48a0eaafdb73f792eab033089637a37d8b7a259cf75a9"
+  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets@sha256:972c825fa1e850f57aacc59cadde18750cce4a65b67823c2a0ed2647e67470ab"
   version: 1.6.9
   backstage:
     role: frontend-plugin
@@ -33,4 +33,4 @@ spec:
       content:
         dynamicPlugins:
           frontend:
-            red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: { }
+            red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: rhdh
   title: Orchestrator Frontend
   links:
-  - url: https://red.ht/rhdh
-    title: Homepage
-  - url: https://issues.redhat.com/browse/RHDHBUGS
-    title: "Report issues here. Note: Customers of Red Hat Developer Hub should raise a Red Hat support case instead."
-  - title: Source Code
-    url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://issues.redhat.com/browse/RHDHBUGS
+      title: "Report issues here. Note: Customers of Red Hat Developer Hub should raise a Red Hat support case instead."
+    - title: Source Code
+      url: https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator
   annotations:
     backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/plugins/orchestrator
   tags:
-  - automation
+    - automation
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-orchestrator'
   # Tag: 1.9.2--5.4.3, Build date: 2026-03-18T10:58:35Z
-  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator@sha256:2bbc01aa98aeece7042bcc7efffe8f6b950f6d755e81ca4b81800cdd69c98e35"
+  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator@sha256:3786c9d09bfef2105641a27dfab1bfe69004862714e4259b790dcd5b8faed937"
   version: 5.4.7
   backstage:
     role: frontend-plugin
@@ -27,34 +27,34 @@ spec:
   support: production
   lifecycle: active
   partOf:
-  - orchestrator
+    - orchestrator
   appConfigExamples:
-  - title: Default configuration
-    content:
-      dynamicPlugins:
-        frontend:
-          red-hat-developer-hub.backstage-plugin-orchestrator:
-            appIcons:
-            - importName: OrchestratorIcon
-              name: orchestratorIcon
-            dynamicRoutes:
-            - importName: OrchestratorPage
-              menuItem:
-                icon: orchestratorIcon
-                text: Orchestrator
-                textKey: menuItem.orchestrator
-              path: /orchestrator
-            entityTabs:
-            - path: /workflows
-              title: Workflows
-              titleKey: catalog.entityPage.workflows.title
-              mountPoint: entity.page.workflows
-            mountPoints:
-            - mountPoint: entity.page.workflows/cards
-              importName: OrchestratorCatalogTab
-              config:
-                layout:
-                  gridColumn: 1 / -1
-                  if:
-                    anyOf:
-                    - IsOrchestratorCatalogTabAvailable
+    - title: Default configuration
+      content:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-orchestrator:
+              appIcons:
+                - importName: OrchestratorIcon
+                  name: orchestratorIcon
+              dynamicRoutes:
+                - importName: OrchestratorPage
+                  menuItem:
+                    icon: orchestratorIcon
+                    text: Orchestrator
+                    textKey: menuItem.orchestrator
+                  path: /orchestrator
+              entityTabs:
+                - path: /workflows
+                  title: Workflows
+                  titleKey: catalog.entityPage.workflows.title
+                  mountPoint: entity.page.workflows
+              mountPoints:
+                - mountPoint: entity.page.workflows/cards
+                  importName: OrchestratorCatalogTab
+                  config:
+                    layout:
+                      gridColumn: 1 / -1
+                      if:
+                        anyOf:
+                          - IsOrchestratorCatalogTabAvailable

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-scaffolder-backend-module-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-scaffolder-backend-module-orchestrator.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator"
   # Tag: 1.9.2--1.3.4, Build date: 2026-03-18T10:58:35Z
-  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator@sha256:cbb0733c18541479edfbc76b06e9863bb08e6c4663ffec53fc1471c80bfe5db9"
+  dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator@sha256:dd81d904d8fccec10ce1c225246b1d3cbc4eb660f72b4a784ae3f8164f818252"
   version: 1.3.6
   backstage:
     role: backend-plugin-module


### PR DESCRIPTION
This PR updates the five orchestrator Package metadata files under workspaces/orchestrator/metadata/ so each spec.dynamicArtifact uses the latest Red Hat registry digest for images built for the RHDH 1.9.4 release from quay.