### PR TITLE
feat: add E2E coverage instrumentation for dynamic plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ build/
 # Coverage
 coverage/
 .nyc_output/
+.instrumented/
 
 # Python Caches
 **/__pycache__/

--- a/e2e-coverage/coverage-fixture.ts
+++ b/e2e-coverage/coverage-fixture.ts
@@ -1,0 +1,159 @@
+/**
+ * Playwright fixture that collects Istanbul coverage (window.__coverage__)
+ * from the browser after E2E tests.
+ *
+ * Enable by setting E2E_COLLECT_COVERAGE=1 in the environment.
+ *
+ * Usage in playwright.config.ts:
+ *   import { coverageFixture } from '../e2e-coverage/coverage-fixture';
+ *   export default defineConfig({
+ *     use: { ...coverageFixture },
+ *   });
+ *
+ * Or register as a global teardown:
+ *   globalTeardown: '../e2e-coverage/coverage-fixture',
+ */
+
+import { test as base, type Page } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+const COVERAGE_DIR = path.resolve(
+  process.cwd(),
+  process.env.COVERAGE_OUTPUT_DIR || "coverage/istanbul",
+);
+const COLLECT_COVERAGE = process.env.E2E_COLLECT_COVERAGE === "1";
+
+interface CoverageData {
+  [filePath: string]: {
+    path: string;
+    statementMap: Record<string, unknown>;
+    fnMap: Record<string, unknown>;
+    branchMap: Record<string, unknown>;
+    s: Record<string, number>;
+    f: Record<string, number>;
+    b: Record<string, number[]>;
+  };
+}
+
+async function collectCoverage(page: Page): Promise<CoverageData | null> {
+  try {
+    const coverage = await page.evaluate(
+      () => (window as unknown as { __coverage__?: CoverageData }).__coverage__,
+    );
+    return coverage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function mergeCoverage(
+  target: CoverageData,
+  source: CoverageData,
+): CoverageData {
+  for (const [filePath, fileCov] of Object.entries(source)) {
+    if (!target[filePath]) {
+      target[filePath] = fileCov;
+      continue;
+    }
+
+    const existing = target[filePath];
+
+    for (const [key, count] of Object.entries(fileCov.s)) {
+      existing.s[key] = (existing.s[key] || 0) + count;
+    }
+
+    for (const [key, count] of Object.entries(fileCov.f)) {
+      existing.f[key] = (existing.f[key] || 0) + count;
+    }
+
+    for (const [key, counts] of Object.entries(fileCov.b)) {
+      if (!existing.b[key]) {
+        existing.b[key] = counts;
+      } else {
+        existing.b[key] = existing.b[key].map(
+          (v: number, i: number) => v + (counts[i] || 0),
+        );
+      }
+    }
+  }
+
+  return target;
+}
+
+let mergedCoverage: CoverageData = {};
+let testCount = 0;
+
+export const coverageTest = base.extend<{ coveragePage: Page }>({
+  coveragePage: async ({ page }, use) => {
+    if (!COLLECT_COVERAGE) {
+      await use(page);
+      return;
+    }
+
+    await use(page);
+
+    const coverage = await collectCoverage(page);
+    if (coverage) {
+      mergedCoverage = mergeCoverage(mergedCoverage, coverage);
+      testCount++;
+
+      const workerFile = path.join(
+        COVERAGE_DIR,
+        `worker-${process.pid}-${testCount}.json`,
+      );
+      fs.mkdirSync(COVERAGE_DIR, { recursive: true });
+      fs.writeFileSync(workerFile, JSON.stringify(coverage));
+    }
+  },
+});
+
+/**
+ * Standalone coverage collector that can be used without extending fixtures.
+ * Call this in afterEach or afterAll hooks.
+ */
+export async function collectAndSaveCoverage(
+  page: Page,
+  testName: string,
+): Promise<void> {
+  if (!COLLECT_COVERAGE) return;
+
+  const coverage = await collectCoverage(page);
+  if (!coverage) return;
+
+  const sanitizedName = testName.replace(/[^a-zA-Z0-9-_]/g, "_");
+  const outFile = path.join(COVERAGE_DIR, `${sanitizedName}.json`);
+  fs.mkdirSync(COVERAGE_DIR, { recursive: true });
+  fs.writeFileSync(outFile, JSON.stringify(coverage));
+}
+
+/**
+ * Merge all per-test coverage JSON files into a single coverage-final.json.
+ * Call this in globalTeardown or after all tests complete.
+ */
+export function mergeCoverageFiles(coverageDir?: string): void {
+  const dir = coverageDir || COVERAGE_DIR;
+  if (!fs.existsSync(dir)) return;
+
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".json") && f !== "coverage-final.json");
+
+  if (files.length === 0) return;
+
+  let merged: CoverageData = {};
+  for (const file of files) {
+    const data = JSON.parse(
+      fs.readFileSync(path.join(dir, file), "utf-8"),
+    ) as CoverageData;
+    merged = mergeCoverage(merged, data);
+  }
+
+  const outFile = path.join(dir, "coverage-final.json");
+  fs.writeFileSync(outFile, JSON.stringify(merged, null, 2));
+
+  const fileCount = Object.keys(merged).length;
+  console.log(
+    `\n=== Coverage Summary ===\nFiles covered: ${fileCount}\nTests collected: ${files.length}\nOutput: ${outFile}\n`,
+  );
+}

--- a/e2e-coverage/coverage-fixture.ts
+++ b/e2e-coverage/coverage-fixture.ts
@@ -17,24 +17,12 @@
 import { test as base, type Page } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
-
-const COVERAGE_DIR = path.resolve(
-  process.cwd(),
-  process.env.COVERAGE_OUTPUT_DIR || "coverage/istanbul",
-);
-const COLLECT_COVERAGE = process.env.E2E_COLLECT_COVERAGE === "1";
-
-interface CoverageData {
-  [filePath: string]: {
-    path: string;
-    statementMap: Record<string, unknown>;
-    fnMap: Record<string, unknown>;
-    branchMap: Record<string, unknown>;
-    s: Record<string, number>;
-    f: Record<string, number>;
-    b: Record<string, number[]>;
-  };
-}
+import {
+  COLLECT_COVERAGE,
+  COVERAGE_DIR,
+  type CoverageData,
+  mergeCoverage,
+} from "./coverage-utils";
 
 async function collectCoverage(page: Page): Promise<CoverageData | null> {
   try {
@@ -45,40 +33,6 @@ async function collectCoverage(page: Page): Promise<CoverageData | null> {
   } catch {
     return null;
   }
-}
-
-function mergeCoverage(
-  target: CoverageData,
-  source: CoverageData,
-): CoverageData {
-  for (const [filePath, fileCov] of Object.entries(source)) {
-    if (!target[filePath]) {
-      target[filePath] = fileCov;
-      continue;
-    }
-
-    const existing = target[filePath];
-
-    for (const [key, count] of Object.entries(fileCov.s)) {
-      existing.s[key] = (existing.s[key] || 0) + count;
-    }
-
-    for (const [key, count] of Object.entries(fileCov.f)) {
-      existing.f[key] = (existing.f[key] || 0) + count;
-    }
-
-    for (const [key, counts] of Object.entries(fileCov.b)) {
-      if (!existing.b[key]) {
-        existing.b[key] = counts;
-      } else {
-        existing.b[key] = existing.b[key].map(
-          (v: number, i: number) => v + (counts[i] || 0),
-        );
-      }
-    }
-  }
-
-  return target;
 }
 
 let mergedCoverage: CoverageData = {};

--- a/e2e-coverage/coverage-reporter.ts
+++ b/e2e-coverage/coverage-reporter.ts
@@ -18,62 +18,16 @@ import type {
 } from "@playwright/test/reporter";
 import * as fs from "fs";
 import * as path from "path";
-
-const COVERAGE_DIR = path.resolve(
-  process.cwd(),
-  process.env.COVERAGE_OUTPUT_DIR || "coverage/istanbul",
-);
-const COLLECT_COVERAGE = process.env.E2E_COLLECT_COVERAGE === "1";
-
-interface CoverageData {
-  [filePath: string]: {
-    path: string;
-    statementMap: Record<string, { start: { line: number; column: number }; end: { line: number; column: number } }>;
-    fnMap: Record<string, { name: string; decl: { start: { line: number; column: number }; end: { line: number; column: number } }; loc: { start: { line: number; column: number }; end: { line: number; column: number } } }>;
-    branchMap: Record<string, { loc: { start: { line: number; column: number }; end: { line: number; column: number } }; type: string; locations: Array<{ start: { line: number; column: number }; end: { line: number; column: number } }> }>;
-    s: Record<string, number>;
-    f: Record<string, number>;
-    b: Record<string, number[]>;
-  };
-}
-
-function mergeCoverage(
-  target: CoverageData,
-  source: CoverageData,
-): CoverageData {
-  for (const [filePath, fileCov] of Object.entries(source)) {
-    if (!target[filePath]) {
-      target[filePath] = fileCov;
-      continue;
-    }
-
-    const existing = target[filePath];
-
-    for (const [key, count] of Object.entries(fileCov.s)) {
-      existing.s[key] = (existing.s[key] || 0) + count;
-    }
-
-    for (const [key, count] of Object.entries(fileCov.f)) {
-      existing.f[key] = (existing.f[key] || 0) + count;
-    }
-
-    for (const [key, counts] of Object.entries(fileCov.b)) {
-      if (!existing.b[key]) {
-        existing.b[key] = counts;
-      } else {
-        existing.b[key] = existing.b[key].map(
-          (v: number, i: number) => v + (counts[i] || 0),
-        );
-      }
-    }
-  }
-
-  return target;
-}
+import {
+  COLLECT_COVERAGE,
+  COVERAGE_DIR,
+  type CoverageData,
+  mergeCoverage,
+} from "./coverage-utils";
 
 /**
  * Convert Istanbul coverage JSON to lcov format.
- * This is a standalone implementation to avoid requiring istanbul-reports
+ * Standalone implementation to avoid requiring istanbul-reports
  * as a dependency (keeping the overlay repo lightweight).
  */
 function coverageToLcov(coverage: CoverageData): string {

--- a/e2e-coverage/coverage-reporter.ts
+++ b/e2e-coverage/coverage-reporter.ts
@@ -1,0 +1,212 @@
+/**
+ * Playwright custom reporter that merges Istanbul coverage files
+ * and converts to lcov format for Codecov upload.
+ *
+ * Usage in playwright.config.ts:
+ *   reporter: [['list'], ['../e2e-coverage/coverage-reporter.ts']],
+ *
+ * Requires: E2E_COLLECT_COVERAGE=1
+ */
+
+import type {
+  FullConfig,
+  FullResult,
+  Reporter,
+  Suite,
+  TestCase,
+  TestResult,
+} from "@playwright/test/reporter";
+import * as fs from "fs";
+import * as path from "path";
+
+const COVERAGE_DIR = path.resolve(
+  process.cwd(),
+  process.env.COVERAGE_OUTPUT_DIR || "coverage/istanbul",
+);
+const COLLECT_COVERAGE = process.env.E2E_COLLECT_COVERAGE === "1";
+
+interface CoverageData {
+  [filePath: string]: {
+    path: string;
+    statementMap: Record<string, { start: { line: number; column: number }; end: { line: number; column: number } }>;
+    fnMap: Record<string, { name: string; decl: { start: { line: number; column: number }; end: { line: number; column: number } }; loc: { start: { line: number; column: number }; end: { line: number; column: number } } }>;
+    branchMap: Record<string, { loc: { start: { line: number; column: number }; end: { line: number; column: number } }; type: string; locations: Array<{ start: { line: number; column: number }; end: { line: number; column: number } }> }>;
+    s: Record<string, number>;
+    f: Record<string, number>;
+    b: Record<string, number[]>;
+  };
+}
+
+function mergeCoverage(
+  target: CoverageData,
+  source: CoverageData,
+): CoverageData {
+  for (const [filePath, fileCov] of Object.entries(source)) {
+    if (!target[filePath]) {
+      target[filePath] = fileCov;
+      continue;
+    }
+
+    const existing = target[filePath];
+
+    for (const [key, count] of Object.entries(fileCov.s)) {
+      existing.s[key] = (existing.s[key] || 0) + count;
+    }
+
+    for (const [key, count] of Object.entries(fileCov.f)) {
+      existing.f[key] = (existing.f[key] || 0) + count;
+    }
+
+    for (const [key, counts] of Object.entries(fileCov.b)) {
+      if (!existing.b[key]) {
+        existing.b[key] = counts;
+      } else {
+        existing.b[key] = existing.b[key].map(
+          (v: number, i: number) => v + (counts[i] || 0),
+        );
+      }
+    }
+  }
+
+  return target;
+}
+
+/**
+ * Convert Istanbul coverage JSON to lcov format.
+ * This is a standalone implementation to avoid requiring istanbul-reports
+ * as a dependency (keeping the overlay repo lightweight).
+ */
+function coverageToLcov(coverage: CoverageData): string {
+  const lines: string[] = [];
+
+  for (const [filePath, fileCov] of Object.entries(coverage)) {
+    lines.push("TN:");
+    lines.push(`SF:${fileCov.path || filePath}`);
+
+    for (const [, fnData] of Object.entries(fileCov.fnMap)) {
+      lines.push(
+        `FN:${fnData.decl.start.line},${fnData.name || "(anonymous)"}`,
+      );
+    }
+
+    for (const [key, fnData] of Object.entries(fileCov.fnMap)) {
+      lines.push(
+        `FNDA:${fileCov.f[key] || 0},${fnData.name || "(anonymous)"}`,
+      );
+    }
+
+    lines.push(`FNF:${Object.keys(fileCov.fnMap).length}`);
+    lines.push(
+      `FNH:${Object.values(fileCov.f).filter((v) => v > 0).length}`,
+    );
+
+    const lineCounts: Record<number, number> = {};
+    for (const [key, stmtData] of Object.entries(fileCov.statementMap)) {
+      const line = stmtData.start.line;
+      const count = fileCov.s[key] || 0;
+      lineCounts[line] = (lineCounts[line] || 0) + count;
+    }
+
+    for (const [line, count] of Object.entries(lineCounts)) {
+      lines.push(`DA:${line},${count}`);
+    }
+
+    const totalLines = Object.keys(lineCounts).length;
+    const hitLines = Object.values(lineCounts).filter((v) => v > 0).length;
+    lines.push(`LF:${totalLines}`);
+    lines.push(`LH:${hitLines}`);
+
+    let branchIdx = 0;
+    for (const [key, branchData] of Object.entries(fileCov.branchMap)) {
+      const counts = fileCov.b[key] || [];
+      for (let i = 0; i < counts.length; i++) {
+        lines.push(
+          `BRDA:${branchData.loc.start.line},${branchIdx},${i},${counts[i]}`,
+        );
+      }
+      branchIdx++;
+    }
+
+    const totalBranches = Object.values(fileCov.b).reduce(
+      (sum, counts) => sum + counts.length,
+      0,
+    );
+    const hitBranches = Object.values(fileCov.b).reduce(
+      (sum, counts) => sum + counts.filter((v) => v > 0).length,
+      0,
+    );
+    lines.push(`BRF:${totalBranches}`);
+    lines.push(`BRH:${hitBranches}`);
+
+    lines.push("end_of_record");
+  }
+
+  return lines.join("\n");
+}
+
+class CoverageReporter implements Reporter {
+  onBegin(_config: FullConfig, _suite: Suite) {
+    if (COLLECT_COVERAGE) {
+      console.log("\n[coverage-reporter] Coverage collection enabled");
+      fs.mkdirSync(COVERAGE_DIR, { recursive: true });
+    }
+  }
+
+  onTestEnd(_test: TestCase, _result: TestResult) {}
+
+  onEnd(_result: FullResult) {
+    if (!COLLECT_COVERAGE) return;
+
+    if (!fs.existsSync(COVERAGE_DIR)) {
+      console.log("[coverage-reporter] No coverage directory found");
+      return;
+    }
+
+    const files = fs
+      .readdirSync(COVERAGE_DIR)
+      .filter((f) => f.endsWith(".json") && f !== "coverage-final.json");
+
+    if (files.length === 0) {
+      console.log("[coverage-reporter] No coverage files found");
+      return;
+    }
+
+    let merged: CoverageData = {};
+    for (const file of files) {
+      const data = JSON.parse(
+        fs.readFileSync(path.join(COVERAGE_DIR, file), "utf-8"),
+      ) as CoverageData;
+      merged = mergeCoverage(merged, data);
+    }
+
+    const finalFile = path.join(COVERAGE_DIR, "coverage-final.json");
+    fs.writeFileSync(finalFile, JSON.stringify(merged, null, 2));
+
+    const lcov = coverageToLcov(merged);
+    const lcovFile = path.join(COVERAGE_DIR, "lcov.info");
+    fs.writeFileSync(lcovFile, lcov);
+
+    const fileCount = Object.keys(merged).length;
+    const totalStatements = Object.values(merged).reduce(
+      (sum, f) => sum + Object.keys(f.s).length,
+      0,
+    );
+    const hitStatements = Object.values(merged).reduce(
+      (sum, f) => sum + Object.values(f.s).filter((v) => v > 0).length,
+      0,
+    );
+    const pct =
+      totalStatements > 0
+        ? ((hitStatements / totalStatements) * 100).toFixed(1)
+        : "0.0";
+
+    console.log("\n=== E2E Coverage Summary ===");
+    console.log(`  Files:      ${fileCount}`);
+    console.log(`  Statements: ${hitStatements}/${totalStatements} (${pct}%)`);
+    console.log(`  Istanbul:   ${finalFile}`);
+    console.log(`  LCOV:       ${lcovFile}`);
+    console.log("============================\n");
+  }
+}
+
+export default CoverageReporter;

--- a/e2e-coverage/coverage-utils.ts
+++ b/e2e-coverage/coverage-utils.ts
@@ -1,0 +1,53 @@
+import * as path from "path";
+
+export const COVERAGE_DIR = path.resolve(
+  process.cwd(),
+  process.env.COVERAGE_OUTPUT_DIR || "coverage/istanbul",
+);
+export const COLLECT_COVERAGE = process.env.E2E_COLLECT_COVERAGE === "1";
+
+export interface CoverageData {
+  [filePath: string]: {
+    path: string;
+    statementMap: Record<string, { start: { line: number; column: number }; end: { line: number; column: number } }>;
+    fnMap: Record<string, { name: string; decl: { start: { line: number; column: number }; end: { line: number; column: number } }; loc: { start: { line: number; column: number }; end: { line: number; column: number } } }>;
+    branchMap: Record<string, { loc: { start: { line: number; column: number }; end: { line: number; column: number } }; type: string; locations: Array<{ start: { line: number; column: number }; end: { line: number; column: number } }> }>;
+    s: Record<string, number>;
+    f: Record<string, number>;
+    b: Record<string, number[]>;
+  };
+}
+
+export function mergeCoverage(
+  target: CoverageData,
+  source: CoverageData,
+): CoverageData {
+  for (const [filePath, fileCov] of Object.entries(source)) {
+    if (!target[filePath]) {
+      target[filePath] = fileCov;
+      continue;
+    }
+
+    const existing = target[filePath];
+
+    for (const [key, count] of Object.entries(fileCov.s)) {
+      existing.s[key] = (existing.s[key] || 0) + count;
+    }
+
+    for (const [key, count] of Object.entries(fileCov.f)) {
+      existing.f[key] = (existing.f[key] || 0) + count;
+    }
+
+    for (const [key, counts] of Object.entries(fileCov.b)) {
+      if (!existing.b[key]) {
+        existing.b[key] = counts;
+      } else {
+        existing.b[key] = existing.b[key].map(
+          (v: number, i: number) => v + (counts[i] || 0),
+        );
+      }
+    }
+  }
+
+  return target;
+}

--- a/scripts/instrument-plugin.sh
+++ b/scripts/instrument-plugin.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# Build an Istanbul-instrumented version of a dynamic plugin for E2E coverage collection.
+#
+# Usage:
+#   ./scripts/instrument-plugin.sh <workspace-name> [plugin-name]
+#
+# Example:
+#   ./scripts/instrument-plugin.sh tech-radar
+#   ./scripts/instrument-plugin.sh bulk-import backstage-plugin-bulk-import
+#
+# The script:
+#   1. Reads source.json for the upstream repo URL and git ref
+#   2. Clones the upstream repo at that ref
+#   3. Builds the plugin normally (backstage-cli + janus-cli export-dynamic)
+#   4. Post-processes the webpack output with nyc instrument to add Istanbul coverage
+#   5. Outputs the instrumented bundle to .instrumented/<workspace>/
+#
+# The source maps in the webpack output reference original source files (e.g., RadarPage.tsx),
+# enabling coverage remapping back to the actual plugin source code.
+
+set -euo pipefail
+
+WORKSPACE="${1:?Usage: $0 <workspace-name> [plugin-name]}"
+PLUGIN_NAME="${2:-}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="$REPO_ROOT/workspaces/$WORKSPACE"
+OUTPUT_DIR="$REPO_ROOT/.instrumented/$WORKSPACE"
+CLONE_DIR="$REPO_ROOT/.instrumented/.sources/$WORKSPACE"
+
+if [[ ! -f "$WORKSPACE_DIR/source.json" ]]; then
+  echo "ERROR: $WORKSPACE_DIR/source.json not found"
+  exit 1
+fi
+
+REPO_URL=$(python3 -c "import json; print(json.load(open('$WORKSPACE_DIR/source.json'))['repo'])")
+REPO_REF=$(python3 -c "import json; print(json.load(open('$WORKSPACE_DIR/source.json'))['repo-ref'])")
+REPO_FLAT=$(python3 -c "import json; print(json.load(open('$WORKSPACE_DIR/source.json')).get('repo-flat', False))")
+
+echo "=== Instrumenting plugin for workspace: $WORKSPACE ==="
+echo "  Upstream repo: $REPO_URL"
+echo "  Ref: $REPO_REF"
+echo "  Flat repo: $REPO_FLAT"
+
+# Step 1: Clone upstream repo at the exact ref
+echo ""
+echo "--- Step 1: Cloning upstream repo ---"
+rm -rf "$CLONE_DIR"
+mkdir -p "$CLONE_DIR"
+
+git clone --depth 1 "$REPO_URL" "$CLONE_DIR" 2>/dev/null || {
+  git clone "$REPO_URL" "$CLONE_DIR"
+}
+cd "$CLONE_DIR"
+git fetch --depth 1 origin "$REPO_REF" 2>/dev/null || git fetch origin "$REPO_REF"
+git checkout "$REPO_REF"
+
+# Step 2: Navigate to the plugin workspace
+echo ""
+echo "--- Step 2: Finding plugin workspace ---"
+if [[ "$REPO_FLAT" == "True" ]]; then
+  PLUGIN_WORKSPACE_DIR="$CLONE_DIR"
+else
+  PLUGIN_WORKSPACE_DIR="$CLONE_DIR/workspaces/$WORKSPACE"
+fi
+
+if [[ ! -d "$PLUGIN_WORKSPACE_DIR" ]]; then
+  echo "ERROR: Plugin workspace not found at $PLUGIN_WORKSPACE_DIR"
+  echo "Available workspaces:"
+  ls "$CLONE_DIR/workspaces/" 2>/dev/null || echo "  (none)"
+  exit 1
+fi
+
+cd "$PLUGIN_WORKSPACE_DIR"
+echo "  Plugin workspace: $PLUGIN_WORKSPACE_DIR"
+
+# Step 3: Find the frontend plugin package
+echo ""
+echo "--- Step 3: Finding frontend plugin package ---"
+if [[ -n "$PLUGIN_NAME" ]]; then
+  PLUGIN_PKG_DIR=$(find . -name "package.json" -path "*/$PLUGIN_NAME/*" -not -path "*/node_modules/*" | head -1 | xargs dirname)
+else
+  PLUGIN_PKG_DIR=$(find . -name "package.json" -not -path "*/node_modules/*" -not -path "*/e2e-*/*" -not -path "*/backend*/*" -not -path "*/module-*/*" -not -path "./package.json" | while read pkg; do
+    if grep -q '"backstage"' "$pkg" && grep -q '"frontend-plugin"' "$pkg" 2>/dev/null; then
+      dirname "$pkg"
+      break
+    fi
+  done)
+fi
+
+if [[ -z "$PLUGIN_PKG_DIR" ]]; then
+  echo "ERROR: Could not find frontend plugin package"
+  echo "Hint: specify the plugin name as the second argument"
+  exit 1
+fi
+
+echo "  Plugin package: $PLUGIN_PKG_DIR"
+PLUGIN_PKG_NAME=$(python3 -c "import json; print(json.load(open('$PLUGIN_PKG_DIR/package.json'))['name'])")
+echo "  Plugin npm name: $PLUGIN_PKG_NAME"
+
+# Step 4: Install dependencies
+echo ""
+echo "--- Step 4: Installing dependencies ---"
+cd "$PLUGIN_WORKSPACE_DIR"
+
+if [[ -f "yarn.lock" ]]; then
+  yarn install --no-immutable 2>&1 | tail -5
+elif [[ -f "package-lock.json" ]]; then
+  npm install 2>&1 | tail -5
+fi
+
+# Step 5: Build the plugin (standard build, no instrumentation at this stage)
+echo ""
+echo "--- Step 5: Building plugin ---"
+cd "$PLUGIN_WORKSPACE_DIR"
+
+# Generate TypeScript declarations
+npx tsc --build 2>&1 | tail -5 || true
+
+cd "$PLUGIN_PKG_DIR"
+if command -v backstage-cli &>/dev/null; then
+  backstage-cli package build 2>&1 | tail -5
+else
+  npx --yes @backstage/cli package build 2>&1 | tail -5
+fi
+
+# Step 6: Export as dynamic plugin (webpack + module federation)
+echo ""
+echo "--- Step 6: Exporting as dynamic plugin ---"
+cd "$PLUGIN_PKG_DIR"
+
+if command -v janus-cli &>/dev/null; then
+  janus-cli package export-dynamic-plugin 2>&1 | tail -5
+elif npx --yes @janus-idp/cli package export-dynamic-plugin --help &>/dev/null 2>&1; then
+  npx @janus-idp/cli package export-dynamic-plugin 2>&1 | tail -5
+elif npx --yes @red-hat-developer-hub/cli package export-dynamic-plugin --help &>/dev/null 2>&1; then
+  npx @red-hat-developer-hub/cli package export-dynamic-plugin 2>&1 | tail -5
+else
+  echo "ERROR: No dynamic plugin CLI found (janus-cli / @janus-idp/cli / @red-hat-developer-hub/cli)"
+  exit 1
+fi
+
+# Step 7: Post-process with nyc instrument
+# This is the key step: webpack's module federation externalizes shared modules,
+# causing babel-plugin-istanbul (applied pre-webpack) to be stripped.
+# Instead, we instrument the FINAL webpack output, which contains all the
+# plugin's compiled code in the exposed-PluginRoot chunk.
+echo ""
+echo "--- Step 7: Instrumenting webpack output with nyc ---"
+
+DIST_SCALPRUM=$(find . -path "*/dist-dynamic/dist-scalprum" -o -path "*/dist-scalprum" | grep -v node_modules | head -1)
+if [[ -z "$DIST_SCALPRUM" ]]; then
+  echo "ERROR: No dist-scalprum directory found after export"
+  exit 1
+fi
+
+STATIC_DIR="$DIST_SCALPRUM/static"
+if [[ ! -d "$STATIC_DIR" ]]; then
+  echo "ERROR: No static/ directory in dist-scalprum"
+  exit 1
+fi
+
+INSTRUMENTED_STATIC="${STATIC_DIR}-instrumented"
+npx --yes nyc instrument "$STATIC_DIR" "$INSTRUMENTED_STATIC" --source-map 2>&1 | tail -3
+
+# Replace original static/ with instrumented version
+rm -rf "$STATIC_DIR"
+mv "$INSTRUMENTED_STATIC" "$STATIC_DIR"
+
+# Step 8: Copy output
+echo ""
+echo "--- Step 8: Copying instrumented bundle ---"
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+cp -r "$DIST_SCALPRUM"/* "$OUTPUT_DIR/"
+
+# Also copy package.json for metadata
+cp "$PLUGIN_PKG_DIR/package.json" "$OUTPUT_DIR/package.json" 2>/dev/null || true
+
+echo ""
+echo "=== Done ==="
+echo "  Instrumented bundle: $OUTPUT_DIR/"
+echo "  Source repo: $REPO_URL"
+echo "  Source ref:  $REPO_REF"
+
+# Verify instrumentation
+echo ""
+echo "--- Verification ---"
+INSTRUMENTED_FILES=$(grep -r "__coverage__" "$OUTPUT_DIR/" --include="*.js" -l 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$INSTRUMENTED_FILES" -gt 0 ]]; then
+  echo "  Istanbul instrumentation: $INSTRUMENTED_FILES files instrumented"
+
+  # Check source map references
+  SRC_FILES=$(grep -roh 'webpack://[^"]*\./src/[^"]*' "$OUTPUT_DIR/" --include="*.map" 2>/dev/null | sort -u | wc -l | tr -d ' ')
+  echo "  Source map references: $SRC_FILES original source files"
+  echo ""
+  echo "  Source files covered:"
+  grep -roh 'webpack://[^"]*\./src/[^"]*' "$OUTPUT_DIR/" --include="*.map" 2>/dev/null | sort -u | sed 's|webpack://[^/]*/||' | head -20
+else
+  echo "  WARNING: No __coverage__ instrumentation found!"
+  echo "  nyc instrument may have failed."
+  exit 1
+fi

--- a/scripts/upload-coverage.sh
+++ b/scripts/upload-coverage.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Upload Istanbul/lcov coverage to Codecov with cross-repo attribution.
+#
+# Usage:
+#   ./scripts/upload-coverage.sh <workspace-name>
+#
+# Example:
+#   E2E_COLLECT_COVERAGE=1 ./run-e2e.sh -w tech-radar
+#   ./scripts/upload-coverage.sh tech-radar
+#
+# The script reads source.json to determine the upstream repo and SHA,
+# then uploads the lcov coverage to Codecov attributed to that repo.
+#
+# Required environment:
+#   CODECOV_TOKEN  - Codecov upload token (org-level for cross-repo uploads)
+#
+# Optional environment:
+#   COVERAGE_OUTPUT_DIR - Override coverage directory (default: coverage/istanbul)
+
+set -euo pipefail
+
+WORKSPACE="${1:?Usage: $0 <workspace-name>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="$REPO_ROOT/workspaces/$WORKSPACE"
+COVERAGE_DIR="${COVERAGE_OUTPUT_DIR:-$REPO_ROOT/coverage/istanbul}"
+LCOV_FILE="$COVERAGE_DIR/lcov.info"
+
+if [[ ! -f "$LCOV_FILE" ]]; then
+  echo "ERROR: No lcov file found at $LCOV_FILE"
+  echo "Run tests with E2E_COLLECT_COVERAGE=1 first"
+  exit 1
+fi
+
+if [[ ! -f "$WORKSPACE_DIR/source.json" ]]; then
+  echo "ERROR: source.json not found at $WORKSPACE_DIR/source.json"
+  exit 1
+fi
+
+REPO_URL=$(python3 -c "import json; print(json.load(open('$WORKSPACE_DIR/source.json'))['repo'])")
+REPO_REF=$(python3 -c "import json; print(json.load(open('$WORKSPACE_DIR/source.json'))['repo-ref'])")
+
+# Extract GitHub slug from repo URL (e.g., "redhat-developer/rhdh-plugins")
+SLUG=$(echo "$REPO_URL" | sed 's|https://github.com/||' | sed 's|\.git$||')
+
+echo "=== Uploading E2E coverage to Codecov ==="
+echo "  Workspace:  $WORKSPACE"
+echo "  LCOV file:  $LCOV_FILE"
+echo "  Target repo: $SLUG"
+echo "  Target SHA:  $REPO_REF"
+echo "  Flag:        e2e-overlays-$WORKSPACE"
+
+# Check for codecov CLI
+if ! command -v codecov &>/dev/null; then
+  echo ""
+  echo "Installing Codecov CLI..."
+  pip install codecov-cli 2>/dev/null || {
+    echo "ERROR: Could not install codecov-cli"
+    echo "Install manually: pip install codecov-cli"
+    exit 1
+  }
+fi
+
+if [[ -z "${CODECOV_TOKEN:-}" ]]; then
+  echo ""
+  echo "ERROR: CODECOV_TOKEN is not set"
+  echo "Set it to an org-level Codecov token that has upload access to $SLUG"
+  exit 1
+fi
+
+echo ""
+codecov upload-process \
+  --file "$LCOV_FILE" \
+  --flag "e2e-overlays-$WORKSPACE" \
+  --sha "$REPO_REF" \
+  --slug "$SLUG" \
+  --token "$CODECOV_TOKEN" \
+  --name "overlay-e2e-$WORKSPACE" \
+  --disable-search
+
+echo ""
+echo "=== Upload complete ==="
+echo "  View coverage at: https://app.codecov.io/gh/$SLUG/commit/$REPO_REF"


### PR DESCRIPTION
## Summary

Adds Istanbul-based code coverage collection for E2E tests running against dynamic plugins. This enables uploading per-plugin coverage to Codecov with cross-repo attribution back to the upstream source repos (rhdh-plugins, community-plugins, etc.).

### Key insight

`babel-plugin-istanbul` applied pre-build gets stripped by webpack's module federation during `export-dynamic-plugin`. Instead, we apply `nyc instrument` **after** the final webpack output — the Istanbul `__coverage__` instrumentation survives in the browser runtime, and webpack source maps reference all original source files.

### What's included

- **`scripts/instrument-plugin.sh`** — Clones upstream repo at `source.json` ref, builds the dynamic plugin, then post-processes the webpack output with `nyc instrument` to add Istanbul coverage
- **`e2e-coverage/coverage-fixture.ts`** — Playwright fixture that collects `window.__coverage__` from the browser after each E2E test
- **`e2e-coverage/coverage-reporter.ts`** — Playwright custom reporter that merges per-test Istanbul JSON files and converts to lcov format
- **`scripts/upload-coverage.sh`** — Uploads lcov to Codecov using `source.json` repo URL and SHA for cross-repo attribution
- **`.gitignore`** — Added `.instrumented/` directory

### Usage

```bash
# 1. Instrument a plugin
./scripts/instrument-plugin.sh tech-radar

# 2. Run E2E tests with coverage collection
E2E_COLLECT_COVERAGE=1 ./run-e2e.sh -w tech-radar

# 3. Upload to Codecov
CODECOV_TOKEN=xxx ./scripts/upload-coverage.sh tech-radar
```

### Coverage flow

```
source.json ref → clone upstream → backstage-cli build → janus-cli export-dynamic
    → nyc instrument on dist-scalprum/static/ → deploy instrumented bundle to RHDH
    → Playwright collects window.__coverage__ → merge + lcov → Codecov upload (cross-repo)
```

## Test plan

- [ ] Run `./scripts/instrument-plugin.sh tech-radar` — verify `.instrumented/tech-radar/` contains JS files with `__coverage__` and source maps referencing original `.tsx` files
- [ ] Deploy instrumented bundle to RHDH, run E2E tests with `E2E_COLLECT_COVERAGE=1` — verify `coverage/istanbul/` contains per-test JSON files
- [ ] Verify `coverage-final.json` and `lcov.info` are generated after test run
- [ ] Verify Codecov upload with `--dry-run` against the upstream repo slug and SHA

Ref: [RHIDP-13411](https://redhat.atlassian.net/browse/RHIDP-13411)

🤖 Generated with [Claude Code](https://claude.com/claude-code)