### PR TITLE
Update cost-management plugin to v2.1.0 for RHDH 1.10 Tech Preview

### DIFF
--- a/catalog-entities/extensions/plugins/cost-management.yaml
+++ b/catalog-entities/extensions/plugins/cost-management.yaml
@@ -22,7 +22,7 @@ spec:
   author: Red Hat
   support:
     provider: Red Hat
-    level: dev-preview
+    level: tech-preview
   lifecycle: active
   publisher: Red Hat
 

--- a/workspaces/cost-management/metadata/cost-management-backend.yaml
+++ b/workspaces/cost-management/metadata/cost-management-backend.yaml
@@ -21,13 +21,13 @@ metadata:
     - openshift
 spec:
   packageName: "@red-hat-developer-hub/plugin-cost-management-backend"
-  dynamicArtifact: oci://quay.io/redhat-resource-optimization/dynamic-plugins:2.0.2!red-hat-developer-hub-plugin-cost-management-backend
+  dynamicArtifact: oci://quay.io/redhat-resource-optimization/dynamic-plugins:2.1.0!red-hat-developer-hub-plugin-cost-management-backend
   version: 2.1.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
-  support: dev-preview
+  support: tech-preview
   lifecycle: active
   partOf:
     - cost-management

--- a/workspaces/cost-management/metadata/cost-management.yaml
+++ b/workspaces/cost-management/metadata/cost-management.yaml
@@ -21,13 +21,13 @@ metadata:
     - openshift
 spec:
   packageName: "@red-hat-developer-hub/plugin-cost-management"
-  dynamicArtifact: oci://quay.io/redhat-resource-optimization/dynamic-plugins:2.0.1!red-hat-developer-hub-plugin-cost-management
+  dynamicArtifact: oci://quay.io/redhat-resource-optimization/dynamic-plugins:2.1.0!red-hat-developer-hub-plugin-cost-management
   version: 2.1.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
-  support: dev-preview
+  support: tech-preview
   lifecycle: active
   partOf:
     - cost-management


### PR DESCRIPTION
- Update OCI tags to 2.1.0 for both frontend and backend packages
- Update supportedVersions from 1.45.3 to 1.49.4 (Backstage target for RHDH 1.10)
- Promote support level from dev-preview to tech-preview