### PR TITLE
chore(orchestrator): update the loki backend module to be GA

### DIFF
--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend-mod-loki.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend-mod-loki.yaml
@@ -24,7 +24,7 @@ spec:
     role: backend-plugin-module
     supportedVersions: 1.49.3
   author: Red Hat
-  support: tech-preview
+  support: generally-available
   lifecycle: active
   partOf:
     - orchestrator
@@ -35,3 +35,4 @@ spec:
           workflowLogProvider:
             loki:
               baseUrl: ${LOKI_BASE_URL}
+              token: ${AUTH_TOKEN}

--- a/workspaces/orchestrator/smoke-tests/test.env
+++ b/workspaces/orchestrator/smoke-tests/test.env
@@ -3,3 +3,4 @@
 # Existing entries win over generated defaults; re-run to add missing keys.
 
 LOKI_BASE_URL=https://example_url
+AUTH_TOKEN=notsecret


### PR DESCRIPTION
Updating the loki backend module metadata to move it from TP to GA.  Part of https://redhat.atlassian.net/browse/RHDHPLAN-926

I also noticed that the `AUTH_TOKEN` environment variable was missing in the `.env` for the smoke tests which is in the 1.9 release file https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/release-1.9/workspaces/orchestrator/smoke-tests/test.env#L2