### PR TITLE
chore(orchestrator): add translationResources to default Package metadata

### DIFF
--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
@@ -34,6 +34,10 @@ spec:
         dynamicPlugins:
           frontend:
             red-hat-developer-hub.backstage-plugin-orchestrator:
+              translationResources:
+                - importName: orchestratorTranslations
+                  module: Alpha
+                  ref: orchestratorTranslationRef
               appIcons:
                 - importName: OrchestratorIcon
                   name: orchestratorIcon


### PR DESCRIPTION
Updates `workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml `so the default appConfigExamples dynamic plugin entry includes translationResources (Alpha module / orchestratorTranslations), matching the orchestrator plugin’s upstream app-config.yaml after [redhat-developer/rhdh-plugins#2987](https://github.com/redhat-developer/rhdh-plugins/pull/2987).