### PR TITLE
chore: bump e2e-test-utils to 1.1.39

### DIFF
--- a/workspaces/acr/e2e-tests/package.json
+++ b/workspaces/acr/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/acr/e2e-tests/yarn.lock
+++ b/workspaces/acr/e2e-tests/yarn.lock
@@ -282,9 +282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -307,7 +307,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -551,7 +551,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/adoption-insights/e2e-tests/package.json
+++ b/workspaces/adoption-insights/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "1.57.0",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/adoption-insights/e2e-tests/yarn.lock
+++ b/workspaces/adoption-insights/e2e-tests/yarn.lock
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -379,7 +379,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -765,7 +765,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:1.57.0"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/analytics/e2e-tests/package.json
+++ b/workspaces/analytics/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/analytics/e2e-tests/yarn.lock
+++ b/workspaces/analytics/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -577,7 +577,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/argocd/e2e-tests/package.json
+++ b/workspaces/argocd/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/argocd/e2e-tests/yarn.lock
+++ b/workspaces/argocd/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -572,7 +572,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/backstage/e2e-tests/package.json
+++ b/workspaces/backstage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/backstage/e2e-tests/yarn.lock
+++ b/workspaces/backstage/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -626,7 +626,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/github/e2e-tests/package.json
+++ b/workspaces/github/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/github/e2e-tests/yarn.lock
+++ b/workspaces/github/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1187,7 +1187,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/global-header/e2e-tests/package.json
+++ b/workspaces/global-header/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/global-header/e2e-tests/yarn.lock
+++ b/workspaces/global-header/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1246,7 +1246,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/homepage/e2e-tests/package.json
+++ b/workspaces/homepage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/homepage/e2e-tests/yarn.lock
+++ b/workspaces/homepage/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1312,7 +1312,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/keycloak/e2e-tests/package.json
+++ b/workspaces/keycloak/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/keycloak/e2e-tests/yarn.lock
+++ b/workspaces/keycloak/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1482,7 +1482,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/quay/e2e-tests/package.json
+++ b/workspaces/quay/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quay/e2e-tests/yarn.lock
+++ b/workspaces/quay/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/quickstart/e2e-tests/package.json
+++ b/workspaces/quickstart/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quickstart/e2e-tests/yarn.lock
+++ b/workspaces/quickstart/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1955,7 +1955,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/rbac/e2e-tests/package.json
+++ b/workspaces/rbac/e2e-tests/package.json
@@ -26,7 +26,7 @@
     "@backstage-community/plugin-rbac-common": "1.26.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/rbac/e2e-tests/yarn.lock
+++ b/workspaces/rbac/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1933,7 +1933,7 @@ __metadata:
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scorecard/e2e-tests/package.json
+++ b/workspaces/scorecard/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.36",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scorecard/e2e-tests/yarn.lock
+++ b/workspaces/scorecard/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.36":
-  version: 1.1.36
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.36"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/87c381f59723726b2e1ed7b98496b2c361f796e57e12960fa1c88a8dcd2d0a11f3c9d10065846d3aea9d0bcef22427c5bb37409d59c2af756fd7aa8e1ff3949d
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.36"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tekton/e2e-tests/package.json
+++ b/workspaces/tekton/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tekton/e2e-tests/yarn.lock
+++ b/workspaces/tekton/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -2097,7 +2097,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/theme/e2e-tests/package.json
+++ b/workspaces/theme/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/theme/e2e-tests/yarn.lock
+++ b/workspaces/theme/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -2106,7 +2106,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/topology/e2e-tests/package.json
+++ b/workspaces/topology/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.35",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/topology/e2e-tests/yarn.lock
+++ b/workspaces/topology/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.35":
-  version: 1.1.35
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.35"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
+  version: 1.1.39
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/e2d84b54e92ff4496306312ef3eebfe53cbb047a9f88d2a23dfd5edf67435a489976d124e7d3d7d437b41ca5559ad9a4432880041e8a12eceedb0302285529fc
+  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
   languageName: node
   linkType: hard
 
@@ -2133,7 +2133,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.35"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
## Summary
Bumps `@red-hat-developer-hub/e2e-test-utils` from 1.1.35 to 1.1.39 across all 18 e2e-tests workspaces.

### Changes in 1.1.39
- fix: handle annotations gracefully when testDir path is too shallow ([#101](https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/101))

### Changes in 1.1.38
- feat: add automatic workspace and project annotations to all tests ([#99](https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/99))

### Changes in 1.1.37
- feat: add JUnit reporter to base Playwright config ([#96](https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/96))

### Changes in 1.1.36
- fix: resolve wrapper plugins to metadata path in nightly mode ([#94](https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/94))