### PR TITLE
mark homepage backend as dev-preview plugin

### DIFF
--- a/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-homepage-backend.yaml
+++ b/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-homepage-backend.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin
     supportedVersions: 1.49.4
   author: Red Hat
-  support: generally-available
+  support: dev-preview
   lifecycle: active
   partOf:
     - home-page


### PR DESCRIPTION



Mark homepage backend plugin (0.1.0)  as `dev-preview`  for RHDH 1.10