### PR TITLE
chore(e2e): add Playwright annotations to all spec files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,22 +143,18 @@ Each Playwright project creates a **separate Kubernetes namespace** (project nam
 
 ### Standard Test Pattern
 
-Every `test.describe` block must include `component` and `workspace` annotations in the details parameter. The `component` is always `"plugins"` in this repo. The `workspace` value must match the workspace directory name (e.g., `tech-radar`, `rbac`, `backstage`).
+Every `test.beforeAll` must push `component` and `workspace` annotations via `test.info().annotations.push()`. The `component` is always `"plugins"` in this repo. The `workspace` value must match the workspace directory name (e.g., `tech-radar`, `rbac`, `backstage`).
 
 ```typescript
 import { test, expect } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { $ } from "@red-hat-developer-hub/e2e-test-utils/utils";
 
-test.describe(
-  "My Plugin",
-  {
-    annotation: [
+test.describe("My Plugin", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "my-workspace" },
-    ],
-  },
-  () => {
-  test.beforeAll(async ({ rhdh }) => {
+    );
     await rhdh.configure({ auth: "keycloak" });
     // Optional: deploy external services before RHDH
     await $`bash scripts/setup.sh ${rhdh.deploymentConfig.namespace}`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,11 +143,21 @@ Each Playwright project creates a **separate Kubernetes namespace** (project nam
 
 ### Standard Test Pattern
 
+Every `test.describe` block must include `component` and `workspace` annotations in the details parameter. The `component` is always `"plugins"` in this repo. The `workspace` value must match the workspace directory name (e.g., `tech-radar`, `rbac`, `backstage`).
+
 ```typescript
 import { test, expect } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { $ } from "@red-hat-developer-hub/e2e-test-utils/utils";
 
-test.describe("My Plugin", () => {
+test.describe(
+  "My Plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "my-workspace" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({ auth: "keycloak" });
     // Optional: deploy external services before RHDH

--- a/workspaces/acr/e2e-tests/tests/specs/acr.spec.ts
+++ b/workspaces/acr/e2e-tests/tests/specs/acr.spec.ts
@@ -9,27 +9,28 @@ test.describe(
     ],
   },
   () => {
-  const dateRegex =
-    /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2},\s\d{4}/gm;
+    const dateRegex =
+      /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2},\s\d{4}/gm;
 
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({ auth: "guest" });
-    await rhdh.deploy();
-  });
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({ auth: "guest" });
+      await rhdh.deploy();
+    });
 
-  test.beforeEach(async ({ loginHelper }) => {
-    await loginHelper.loginAsGuest();
-  });
+    test.beforeEach(async ({ loginHelper }) => {
+      await loginHelper.loginAsGuest();
+    });
 
-  test("Verify ACR Images are visible", async ({ uiHelper }) => {
-    await uiHelper.openCatalogSidebar("Component");
-    await uiHelper.clickLink("acr-test-entity");
-    await uiHelper.clickTab("Image Registry");
-    await uiHelper.verifyHeading(
-      "Azure Container Registry Repository: hello-world",
-    );
-    await uiHelper.verifyRowInTableByUniqueText("latest", [dateRegex]);
-    await uiHelper.verifyRowInTableByUniqueText("v1", [dateRegex]);
-    await uiHelper.verifyRowsInTable(["v2", "v3"]);
-  });
-});
+    test("Verify ACR Images are visible", async ({ uiHelper }) => {
+      await uiHelper.openCatalogSidebar("Component");
+      await uiHelper.clickLink("acr-test-entity");
+      await uiHelper.clickTab("Image Registry");
+      await uiHelper.verifyHeading(
+        "Azure Container Registry Repository: hello-world",
+      );
+      await uiHelper.verifyRowInTableByUniqueText("latest", [dateRegex]);
+      await uiHelper.verifyRowInTableByUniqueText("v1", [dateRegex]);
+      await uiHelper.verifyRowsInTable(["v2", "v3"]);
+    });
+  },
+);

--- a/workspaces/acr/e2e-tests/tests/specs/acr.spec.ts
+++ b/workspaces/acr/e2e-tests/tests/specs/acr.spec.ts
@@ -1,36 +1,31 @@
 import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
 
-test.describe(
-  "Test ACR plugin",
-  {
-    annotation: [
+test.describe("Test ACR plugin", () => {
+  const dateRegex =
+    /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2},\s\d{4}/gm;
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "acr" },
-    ],
-  },
-  () => {
-    const dateRegex =
-      /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2},\s\d{4}/gm;
+    );
+    await rhdh.configure({ auth: "guest" });
+    await rhdh.deploy();
+  });
 
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({ auth: "guest" });
-      await rhdh.deploy();
-    });
+  test.beforeEach(async ({ loginHelper }) => {
+    await loginHelper.loginAsGuest();
+  });
 
-    test.beforeEach(async ({ loginHelper }) => {
-      await loginHelper.loginAsGuest();
-    });
-
-    test("Verify ACR Images are visible", async ({ uiHelper }) => {
-      await uiHelper.openCatalogSidebar("Component");
-      await uiHelper.clickLink("acr-test-entity");
-      await uiHelper.clickTab("Image Registry");
-      await uiHelper.verifyHeading(
-        "Azure Container Registry Repository: hello-world",
-      );
-      await uiHelper.verifyRowInTableByUniqueText("latest", [dateRegex]);
-      await uiHelper.verifyRowInTableByUniqueText("v1", [dateRegex]);
-      await uiHelper.verifyRowsInTable(["v2", "v3"]);
-    });
-  },
-);
+  test("Verify ACR Images are visible", async ({ uiHelper }) => {
+    await uiHelper.openCatalogSidebar("Component");
+    await uiHelper.clickLink("acr-test-entity");
+    await uiHelper.clickTab("Image Registry");
+    await uiHelper.verifyHeading(
+      "Azure Container Registry Repository: hello-world",
+    );
+    await uiHelper.verifyRowInTableByUniqueText("latest", [dateRegex]);
+    await uiHelper.verifyRowInTableByUniqueText("v1", [dateRegex]);
+    await uiHelper.verifyRowsInTable(["v2", "v3"]);
+  });
+});

--- a/workspaces/acr/e2e-tests/tests/specs/acr.spec.ts
+++ b/workspaces/acr/e2e-tests/tests/specs/acr.spec.ts
@@ -1,6 +1,14 @@
 import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
 
-test.describe("Test ACR plugin", () => {
+test.describe(
+  "Test ACR plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "acr" },
+    ],
+  },
+  () => {
   const dateRegex =
     /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{1,2},\s\d{4}/gm;
 

--- a/workspaces/adoption-insights/e2e-tests/tests/specs/adoption-insights.spec.ts
+++ b/workspaces/adoption-insights/e2e-tests/tests/specs/adoption-insights.spec.ts
@@ -19,248 +19,238 @@ const ADOPTION_INSIGHTS_WRAPPER_DIST_NAMES: string[] = [
   "red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights-dynamic",
 ];
 
-test.describe.serial(
-  "Test Adoption Insights",
-  {
-    annotation: [
+test.describe.serial("Test Adoption Insights", () => {
+  let context: BrowserContext | undefined;
+  let page: Page;
+  let uiHelper: UIhelper;
+  let testHelper: TestHelper;
+
+  test.beforeAll(async ({ browser, rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "adoption-insights" },
-    ],
-  },
-  () => {
-    let context: BrowserContext | undefined;
-    let page: Page;
-    let uiHelper: UIhelper;
-    let testHelper: TestHelper;
+    );
+    await rhdh.configure({
+      auth: "keycloak",
+      disableWrappers: ADOPTION_INSIGHTS_WRAPPER_DIST_NAMES,
+    });
+    await rhdh.deploy();
 
-    test.beforeAll(async ({ browser, rhdh }) => {
-      await rhdh.configure({
-        auth: "keycloak",
-        disableWrappers: ADOPTION_INSIGHTS_WRAPPER_DIST_NAMES,
-      });
-      await rhdh.deploy();
+    context = await browser.newContext({
+      baseURL: rhdh.rhdhUrl,
+    });
+    page = await context.newPage();
+    uiHelper = new UIhelper(page);
+    testHelper = new TestHelper(page);
 
-      context = await browser.newContext({
-        baseURL: rhdh.rhdhUrl,
-      });
-      page = await context.newPage();
-      uiHelper = new UIhelper(page);
-      testHelper = new TestHelper(page);
+    const loginHelper = new LoginHelper(page);
+    await loginHelper.loginAsKeycloakUser();
+  });
 
-      const loginHelper = new LoginHelper(page);
-      await loginHelper.loginAsKeycloakUser();
+  test.afterAll(async () => {
+    await context?.close();
+  });
+
+  test.describe
+    .serial("Test Adoption Insights plugin: load permission policies and conditions from files", () => {
+    let initialSearchCount: number;
+    let templatesFirstEntry: string[] = [];
+    let catalogEntitiesFirstEntry: string[] = [];
+    let techdocsFirstEntry: string[] = [];
+
+    test("Check UI navigation by nav bar when adoption-insights is enabled", async () => {
+      await goToAdoptionInsights(uiHelper, page);
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- intentional delay for UI stabilization
+      await page.waitForTimeout(5000);
+      await uiHelper.verifyHeading("Adoption Insights");
+      expect(page.url()).toContain("adoption-insights");
     });
 
-    test.afterAll(async () => {
-      await context?.close();
+    test("Select date range", async () => {
+      await testHelper.clickByText("Last 28 days");
+      const dateRanges = ["Today", "Last week", "Last month", "Last year"];
+      for (const range of dateRanges) {
+        await expect(page.getByRole("option", { name: range })).toBeVisible();
+      }
+      await testHelper.selectOption("Date range...");
+      const datePicker = page.locator(".v5-MuiPaper-root", {
+        hasText: "Start date",
+      });
+      await expect(datePicker).toBeVisible();
+      await datePicker.getByRole("button", { name: "Cancel" }).click();
+      await expect(datePicker).toBeHidden();
+
+      await Promise.all([
+        waitForPanelApiCalls(page),
+        testHelper.selectOption("Today"),
+      ]);
     });
 
-    test.describe
-      .serial("Test Adoption Insights plugin: load permission policies and conditions from files", () => {
-      let initialSearchCount: number;
-      let templatesFirstEntry: string[] = [];
-      let catalogEntitiesFirstEntry: string[] = [];
-      let techdocsFirstEntry: string[] = [];
-
-      test("Check UI navigation by nav bar when adoption-insights is enabled", async () => {
-        await goToAdoptionInsights(uiHelper, page);
-        // eslint-disable-next-line playwright/no-wait-for-timeout -- intentional delay for UI stabilization
-        await page.waitForTimeout(5000);
-        await uiHelper.verifyHeading("Adoption Insights");
-        expect(page.url()).toContain("adoption-insights");
+    test("Active users panel shows the visitor", async () => {
+      const panel = page.locator(".v5-MuiPaper-root", {
+        hasText: "Active users",
       });
+      await expect(panel.locator(".recharts-surface")).toBeVisible();
+      await expect(
+        panel.getByText(
+          /^Average peak active user count was \d+ per hour for this period\.$/,
+        ),
+      ).toBeVisible();
+      await expect(
+        panel.getByRole("button", { name: "Export CSV" }),
+      ).toBeVisible();
+    });
 
-      test("Select date range", async () => {
-        await testHelper.clickByText("Last 28 days");
-        const dateRanges = ["Today", "Last week", "Last month", "Last year"];
-        for (const range of dateRanges) {
-          await expect(page.getByRole("option", { name: range })).toBeVisible();
+    test("Total number of users panel shows visitor of 100", async () => {
+      const panel = page.locator(".v5-MuiPaper-root", {
+        hasText: "Total number of users",
+      });
+      await expect(panel.locator(".recharts-surface")).toBeVisible();
+      await expect(panel.getByText(/^\d+of 100$/)).toBeVisible();
+      await expect(panel.getByText(/^\d+%have logged in$/)).toBeVisible();
+    });
+
+    test("Data shows in Top plugins Entity", async () => {
+      await testHelper.expectTopEntriesToBePresent("plugins");
+      await expect(
+        page
+          .locator(".v5-MuiPaper-root", { hasText: "plugins" })
+          .locator("tbody tr")
+          .first(),
+      ).toBeVisible();
+    });
+
+    test("Rest of the panels are visible", async () => {
+      const titles = ["templates", "catalog entities", "techdocs", "Searches"];
+
+      for (const title of titles) {
+        const panel = page
+          .locator(".v5-MuiPaper-root", { hasText: title })
+          .last();
+        await expect(panel).toBeVisible();
+
+        /* eslint-disable playwright/no-conditional-in-test -- iterating panel types to collect state */
+        if (
+          title === "catalog entities" ||
+          title === "techdocs" ||
+          title === "templates"
+        ) {
+          const firstRow = await testHelper.getVisibleFirstRowText(panel);
+
+          if (title === "templates") templatesFirstEntry = firstRow;
+          else if (title === "catalog entities")
+            catalogEntitiesFirstEntry = firstRow;
+          else if (title === "techdocs") techdocsFirstEntry = firstRow;
         }
-        await testHelper.selectOption("Date range...");
-        const datePicker = page.locator(".v5-MuiPaper-root", {
-          hasText: "Start date",
-        });
-        await expect(datePicker).toBeVisible();
-        await datePicker.getByRole("button", { name: "Cancel" }).click();
-        await expect(datePicker).toBeHidden();
 
+        if (title === "Searches") {
+          const count = await testHelper.getCountFromPanel(panel);
+          initialSearchCount = count || 0;
+        }
+        /* eslint-enable playwright/no-conditional-in-test */
+      }
+    });
+
+    test("Interaction-based tracking tests", async () => {
+      await runInteractionTrackingSetup(
+        page,
+        uiHelper as AdoptionInsightsUiHelperForPanel,
+        templatesFirstEntry,
+        catalogEntitiesFirstEntry,
+        techdocsFirstEntry,
+      );
+
+      await test.step("Visited component shows up in top catalog entities", async () => {
+        await testHelper.expectTopEntriesToBePresent("catalog entities");
+      });
+
+      await test.step("Visited techdoc shows up in top techdocs", async () => {
+        await testHelper.expectTopEntriesToBePresent("techdocs");
+      });
+
+      await test.step("Visited templates shows in top templates", async () => {
+        await testHelper.expectTopEntriesToBePresent("templates");
+      });
+
+      await test.step("Changes are Reflecting in panels", async () => {
+        const titles = ["catalog entities", "techdocs"];
+        interface PanelState {
+          firstRow?: string[];
+          initialViewsCount?: number;
+        }
+        const state: Record<string, PanelState> = {};
+        state["catalog entities"] = {};
+        state["techdocs"] = {};
+
+        /* eslint-disable playwright/no-conditional-in-test -- iterate panel types and branch by title */
+        for (const title of titles) {
+          const panel = page
+            .locator(".v5-MuiPaper-root", { hasText: title })
+            .last();
+          state[title].firstRow =
+            await testHelper.getVisibleFirstRowText(panel);
+          if (title === "catalog entities")
+            catalogEntitiesFirstEntry = state[title].firstRow ?? [];
+          else if (title === "techdocs")
+            techdocsFirstEntry = state[title].firstRow ?? [];
+          const firstRow = panel
+            .locator("table.v5-MuiTable-root tbody tr")
+            .first();
+          const firstEntry = firstRow.locator("td").first();
+          let headerTxt: string;
+          if (title === "techdocs") {
+            headerTxt = techdocsFirstEntry[0];
+            state[title].initialViewsCount = Number(techdocsFirstEntry[1]);
+            if (headerTxt === "docs") headerTxt = "Documentation";
+            await testHelper.clickAndVerifyText(firstEntry, headerTxt);
+          } else if (title === "catalog entities") {
+            headerTxt = "Red Hat Developer Hub";
+            state[title].initialViewsCount = Number(
+              catalogEntitiesFirstEntry[1],
+            );
+            await testHelper.clickAndVerifyText(firstEntry, headerTxt);
+          }
+        }
+        /* eslint-enable playwright/no-conditional-in-test */
+
+        await page.reload();
+        await testHelper.waitUntilApiCallSucceeds(page);
+        await uiHelper.openSidebarButton("Administration");
+        await uiHelper.clickLink("Adoption Insights");
+        await testHelper.clickByText("Last 28 days");
         await Promise.all([
           waitForPanelApiCalls(page),
           testHelper.selectOption("Today"),
         ]);
-      });
-
-      test("Active users panel shows the visitor", async () => {
-        const panel = page.locator(".v5-MuiPaper-root", {
-          hasText: "Active users",
-        });
-        await expect(panel.locator(".recharts-surface")).toBeVisible();
-        await expect(
-          panel.getByText(
-            /^Average peak active user count was \d+ per hour for this period\.$/,
-          ),
-        ).toBeVisible();
-        await expect(
-          panel.getByRole("button", { name: "Export CSV" }),
-        ).toBeVisible();
-      });
-
-      test("Total number of users panel shows visitor of 100", async () => {
-        const panel = page.locator(".v5-MuiPaper-root", {
-          hasText: "Total number of users",
-        });
-        await expect(panel.locator(".recharts-surface")).toBeVisible();
-        await expect(panel.getByText(/^\d+of 100$/)).toBeVisible();
-        await expect(panel.getByText(/^\d+%have logged in$/)).toBeVisible();
-      });
-
-      test("Data shows in Top plugins Entity", async () => {
-        await testHelper.expectTopEntriesToBePresent("plugins");
-        await expect(
-          page
-            .locator(".v5-MuiPaper-root", { hasText: "plugins" })
-            .locator("tbody tr")
-            .first(),
-        ).toBeVisible();
-      });
-
-      test("Rest of the panels are visible", async () => {
-        const titles = [
-          "templates",
-          "catalog entities",
-          "techdocs",
-          "Searches",
-        ];
+        await testHelper.waitUntilApiCallSucceeds(page);
 
         for (const title of titles) {
           const panel = page
             .locator(".v5-MuiPaper-root", { hasText: title })
             .last();
-          await expect(panel).toBeVisible();
-
-          /* eslint-disable playwright/no-conditional-in-test -- iterating panel types to collect state */
-          if (
-            title === "catalog entities" ||
-            title === "techdocs" ||
-            title === "templates"
-          ) {
-            const firstRow = await testHelper.getVisibleFirstRowText(panel);
-
-            if (title === "templates") templatesFirstEntry = firstRow;
-            else if (title === "catalog entities")
-              catalogEntitiesFirstEntry = firstRow;
-            else if (title === "techdocs") techdocsFirstEntry = firstRow;
-          }
-
-          if (title === "Searches") {
-            const count = await testHelper.getCountFromPanel(panel);
-            initialSearchCount = count || 0;
-          }
-          /* eslint-enable playwright/no-conditional-in-test */
+          const firstRow = panel
+            .locator("table.v5-MuiTable-root tbody tr")
+            .first();
+          const finalViews = firstRow.locator("td").last();
+          await firstRow.waitFor({ state: "visible" });
+          const finalViewsCount = await finalViews.textContent();
+          expect(Number(finalViewsCount)).toBeGreaterThan(
+            state[title].initialViewsCount ?? 0,
+          );
         }
       });
 
-      test("Interaction-based tracking tests", async () => {
-        await runInteractionTrackingSetup(
-          page,
-          uiHelper as AdoptionInsightsUiHelperForPanel,
-          templatesFirstEntry,
-          catalogEntitiesFirstEntry,
-          techdocsFirstEntry,
+      await test.step("New data shows in searches", async () => {
+        const panel = page.locator(".v5-MuiPaper-root", {
+          hasText: "searches",
+        });
+        await expect(panel.locator(".recharts-surface")).toBeVisible();
+        await expect(panel).toContainText(
+          /Average search count was \d+ per \w+ for this period\./,
         );
-
-        await test.step("Visited component shows up in top catalog entities", async () => {
-          await testHelper.expectTopEntriesToBePresent("catalog entities");
-        });
-
-        await test.step("Visited techdoc shows up in top techdocs", async () => {
-          await testHelper.expectTopEntriesToBePresent("techdocs");
-        });
-
-        await test.step("Visited templates shows in top templates", async () => {
-          await testHelper.expectTopEntriesToBePresent("templates");
-        });
-
-        await test.step("Changes are Reflecting in panels", async () => {
-          const titles = ["catalog entities", "techdocs"];
-          interface PanelState {
-            firstRow?: string[];
-            initialViewsCount?: number;
-          }
-          const state: Record<string, PanelState> = {};
-          state["catalog entities"] = {};
-          state["techdocs"] = {};
-
-          /* eslint-disable playwright/no-conditional-in-test -- iterate panel types and branch by title */
-          for (const title of titles) {
-            const panel = page
-              .locator(".v5-MuiPaper-root", { hasText: title })
-              .last();
-            state[title].firstRow =
-              await testHelper.getVisibleFirstRowText(panel);
-            if (title === "catalog entities")
-              catalogEntitiesFirstEntry = state[title].firstRow ?? [];
-            else if (title === "techdocs")
-              techdocsFirstEntry = state[title].firstRow ?? [];
-            const firstRow = panel
-              .locator("table.v5-MuiTable-root tbody tr")
-              .first();
-            const firstEntry = firstRow.locator("td").first();
-            let headerTxt: string;
-            if (title === "techdocs") {
-              headerTxt = techdocsFirstEntry[0];
-              state[title].initialViewsCount = Number(techdocsFirstEntry[1]);
-              if (headerTxt === "docs") headerTxt = "Documentation";
-              await testHelper.clickAndVerifyText(firstEntry, headerTxt);
-            } else if (title === "catalog entities") {
-              headerTxt = "Red Hat Developer Hub";
-              state[title].initialViewsCount = Number(
-                catalogEntitiesFirstEntry[1],
-              );
-              await testHelper.clickAndVerifyText(firstEntry, headerTxt);
-            }
-          }
-          /* eslint-enable playwright/no-conditional-in-test */
-
-          await page.reload();
-          await testHelper.waitUntilApiCallSucceeds(page);
-          await uiHelper.openSidebarButton("Administration");
-          await uiHelper.clickLink("Adoption Insights");
-          await testHelper.clickByText("Last 28 days");
-          await Promise.all([
-            waitForPanelApiCalls(page),
-            testHelper.selectOption("Today"),
-          ]);
-          await testHelper.waitUntilApiCallSucceeds(page);
-
-          for (const title of titles) {
-            const panel = page
-              .locator(".v5-MuiPaper-root", { hasText: title })
-              .last();
-            const firstRow = panel
-              .locator("table.v5-MuiTable-root tbody tr")
-              .first();
-            const finalViews = firstRow.locator("td").last();
-            await firstRow.waitFor({ state: "visible" });
-            const finalViewsCount = await finalViews.textContent();
-            expect(Number(finalViewsCount)).toBeGreaterThan(
-              state[title].initialViewsCount ?? 0,
-            );
-          }
-        });
-
-        await test.step("New data shows in searches", async () => {
-          const panel = page.locator(".v5-MuiPaper-root", {
-            hasText: "searches",
-          });
-          await expect(panel.locator(".recharts-surface")).toBeVisible();
-          await expect(panel).toContainText(
-            /Average search count was \d+ per \w+ for this period\./,
-          );
-          const recount = await testHelper.getCountFromPanel(panel);
-          expect(recount).toBeGreaterThan(initialSearchCount);
-        });
+        const recount = await testHelper.getCountFromPanel(panel);
+        expect(recount).toBeGreaterThan(initialSearchCount);
       });
     });
-  },
-);
+  });
+});

--- a/workspaces/adoption-insights/e2e-tests/tests/specs/adoption-insights.spec.ts
+++ b/workspaces/adoption-insights/e2e-tests/tests/specs/adoption-insights.spec.ts
@@ -28,233 +28,239 @@ test.describe.serial(
     ],
   },
   () => {
-  let context: BrowserContext | undefined;
-  let page: Page;
-  let uiHelper: UIhelper;
-  let testHelper: TestHelper;
+    let context: BrowserContext | undefined;
+    let page: Page;
+    let uiHelper: UIhelper;
+    let testHelper: TestHelper;
 
-  test.beforeAll(async ({ browser, rhdh }) => {
-    await rhdh.configure({
-      auth: "keycloak",
-      disableWrappers: ADOPTION_INSIGHTS_WRAPPER_DIST_NAMES,
-    });
-    await rhdh.deploy();
-
-    context = await browser.newContext({
-      baseURL: rhdh.rhdhUrl,
-    });
-    page = await context.newPage();
-    uiHelper = new UIhelper(page);
-    testHelper = new TestHelper(page);
-
-    const loginHelper = new LoginHelper(page);
-    await loginHelper.loginAsKeycloakUser();
-  });
-
-  test.afterAll(async () => {
-    await context?.close();
-  });
-
-  test.describe
-    .serial("Test Adoption Insights plugin: load permission policies and conditions from files", () => {
-    let initialSearchCount: number;
-    let templatesFirstEntry: string[] = [];
-    let catalogEntitiesFirstEntry: string[] = [];
-    let techdocsFirstEntry: string[] = [];
-
-    test("Check UI navigation by nav bar when adoption-insights is enabled", async () => {
-      await goToAdoptionInsights(uiHelper, page);
-      // eslint-disable-next-line playwright/no-wait-for-timeout -- intentional delay for UI stabilization
-      await page.waitForTimeout(5000);
-      await uiHelper.verifyHeading("Adoption Insights");
-      expect(page.url()).toContain("adoption-insights");
-    });
-
-    test("Select date range", async () => {
-      await testHelper.clickByText("Last 28 days");
-      const dateRanges = ["Today", "Last week", "Last month", "Last year"];
-      for (const range of dateRanges) {
-        await expect(page.getByRole("option", { name: range })).toBeVisible();
-      }
-      await testHelper.selectOption("Date range...");
-      const datePicker = page.locator(".v5-MuiPaper-root", {
-        hasText: "Start date",
+    test.beforeAll(async ({ browser, rhdh }) => {
+      await rhdh.configure({
+        auth: "keycloak",
+        disableWrappers: ADOPTION_INSIGHTS_WRAPPER_DIST_NAMES,
       });
-      await expect(datePicker).toBeVisible();
-      await datePicker.getByRole("button", { name: "Cancel" }).click();
-      await expect(datePicker).toBeHidden();
+      await rhdh.deploy();
 
-      await Promise.all([
-        waitForPanelApiCalls(page),
-        testHelper.selectOption("Today"),
-      ]);
-    });
-
-    test("Active users panel shows the visitor", async () => {
-      const panel = page.locator(".v5-MuiPaper-root", {
-        hasText: "Active users",
+      context = await browser.newContext({
+        baseURL: rhdh.rhdhUrl,
       });
-      await expect(panel.locator(".recharts-surface")).toBeVisible();
-      await expect(
-        panel.getByText(
-          /^Average peak active user count was \d+ per hour for this period\.$/,
-        ),
-      ).toBeVisible();
-      await expect(
-        panel.getByRole("button", { name: "Export CSV" }),
-      ).toBeVisible();
+      page = await context.newPage();
+      uiHelper = new UIhelper(page);
+      testHelper = new TestHelper(page);
+
+      const loginHelper = new LoginHelper(page);
+      await loginHelper.loginAsKeycloakUser();
     });
 
-    test("Total number of users panel shows visitor of 100", async () => {
-      const panel = page.locator(".v5-MuiPaper-root", {
-        hasText: "Total number of users",
-      });
-      await expect(panel.locator(".recharts-surface")).toBeVisible();
-      await expect(panel.getByText(/^\d+of 100$/)).toBeVisible();
-      await expect(panel.getByText(/^\d+%have logged in$/)).toBeVisible();
+    test.afterAll(async () => {
+      await context?.close();
     });
 
-    test("Data shows in Top plugins Entity", async () => {
-      await testHelper.expectTopEntriesToBePresent("plugins");
-      await expect(
-        page
-          .locator(".v5-MuiPaper-root", { hasText: "plugins" })
-          .locator("tbody tr")
-          .first(),
-      ).toBeVisible();
-    });
+    test.describe
+      .serial("Test Adoption Insights plugin: load permission policies and conditions from files", () => {
+      let initialSearchCount: number;
+      let templatesFirstEntry: string[] = [];
+      let catalogEntitiesFirstEntry: string[] = [];
+      let techdocsFirstEntry: string[] = [];
 
-    test("Rest of the panels are visible", async () => {
-      const titles = ["templates", "catalog entities", "techdocs", "Searches"];
-
-      for (const title of titles) {
-        const panel = page
-          .locator(".v5-MuiPaper-root", { hasText: title })
-          .last();
-        await expect(panel).toBeVisible();
-
-        /* eslint-disable playwright/no-conditional-in-test -- iterating panel types to collect state */
-        if (
-          title === "catalog entities" ||
-          title === "techdocs" ||
-          title === "templates"
-        ) {
-          const firstRow = await testHelper.getVisibleFirstRowText(panel);
-
-          if (title === "templates") templatesFirstEntry = firstRow;
-          else if (title === "catalog entities")
-            catalogEntitiesFirstEntry = firstRow;
-          else if (title === "techdocs") techdocsFirstEntry = firstRow;
-        }
-
-        if (title === "Searches") {
-          const count = await testHelper.getCountFromPanel(panel);
-          initialSearchCount = count || 0;
-        }
-        /* eslint-enable playwright/no-conditional-in-test */
-      }
-    });
-
-    test("Interaction-based tracking tests", async () => {
-      await runInteractionTrackingSetup(
-        page,
-        uiHelper as AdoptionInsightsUiHelperForPanel,
-        templatesFirstEntry,
-        catalogEntitiesFirstEntry,
-        techdocsFirstEntry,
-      );
-
-      await test.step("Visited component shows up in top catalog entities", async () => {
-        await testHelper.expectTopEntriesToBePresent("catalog entities");
+      test("Check UI navigation by nav bar when adoption-insights is enabled", async () => {
+        await goToAdoptionInsights(uiHelper, page);
+        // eslint-disable-next-line playwright/no-wait-for-timeout -- intentional delay for UI stabilization
+        await page.waitForTimeout(5000);
+        await uiHelper.verifyHeading("Adoption Insights");
+        expect(page.url()).toContain("adoption-insights");
       });
 
-      await test.step("Visited techdoc shows up in top techdocs", async () => {
-        await testHelper.expectTopEntriesToBePresent("techdocs");
-      });
-
-      await test.step("Visited templates shows in top templates", async () => {
-        await testHelper.expectTopEntriesToBePresent("templates");
-      });
-
-      await test.step("Changes are Reflecting in panels", async () => {
-        const titles = ["catalog entities", "techdocs"];
-        interface PanelState {
-          firstRow?: string[];
-          initialViewsCount?: number;
-        }
-        const state: Record<string, PanelState> = {};
-        state["catalog entities"] = {};
-        state["techdocs"] = {};
-
-        /* eslint-disable playwright/no-conditional-in-test -- iterate panel types and branch by title */
-        for (const title of titles) {
-          const panel = page
-            .locator(".v5-MuiPaper-root", { hasText: title })
-            .last();
-          state[title].firstRow =
-            await testHelper.getVisibleFirstRowText(panel);
-          if (title === "catalog entities")
-            catalogEntitiesFirstEntry = state[title].firstRow ?? [];
-          else if (title === "techdocs")
-            techdocsFirstEntry = state[title].firstRow ?? [];
-          const firstRow = panel
-            .locator("table.v5-MuiTable-root tbody tr")
-            .first();
-          const firstEntry = firstRow.locator("td").first();
-          let headerTxt: string;
-          if (title === "techdocs") {
-            headerTxt = techdocsFirstEntry[0];
-            state[title].initialViewsCount = Number(techdocsFirstEntry[1]);
-            if (headerTxt === "docs") headerTxt = "Documentation";
-            await testHelper.clickAndVerifyText(firstEntry, headerTxt);
-          } else if (title === "catalog entities") {
-            headerTxt = "Red Hat Developer Hub";
-            state[title].initialViewsCount = Number(
-              catalogEntitiesFirstEntry[1],
-            );
-            await testHelper.clickAndVerifyText(firstEntry, headerTxt);
-          }
-        }
-        /* eslint-enable playwright/no-conditional-in-test */
-
-        await page.reload();
-        await testHelper.waitUntilApiCallSucceeds(page);
-        await uiHelper.openSidebarButton("Administration");
-        await uiHelper.clickLink("Adoption Insights");
+      test("Select date range", async () => {
         await testHelper.clickByText("Last 28 days");
+        const dateRanges = ["Today", "Last week", "Last month", "Last year"];
+        for (const range of dateRanges) {
+          await expect(page.getByRole("option", { name: range })).toBeVisible();
+        }
+        await testHelper.selectOption("Date range...");
+        const datePicker = page.locator(".v5-MuiPaper-root", {
+          hasText: "Start date",
+        });
+        await expect(datePicker).toBeVisible();
+        await datePicker.getByRole("button", { name: "Cancel" }).click();
+        await expect(datePicker).toBeHidden();
+
         await Promise.all([
           waitForPanelApiCalls(page),
           testHelper.selectOption("Today"),
         ]);
-        await testHelper.waitUntilApiCallSucceeds(page);
+      });
+
+      test("Active users panel shows the visitor", async () => {
+        const panel = page.locator(".v5-MuiPaper-root", {
+          hasText: "Active users",
+        });
+        await expect(panel.locator(".recharts-surface")).toBeVisible();
+        await expect(
+          panel.getByText(
+            /^Average peak active user count was \d+ per hour for this period\.$/,
+          ),
+        ).toBeVisible();
+        await expect(
+          panel.getByRole("button", { name: "Export CSV" }),
+        ).toBeVisible();
+      });
+
+      test("Total number of users panel shows visitor of 100", async () => {
+        const panel = page.locator(".v5-MuiPaper-root", {
+          hasText: "Total number of users",
+        });
+        await expect(panel.locator(".recharts-surface")).toBeVisible();
+        await expect(panel.getByText(/^\d+of 100$/)).toBeVisible();
+        await expect(panel.getByText(/^\d+%have logged in$/)).toBeVisible();
+      });
+
+      test("Data shows in Top plugins Entity", async () => {
+        await testHelper.expectTopEntriesToBePresent("plugins");
+        await expect(
+          page
+            .locator(".v5-MuiPaper-root", { hasText: "plugins" })
+            .locator("tbody tr")
+            .first(),
+        ).toBeVisible();
+      });
+
+      test("Rest of the panels are visible", async () => {
+        const titles = [
+          "templates",
+          "catalog entities",
+          "techdocs",
+          "Searches",
+        ];
 
         for (const title of titles) {
           const panel = page
             .locator(".v5-MuiPaper-root", { hasText: title })
             .last();
-          const firstRow = panel
-            .locator("table.v5-MuiTable-root tbody tr")
-            .first();
-          const finalViews = firstRow.locator("td").last();
-          await firstRow.waitFor({ state: "visible" });
-          const finalViewsCount = await finalViews.textContent();
-          expect(Number(finalViewsCount)).toBeGreaterThan(
-            state[title].initialViewsCount ?? 0,
-          );
+          await expect(panel).toBeVisible();
+
+          /* eslint-disable playwright/no-conditional-in-test -- iterating panel types to collect state */
+          if (
+            title === "catalog entities" ||
+            title === "techdocs" ||
+            title === "templates"
+          ) {
+            const firstRow = await testHelper.getVisibleFirstRowText(panel);
+
+            if (title === "templates") templatesFirstEntry = firstRow;
+            else if (title === "catalog entities")
+              catalogEntitiesFirstEntry = firstRow;
+            else if (title === "techdocs") techdocsFirstEntry = firstRow;
+          }
+
+          if (title === "Searches") {
+            const count = await testHelper.getCountFromPanel(panel);
+            initialSearchCount = count || 0;
+          }
+          /* eslint-enable playwright/no-conditional-in-test */
         }
       });
 
-      await test.step("New data shows in searches", async () => {
-        const panel = page.locator(".v5-MuiPaper-root", {
-          hasText: "searches",
-        });
-        await expect(panel.locator(".recharts-surface")).toBeVisible();
-        await expect(panel).toContainText(
-          /Average search count was \d+ per \w+ for this period\./,
+      test("Interaction-based tracking tests", async () => {
+        await runInteractionTrackingSetup(
+          page,
+          uiHelper as AdoptionInsightsUiHelperForPanel,
+          templatesFirstEntry,
+          catalogEntitiesFirstEntry,
+          techdocsFirstEntry,
         );
-        const recount = await testHelper.getCountFromPanel(panel);
-        expect(recount).toBeGreaterThan(initialSearchCount);
+
+        await test.step("Visited component shows up in top catalog entities", async () => {
+          await testHelper.expectTopEntriesToBePresent("catalog entities");
+        });
+
+        await test.step("Visited techdoc shows up in top techdocs", async () => {
+          await testHelper.expectTopEntriesToBePresent("techdocs");
+        });
+
+        await test.step("Visited templates shows in top templates", async () => {
+          await testHelper.expectTopEntriesToBePresent("templates");
+        });
+
+        await test.step("Changes are Reflecting in panels", async () => {
+          const titles = ["catalog entities", "techdocs"];
+          interface PanelState {
+            firstRow?: string[];
+            initialViewsCount?: number;
+          }
+          const state: Record<string, PanelState> = {};
+          state["catalog entities"] = {};
+          state["techdocs"] = {};
+
+          /* eslint-disable playwright/no-conditional-in-test -- iterate panel types and branch by title */
+          for (const title of titles) {
+            const panel = page
+              .locator(".v5-MuiPaper-root", { hasText: title })
+              .last();
+            state[title].firstRow =
+              await testHelper.getVisibleFirstRowText(panel);
+            if (title === "catalog entities")
+              catalogEntitiesFirstEntry = state[title].firstRow ?? [];
+            else if (title === "techdocs")
+              techdocsFirstEntry = state[title].firstRow ?? [];
+            const firstRow = panel
+              .locator("table.v5-MuiTable-root tbody tr")
+              .first();
+            const firstEntry = firstRow.locator("td").first();
+            let headerTxt: string;
+            if (title === "techdocs") {
+              headerTxt = techdocsFirstEntry[0];
+              state[title].initialViewsCount = Number(techdocsFirstEntry[1]);
+              if (headerTxt === "docs") headerTxt = "Documentation";
+              await testHelper.clickAndVerifyText(firstEntry, headerTxt);
+            } else if (title === "catalog entities") {
+              headerTxt = "Red Hat Developer Hub";
+              state[title].initialViewsCount = Number(
+                catalogEntitiesFirstEntry[1],
+              );
+              await testHelper.clickAndVerifyText(firstEntry, headerTxt);
+            }
+          }
+          /* eslint-enable playwright/no-conditional-in-test */
+
+          await page.reload();
+          await testHelper.waitUntilApiCallSucceeds(page);
+          await uiHelper.openSidebarButton("Administration");
+          await uiHelper.clickLink("Adoption Insights");
+          await testHelper.clickByText("Last 28 days");
+          await Promise.all([
+            waitForPanelApiCalls(page),
+            testHelper.selectOption("Today"),
+          ]);
+          await testHelper.waitUntilApiCallSucceeds(page);
+
+          for (const title of titles) {
+            const panel = page
+              .locator(".v5-MuiPaper-root", { hasText: title })
+              .last();
+            const firstRow = panel
+              .locator("table.v5-MuiTable-root tbody tr")
+              .first();
+            const finalViews = firstRow.locator("td").last();
+            await firstRow.waitFor({ state: "visible" });
+            const finalViewsCount = await finalViews.textContent();
+            expect(Number(finalViewsCount)).toBeGreaterThan(
+              state[title].initialViewsCount ?? 0,
+            );
+          }
+        });
+
+        await test.step("New data shows in searches", async () => {
+          const panel = page.locator(".v5-MuiPaper-root", {
+            hasText: "searches",
+          });
+          await expect(panel.locator(".recharts-surface")).toBeVisible();
+          await expect(panel).toContainText(
+            /Average search count was \d+ per \w+ for this period\./,
+          );
+          const recount = await testHelper.getCountFromPanel(panel);
+          expect(recount).toBeGreaterThan(initialSearchCount);
+        });
       });
     });
-  });
-});
+  },
+);

--- a/workspaces/adoption-insights/e2e-tests/tests/specs/adoption-insights.spec.ts
+++ b/workspaces/adoption-insights/e2e-tests/tests/specs/adoption-insights.spec.ts
@@ -19,7 +19,15 @@ const ADOPTION_INSIGHTS_WRAPPER_DIST_NAMES: string[] = [
   "red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights-dynamic",
 ];
 
-test.describe.serial("Test Adoption Insights", () => {
+test.describe.serial(
+  "Test Adoption Insights",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "adoption-insights" },
+    ],
+  },
+  () => {
   let context: BrowserContext | undefined;
   let page: Page;
   let uiHelper: UIhelper;

--- a/workspaces/analytics/e2e-tests/tests/specs/analytics-segment.spec.ts
+++ b/workspaces/analytics/e2e-tests/tests/specs/analytics-segment.spec.ts
@@ -44,73 +44,76 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({ auth: "guest" });
-    await rhdh.deploy();
-  });
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({ auth: "guest" });
+      await rhdh.deploy();
+    });
 
-  test("Verify analytics events are sent to Segment on navigation", async ({
-    page,
-    loginHelper,
-    uiHelper,
-  }) => {
-    await page.route("**/cdn.segment.com/**", (route) => {
-      if (route.request().url().includes("/settings")) {
+    test("Verify analytics events are sent to Segment on navigation", async ({
+      page,
+      loginHelper,
+      uiHelper,
+    }) => {
+      await page.route("**/cdn.segment.com/**", (route) => {
+        if (route.request().url().includes("/settings")) {
+          return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(SEGMENT_SETTINGS_RESPONSE),
+          });
+        }
+        return route.fulfill({
+          status: 200,
+          contentType: "application/javascript",
+          body: "/* mock */",
+        });
+      });
+
+      const segmentRequests: {
+        url: string;
+        method: string;
+        body: Record<string, unknown> | null;
+      }[] = [];
+
+      await page.route("**/api.segment.io/**", (route) => {
+        let body: Record<string, unknown> | null = null;
+        const postData = route.request().postData();
+        if (postData) {
+          try {
+            body = JSON.parse(postData) as Record<string, unknown>;
+          } catch {
+            /* raw post data, not JSON */
+          }
+        }
+
+        segmentRequests.push({
+          url: route.request().url(),
+          method: route.request().method(),
+          body,
+        });
+
         return route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify(SEGMENT_SETTINGS_RESPONSE),
+          body: JSON.stringify({ success: true }),
         });
-      }
-      return route.fulfill({
-        status: 200,
-        contentType: "application/javascript",
-        body: "/* mock */",
       });
+
+      await loginHelper.loginAsGuest();
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.clickLink("Red Hat Developer Hub");
+
+      await expect
+        .poll(() => segmentRequests.length, {
+          message: "Waiting for Segment API requests",
+          timeout: 10_000,
+        })
+        .toBeGreaterThan(0);
+
+      const pageRequests = segmentRequests.filter((r) =>
+        r.url.includes("/v1/p"),
+      );
+      expect(pageRequests.length).toBeGreaterThan(0);
     });
-
-    const segmentRequests: {
-      url: string;
-      method: string;
-      body: Record<string, unknown> | null;
-    }[] = [];
-
-    await page.route("**/api.segment.io/**", (route) => {
-      let body: Record<string, unknown> | null = null;
-      const postData = route.request().postData();
-      if (postData) {
-        try {
-          body = JSON.parse(postData) as Record<string, unknown>;
-        } catch {
-          /* raw post data, not JSON */
-        }
-      }
-
-      segmentRequests.push({
-        url: route.request().url(),
-        method: route.request().method(),
-        body,
-      });
-
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ success: true }),
-      });
-    });
-
-    await loginHelper.loginAsGuest();
-    await uiHelper.openSidebar("Catalog");
-    await uiHelper.clickLink("Red Hat Developer Hub");
-
-    await expect
-      .poll(() => segmentRequests.length, {
-        message: "Waiting for Segment API requests",
-        timeout: 10_000,
-      })
-      .toBeGreaterThan(0);
-
-    const pageRequests = segmentRequests.filter((r) => r.url.includes("/v1/p"));
-    expect(pageRequests.length).toBeGreaterThan(0);
-  });
-});
+  },
+);

--- a/workspaces/analytics/e2e-tests/tests/specs/analytics-segment.spec.ts
+++ b/workspaces/analytics/e2e-tests/tests/specs/analytics-segment.spec.ts
@@ -35,7 +35,15 @@ const SEGMENT_SETTINGS_RESPONSE = {
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 
-test.describe("Test Segment Analytics Plugin", () => {
+test.describe(
+  "Test Segment Analytics Plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "analytics" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({ auth: "guest" });
     await rhdh.deploy();

--- a/workspaces/analytics/e2e-tests/tests/specs/analytics-segment.spec.ts
+++ b/workspaces/analytics/e2e-tests/tests/specs/analytics-segment.spec.ts
@@ -35,85 +35,78 @@ const SEGMENT_SETTINGS_RESPONSE = {
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 
-test.describe(
-  "Test Segment Analytics Plugin",
-  {
-    annotation: [
+test.describe("Test Segment Analytics Plugin", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "analytics" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({ auth: "guest" });
-      await rhdh.deploy();
-    });
+    );
+    await rhdh.configure({ auth: "guest" });
+    await rhdh.deploy();
+  });
 
-    test("Verify analytics events are sent to Segment on navigation", async ({
-      page,
-      loginHelper,
-      uiHelper,
-    }) => {
-      await page.route("**/cdn.segment.com/**", (route) => {
-        if (route.request().url().includes("/settings")) {
-          return route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify(SEGMENT_SETTINGS_RESPONSE),
-          });
-        }
-        return route.fulfill({
-          status: 200,
-          contentType: "application/javascript",
-          body: "/* mock */",
-        });
-      });
-
-      const segmentRequests: {
-        url: string;
-        method: string;
-        body: Record<string, unknown> | null;
-      }[] = [];
-
-      await page.route("**/api.segment.io/**", (route) => {
-        let body: Record<string, unknown> | null = null;
-        const postData = route.request().postData();
-        if (postData) {
-          try {
-            body = JSON.parse(postData) as Record<string, unknown>;
-          } catch {
-            /* raw post data, not JSON */
-          }
-        }
-
-        segmentRequests.push({
-          url: route.request().url(),
-          method: route.request().method(),
-          body,
-        });
-
+  test("Verify analytics events are sent to Segment on navigation", async ({
+    page,
+    loginHelper,
+    uiHelper,
+  }) => {
+    await page.route("**/cdn.segment.com/**", (route) => {
+      if (route.request().url().includes("/settings")) {
         return route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify({ success: true }),
+          body: JSON.stringify(SEGMENT_SETTINGS_RESPONSE),
         });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/javascript",
+        body: "/* mock */",
+      });
+    });
+
+    const segmentRequests: {
+      url: string;
+      method: string;
+      body: Record<string, unknown> | null;
+    }[] = [];
+
+    await page.route("**/api.segment.io/**", (route) => {
+      let body: Record<string, unknown> | null = null;
+      const postData = route.request().postData();
+      if (postData) {
+        try {
+          body = JSON.parse(postData) as Record<string, unknown>;
+        } catch {
+          /* raw post data, not JSON */
+        }
+      }
+
+      segmentRequests.push({
+        url: route.request().url(),
+        method: route.request().method(),
+        body,
       });
 
-      await loginHelper.loginAsGuest();
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.clickLink("Red Hat Developer Hub");
-
-      await expect
-        .poll(() => segmentRequests.length, {
-          message: "Waiting for Segment API requests",
-          timeout: 10_000,
-        })
-        .toBeGreaterThan(0);
-
-      const pageRequests = segmentRequests.filter((r) =>
-        r.url.includes("/v1/p"),
-      );
-      expect(pageRequests.length).toBeGreaterThan(0);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true }),
+      });
     });
-  },
-);
+
+    await loginHelper.loginAsGuest();
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.clickLink("Red Hat Developer Hub");
+
+    await expect
+      .poll(() => segmentRequests.length, {
+        message: "Waiting for Segment API requests",
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(0);
+
+    const pageRequests = segmentRequests.filter((r) => r.url.includes("/v1/p"));
+    expect(pageRequests.length).toBeGreaterThan(0);
+  });
+});

--- a/workspaces/argocd/e2e-tests/tests/specs/argocd.spec.ts
+++ b/workspaces/argocd/e2e-tests/tests/specs/argocd.spec.ts
@@ -24,196 +24,207 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    test.setTimeout(900_000);
+    test.beforeAll(async ({ rhdh }) => {
+      test.setTimeout(900_000);
 
-    await test.runOnce("argocd-infra", async () => {
-      const namespace = rhdh.deploymentConfig.namespace;
-      await $`bash ${setupScript} ${namespace}`;
+      await test.runOnce("argocd-infra", async () => {
+        const namespace = rhdh.deploymentConfig.namespace;
+        await $`bash ${setupScript} ${namespace}`;
+      });
+
+      const argoRoute = await rhdh.k8sClient.getRouteLocation(
+        "openshift-gitops",
+        "openshift-gitops-server",
+      );
+
+      const jsonpath = String.raw`{.data.admin\.password}`;
+      const secretResult =
+        await $pipe`oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath=${jsonpath}`;
+      const argoPassword = Buffer.from(
+        secretResult.stdout.trim(),
+        "base64",
+      ).toString();
+
+      process.env.ARGOCD_INSTANCE1_URL = argoRoute;
+      process.env.ARGOCD_USERNAME = "admin";
+      process.env.ARGOCD_PASSWORD = argoPassword;
+
+      await rhdh.configure({ auth: "keycloak" });
+      await rhdh.deploy({ timeout: 900_000 });
     });
 
-    const argoRoute = await rhdh.k8sClient.getRouteLocation(
-      "openshift-gitops",
-      "openshift-gitops-server",
-    );
+    test.beforeEach(async ({ page, loginHelper, uiHelper }) => {
+      await loginHelper.loginAsKeycloakUser();
+      await navigateToComponent(page, uiHelper);
+      await uiHelper.clickTab("CD");
+      await uiHelper.clickByDataTestId("test-argocd-app-card");
+    });
 
-    const jsonpath = String.raw`{.data.admin\.password}`;
-    const secretResult =
-      await $pipe`oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath=${jsonpath}`;
-    const argoPassword = Buffer.from(
-      secretResult.stdout.trim(),
-      "base64",
-    ).toString();
+    test("Verify deployment summary card and drawer close button", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.clickButtonByLabel("Close the drawer");
 
-    process.env.ARGOCD_INSTANCE1_URL = argoRoute;
-    process.env.ARGOCD_USERNAME = "admin";
-    process.env.ARGOCD_PASSWORD = argoPassword;
+      const card = page.getByTestId("test-argocd-app-card");
+      await expect(card).toBeVisible();
+      await expect(card).toContainText("test-argocd-app");
+      await expect(card).toContainText("Synced");
+      await expect(card).toContainText(/Healthy|Degraded/);
+    });
 
-    await rhdh.configure({ auth: "keycloak" });
-    await rhdh.deploy({ timeout: 900_000 });
-  });
+    test("Verify app drawer shows instance details", async ({ uiHelper }) => {
+      await uiHelper.verifyHeading("test-argocd-app");
+      await uiHelper.verifyText("Synced");
+      await uiHelper.verifyText(/Healthy|Degraded/);
+      await uiHelper.verifyText("argoInstance1");
+      await uiHelper.verifyText("https://kubernetes.default.svc", false);
+      await uiHelper.verifyText("argocd");
+    });
 
-  test.beforeEach(async ({ page, loginHelper, uiHelper }) => {
-    await loginHelper.loginAsKeycloakUser();
-    await navigateToComponent(page, uiHelper);
-    await uiHelper.clickTab("CD");
-    await uiHelper.clickByDataTestId("test-argocd-app-card");
-  });
+    test("Verify resources table lists expected resources", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.verifyText("Resources");
 
-  test("Verify deployment summary card and drawer close button", async ({
-    page,
-    uiHelper,
-  }) => {
-    await uiHelper.clickButtonByLabel("Close the drawer");
+      await uiHelper.clickButtonByLabel("rows");
+      await page.getByRole("option", { name: "10 rows" }).click();
 
-    const card = page.getByTestId("test-argocd-app-card");
-    await expect(card).toBeVisible();
-    await expect(card).toContainText("test-argocd-app");
-    await expect(card).toContainText("Synced");
-    await expect(card).toContainText(/Healthy|Degraded/);
-  });
+      await uiHelper.verifyColumnHeading([
+        "Name",
+        "Kind",
+        "Sync status",
+        "Health status",
+      ]);
 
-  test("Verify app drawer shows instance details", async ({ uiHelper }) => {
-    await uiHelper.verifyHeading("test-argocd-app");
-    await uiHelper.verifyText("Synced");
-    await uiHelper.verifyText(/Healthy|Degraded/);
-    await uiHelper.verifyText("argoInstance1");
-    await uiHelper.verifyText("https://kubernetes.default.svc", false);
-    await uiHelper.verifyText("argocd");
-  });
+      await uiHelper.verifyRowInTableByUniqueText("always-pass", [
+        "AnalysisTemplate",
+        "Synced",
+      ]);
+      await uiHelper.verifyRowInTableByUniqueText("random-fail", [
+        "AnalysisTemplate",
+        "Synced",
+      ]);
+      await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen-active", [
+        "Service",
+        "Synced",
+        "Healthy",
+      ]);
+      await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen-preview", [
+        "Service",
+        "Synced",
+        "Healthy",
+      ]);
+      await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen", [
+        /Rollout/,
+        /Synced/,
+        /Healthy|Degraded/,
+      ]);
 
-  test("Verify resources table lists expected resources", async ({
-    page,
-    uiHelper,
-  }) => {
-    await uiHelper.verifyText("Resources");
+      const row = (name: string, kind: string) =>
+        rowByNameAndKind(page, name, kind);
 
-    await uiHelper.clickButtonByLabel("rows");
-    await page.getByRole("option", { name: "10 rows" }).click();
+      await expect(row("canary-rollout-analysis", "Service")).toBeVisible();
+      await expect(row("canary-rollout-analysis", "Rollout")).toBeVisible();
+      await expect(row("test-argocd-app", "Service")).toBeVisible();
+      await expect(row("test-argocd-app", "Deployment")).toBeVisible();
+    });
 
-    await uiHelper.verifyColumnHeading([
-      "Name",
-      "Kind",
-      "Sync status",
-      "Health status",
-    ]);
+    test("Verify resources table filters by Kind, Name, Sync and Health status", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.verifyText("Resources");
 
-    await uiHelper.verifyRowInTableByUniqueText("always-pass", [
-      "AnalysisTemplate",
-      "Synced",
-    ]);
-    await uiHelper.verifyRowInTableByUniqueText("random-fail", [
-      "AnalysisTemplate",
-      "Synced",
-    ]);
-    await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen-active", [
-      "Service",
-      "Synced",
-      "Healthy",
-    ]);
-    await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen-preview", [
-      "Service",
-      "Synced",
-      "Healthy",
-    ]);
-    await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen", [
-      /Rollout/,
-      /Synced/,
-      /Healthy|Degraded/,
-    ]);
+      const toolbar = page.locator("#toolbar-with-filter");
 
-    const row = (name: string, kind: string) =>
-      rowByNameAndKind(page, name, kind);
+      await switchFilter(page, "Filter by", "Kind");
+      await toggleCheckboxFilter(page, "Kind", ["AnalysisTemplate", "Rollout"]);
 
-    await expect(row("canary-rollout-analysis", "Service")).toBeVisible();
-    await expect(row("canary-rollout-analysis", "Rollout")).toBeVisible();
-    await expect(row("test-argocd-app", "Service")).toBeVisible();
-    await expect(row("test-argocd-app", "Deployment")).toBeVisible();
-  });
+      await expect(toolbar).toContainText("Filter by Kind 2");
+      await uiHelper.verifyCellsInTable(["AnalysisTemplate", "Rollout"]);
+      for (const kind of ["Service", "Deployment"]) {
+        await expect(page.getByRole("cell", { name: kind })).toHaveCount(0);
+      }
 
-  test("Verify resources table filters by Kind, Name, Sync and Health status", async ({
-    page,
-    uiHelper,
-  }) => {
-    await uiHelper.verifyText("Resources");
-
-    const toolbar = page.locator("#toolbar-with-filter");
-
-    await switchFilter(page, "Filter by", "Kind");
-    await toggleCheckboxFilter(page, "Kind", ["AnalysisTemplate", "Rollout"]);
-
-    await expect(toolbar).toContainText("Filter by Kind 2");
-    await uiHelper.verifyCellsInTable(["AnalysisTemplate", "Rollout"]);
-    for (const kind of ["Service", "Deployment"]) {
-      await expect(page.getByRole("cell", { name: kind })).toHaveCount(0);
-    }
-
-    await uiHelper.clickButtonByLabel("Clear all filters");
-    await uiHelper.verifyCellsInTable(["Service"]);
-
-    await switchFilter(page, "Kind", "Name");
-    await page.getByRole("textbox", { name: "Search by name" }).fill("active");
-    await uiHelper.verifyRowsInTable(["rollout-bluegreen-active"]);
-    await uiHelper.clickButtonByLabel("Reset");
-
-    await switchFilter(page, "Name", "Sync status");
-    await uiHelper.clickButtonByLabel("Filter by Sync status");
-    for (const status of ["Synced", "OutOfSync", "Unknown"]) {
-      await expect(page.getByRole("menuitem", { name: status })).toBeVisible();
-    }
-    await uiHelper.clickButtonByLabel("Filter by Sync status");
-
-    for (const status of ["OutOfSync", "Unknown"]) {
-      await toggleCheckboxFilter(page, "Sync status", [status]);
-      await expect(toolbar).toContainText("Filter by Sync status 1");
-      await uiHelper.verifyText("No Resources found");
       await uiHelper.clickButtonByLabel("Clear all filters");
-    }
+      await uiHelper.verifyCellsInTable(["Service"]);
 
-    await switchFilter(page, "Sync status", "Health status");
-    await uiHelper.clickByDataTestId("health-status-toggle");
-    for (const status of [
-      "Healthy",
-      "Degraded",
-      "Suspended",
-      "Progressing",
-      "Missing",
-      "Unknown",
-    ]) {
-      await expect(page.getByRole("menuitem", { name: status })).toBeVisible();
-    }
-    await uiHelper.clickByDataTestId("health-status-toggle");
-  });
+      await switchFilter(page, "Kind", "Name");
+      await page
+        .getByRole("textbox", { name: "Search by name" })
+        .fill("active");
+      await uiHelper.verifyRowsInTable(["rollout-bluegreen-active"]);
+      await uiHelper.clickButtonByLabel("Reset");
 
-  test("Verify deployment lifecycle on CD tab shows revisions", async ({
-    uiHelper,
-  }) => {
-    await uiHelper.verifyText(/Revision \d+/);
-  });
+      await switchFilter(page, "Name", "Sync status");
+      await uiHelper.clickButtonByLabel("Filter by Sync status");
+      for (const status of ["Synced", "OutOfSync", "Unknown"]) {
+        await expect(
+          page.getByRole("menuitem", { name: status }),
+        ).toBeVisible();
+      }
+      await uiHelper.clickButtonByLabel("Filter by Sync status");
 
-  test("Verify bluegreen rollout details and analysis runs", async ({
-    page,
-  }) => {
-    await expandAllSections(page);
+      for (const status of ["OutOfSync", "Unknown"]) {
+        await toggleCheckboxFilter(page, "Sync status", [status]);
+        await expect(toolbar).toContainText("Filter by Sync status 1");
+        await uiHelper.verifyText("No Resources found");
+        await uiHelper.clickButtonByLabel("Clear all filters");
+      }
 
-    const bluegreen = page.locator('[data-testid^="rollout-bluegreen-"]');
-    await expect(
-      bluegreen.getByText(/Traffic to image argoproj\//).first(),
-    ).toBeVisible();
-    await expect(bluegreen.getByText("Stable").first()).toBeVisible();
-    await expect(bluegreen.getByText("Analysis Runs").first()).toBeVisible();
-    await expect(bluegreen.getByText(/Analysis \d+-pre/).first()).toBeVisible();
-  });
+      await switchFilter(page, "Sync status", "Health status");
+      await uiHelper.clickByDataTestId("health-status-toggle");
+      for (const status of [
+        "Healthy",
+        "Degraded",
+        "Suspended",
+        "Progressing",
+        "Missing",
+        "Unknown",
+      ]) {
+        await expect(
+          page.getByRole("menuitem", { name: status }),
+        ).toBeVisible();
+      }
+      await uiHelper.clickByDataTestId("health-status-toggle");
+    });
 
-  test("Verify canary rollout details and analysis runs", async ({ page }) => {
-    await expandAllSections(page);
+    test("Verify deployment lifecycle on CD tab shows revisions", async ({
+      uiHelper,
+    }) => {
+      await uiHelper.verifyText(/Revision \d+/);
+    });
 
-    const canary = page.locator('[data-testid^="canary-rollout-analysis-"]');
-    await expect(canary.getByText("Stable").first()).toBeVisible();
-    await expect(
-      canary.getByText(/Traffic to image argoproj\//).first(),
-    ).toBeVisible();
-    await expect(canary.getByText("Analysis Runs").first()).toBeVisible();
-    await expect(canary.getByText(/Analysis \d+-/).first()).toBeVisible();
-  });
-});
+    test("Verify bluegreen rollout details and analysis runs", async ({
+      page,
+    }) => {
+      await expandAllSections(page);
+
+      const bluegreen = page.locator('[data-testid^="rollout-bluegreen-"]');
+      await expect(
+        bluegreen.getByText(/Traffic to image argoproj\//).first(),
+      ).toBeVisible();
+      await expect(bluegreen.getByText("Stable").first()).toBeVisible();
+      await expect(bluegreen.getByText("Analysis Runs").first()).toBeVisible();
+      await expect(
+        bluegreen.getByText(/Analysis \d+-pre/).first(),
+      ).toBeVisible();
+    });
+
+    test("Verify canary rollout details and analysis runs", async ({
+      page,
+    }) => {
+      await expandAllSections(page);
+
+      const canary = page.locator('[data-testid^="canary-rollout-analysis-"]');
+      await expect(canary.getByText("Stable").first()).toBeVisible();
+      await expect(
+        canary.getByText(/Traffic to image argoproj\//).first(),
+      ).toBeVisible();
+      await expect(canary.getByText("Analysis Runs").first()).toBeVisible();
+      await expect(canary.getByText(/Analysis \d+-/).first()).toBeVisible();
+    });
+  },
+);

--- a/workspaces/argocd/e2e-tests/tests/specs/argocd.spec.ts
+++ b/workspaces/argocd/e2e-tests/tests/specs/argocd.spec.ts
@@ -15,216 +15,201 @@ const setupScript = path.join(
 );
 const $pipe = $({ stdio: "pipe" });
 
-test.describe(
-  "Test ArgoCD plugin",
-  {
-    annotation: [
+test.describe("Test ArgoCD plugin", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "argocd" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      test.setTimeout(900_000);
+    );
+    test.setTimeout(900_000);
 
-      await test.runOnce("argocd-infra", async () => {
-        const namespace = rhdh.deploymentConfig.namespace;
-        await $`bash ${setupScript} ${namespace}`;
-      });
-
-      const argoRoute = await rhdh.k8sClient.getRouteLocation(
-        "openshift-gitops",
-        "openshift-gitops-server",
-      );
-
-      const jsonpath = String.raw`{.data.admin\.password}`;
-      const secretResult =
-        await $pipe`oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath=${jsonpath}`;
-      const argoPassword = Buffer.from(
-        secretResult.stdout.trim(),
-        "base64",
-      ).toString();
-
-      process.env.ARGOCD_INSTANCE1_URL = argoRoute;
-      process.env.ARGOCD_USERNAME = "admin";
-      process.env.ARGOCD_PASSWORD = argoPassword;
-
-      await rhdh.configure({ auth: "keycloak" });
-      await rhdh.deploy({ timeout: 900_000 });
+    await test.runOnce("argocd-infra", async () => {
+      const namespace = rhdh.deploymentConfig.namespace;
+      await $`bash ${setupScript} ${namespace}`;
     });
 
-    test.beforeEach(async ({ page, loginHelper, uiHelper }) => {
-      await loginHelper.loginAsKeycloakUser();
-      await navigateToComponent(page, uiHelper);
-      await uiHelper.clickTab("CD");
-      await uiHelper.clickByDataTestId("test-argocd-app-card");
-    });
+    const argoRoute = await rhdh.k8sClient.getRouteLocation(
+      "openshift-gitops",
+      "openshift-gitops-server",
+    );
 
-    test("Verify deployment summary card and drawer close button", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.clickButtonByLabel("Close the drawer");
+    const jsonpath = String.raw`{.data.admin\.password}`;
+    const secretResult =
+      await $pipe`oc get secret openshift-gitops-cluster -n openshift-gitops -o jsonpath=${jsonpath}`;
+    const argoPassword = Buffer.from(
+      secretResult.stdout.trim(),
+      "base64",
+    ).toString();
 
-      const card = page.getByTestId("test-argocd-app-card");
-      await expect(card).toBeVisible();
-      await expect(card).toContainText("test-argocd-app");
-      await expect(card).toContainText("Synced");
-      await expect(card).toContainText(/Healthy|Degraded/);
-    });
+    process.env.ARGOCD_INSTANCE1_URL = argoRoute;
+    process.env.ARGOCD_USERNAME = "admin";
+    process.env.ARGOCD_PASSWORD = argoPassword;
 
-    test("Verify app drawer shows instance details", async ({ uiHelper }) => {
-      await uiHelper.verifyHeading("test-argocd-app");
-      await uiHelper.verifyText("Synced");
-      await uiHelper.verifyText(/Healthy|Degraded/);
-      await uiHelper.verifyText("argoInstance1");
-      await uiHelper.verifyText("https://kubernetes.default.svc", false);
-      await uiHelper.verifyText("argocd");
-    });
+    await rhdh.configure({ auth: "keycloak" });
+    await rhdh.deploy({ timeout: 900_000 });
+  });
 
-    test("Verify resources table lists expected resources", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.verifyText("Resources");
+  test.beforeEach(async ({ page, loginHelper, uiHelper }) => {
+    await loginHelper.loginAsKeycloakUser();
+    await navigateToComponent(page, uiHelper);
+    await uiHelper.clickTab("CD");
+    await uiHelper.clickByDataTestId("test-argocd-app-card");
+  });
 
-      await uiHelper.clickButtonByLabel("rows");
-      await page.getByRole("option", { name: "10 rows" }).click();
+  test("Verify deployment summary card and drawer close button", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.clickButtonByLabel("Close the drawer");
 
-      await uiHelper.verifyColumnHeading([
-        "Name",
-        "Kind",
-        "Sync status",
-        "Health status",
-      ]);
+    const card = page.getByTestId("test-argocd-app-card");
+    await expect(card).toBeVisible();
+    await expect(card).toContainText("test-argocd-app");
+    await expect(card).toContainText("Synced");
+    await expect(card).toContainText(/Healthy|Degraded/);
+  });
 
-      await uiHelper.verifyRowInTableByUniqueText("always-pass", [
-        "AnalysisTemplate",
-        "Synced",
-      ]);
-      await uiHelper.verifyRowInTableByUniqueText("random-fail", [
-        "AnalysisTemplate",
-        "Synced",
-      ]);
-      await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen-active", [
-        "Service",
-        "Synced",
-        "Healthy",
-      ]);
-      await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen-preview", [
-        "Service",
-        "Synced",
-        "Healthy",
-      ]);
-      await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen", [
-        /Rollout/,
-        /Synced/,
-        /Healthy|Degraded/,
-      ]);
+  test("Verify app drawer shows instance details", async ({ uiHelper }) => {
+    await uiHelper.verifyHeading("test-argocd-app");
+    await uiHelper.verifyText("Synced");
+    await uiHelper.verifyText(/Healthy|Degraded/);
+    await uiHelper.verifyText("argoInstance1");
+    await uiHelper.verifyText("https://kubernetes.default.svc", false);
+    await uiHelper.verifyText("argocd");
+  });
 
-      const row = (name: string, kind: string) =>
-        rowByNameAndKind(page, name, kind);
+  test("Verify resources table lists expected resources", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.verifyText("Resources");
 
-      await expect(row("canary-rollout-analysis", "Service")).toBeVisible();
-      await expect(row("canary-rollout-analysis", "Rollout")).toBeVisible();
-      await expect(row("test-argocd-app", "Service")).toBeVisible();
-      await expect(row("test-argocd-app", "Deployment")).toBeVisible();
-    });
+    await uiHelper.clickButtonByLabel("rows");
+    await page.getByRole("option", { name: "10 rows" }).click();
 
-    test("Verify resources table filters by Kind, Name, Sync and Health status", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.verifyText("Resources");
+    await uiHelper.verifyColumnHeading([
+      "Name",
+      "Kind",
+      "Sync status",
+      "Health status",
+    ]);
 
-      const toolbar = page.locator("#toolbar-with-filter");
+    await uiHelper.verifyRowInTableByUniqueText("always-pass", [
+      "AnalysisTemplate",
+      "Synced",
+    ]);
+    await uiHelper.verifyRowInTableByUniqueText("random-fail", [
+      "AnalysisTemplate",
+      "Synced",
+    ]);
+    await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen-active", [
+      "Service",
+      "Synced",
+      "Healthy",
+    ]);
+    await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen-preview", [
+      "Service",
+      "Synced",
+      "Healthy",
+    ]);
+    await uiHelper.verifyRowInTableByUniqueText("rollout-bluegreen", [
+      /Rollout/,
+      /Synced/,
+      /Healthy|Degraded/,
+    ]);
 
-      await switchFilter(page, "Filter by", "Kind");
-      await toggleCheckboxFilter(page, "Kind", ["AnalysisTemplate", "Rollout"]);
+    const row = (name: string, kind: string) =>
+      rowByNameAndKind(page, name, kind);
 
-      await expect(toolbar).toContainText("Filter by Kind 2");
-      await uiHelper.verifyCellsInTable(["AnalysisTemplate", "Rollout"]);
-      for (const kind of ["Service", "Deployment"]) {
-        await expect(page.getByRole("cell", { name: kind })).toHaveCount(0);
-      }
+    await expect(row("canary-rollout-analysis", "Service")).toBeVisible();
+    await expect(row("canary-rollout-analysis", "Rollout")).toBeVisible();
+    await expect(row("test-argocd-app", "Service")).toBeVisible();
+    await expect(row("test-argocd-app", "Deployment")).toBeVisible();
+  });
 
+  test("Verify resources table filters by Kind, Name, Sync and Health status", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.verifyText("Resources");
+
+    const toolbar = page.locator("#toolbar-with-filter");
+
+    await switchFilter(page, "Filter by", "Kind");
+    await toggleCheckboxFilter(page, "Kind", ["AnalysisTemplate", "Rollout"]);
+
+    await expect(toolbar).toContainText("Filter by Kind 2");
+    await uiHelper.verifyCellsInTable(["AnalysisTemplate", "Rollout"]);
+    for (const kind of ["Service", "Deployment"]) {
+      await expect(page.getByRole("cell", { name: kind })).toHaveCount(0);
+    }
+
+    await uiHelper.clickButtonByLabel("Clear all filters");
+    await uiHelper.verifyCellsInTable(["Service"]);
+
+    await switchFilter(page, "Kind", "Name");
+    await page.getByRole("textbox", { name: "Search by name" }).fill("active");
+    await uiHelper.verifyRowsInTable(["rollout-bluegreen-active"]);
+    await uiHelper.clickButtonByLabel("Reset");
+
+    await switchFilter(page, "Name", "Sync status");
+    await uiHelper.clickButtonByLabel("Filter by Sync status");
+    for (const status of ["Synced", "OutOfSync", "Unknown"]) {
+      await expect(page.getByRole("menuitem", { name: status })).toBeVisible();
+    }
+    await uiHelper.clickButtonByLabel("Filter by Sync status");
+
+    for (const status of ["OutOfSync", "Unknown"]) {
+      await toggleCheckboxFilter(page, "Sync status", [status]);
+      await expect(toolbar).toContainText("Filter by Sync status 1");
+      await uiHelper.verifyText("No Resources found");
       await uiHelper.clickButtonByLabel("Clear all filters");
-      await uiHelper.verifyCellsInTable(["Service"]);
+    }
 
-      await switchFilter(page, "Kind", "Name");
-      await page
-        .getByRole("textbox", { name: "Search by name" })
-        .fill("active");
-      await uiHelper.verifyRowsInTable(["rollout-bluegreen-active"]);
-      await uiHelper.clickButtonByLabel("Reset");
+    await switchFilter(page, "Sync status", "Health status");
+    await uiHelper.clickByDataTestId("health-status-toggle");
+    for (const status of [
+      "Healthy",
+      "Degraded",
+      "Suspended",
+      "Progressing",
+      "Missing",
+      "Unknown",
+    ]) {
+      await expect(page.getByRole("menuitem", { name: status })).toBeVisible();
+    }
+    await uiHelper.clickByDataTestId("health-status-toggle");
+  });
 
-      await switchFilter(page, "Name", "Sync status");
-      await uiHelper.clickButtonByLabel("Filter by Sync status");
-      for (const status of ["Synced", "OutOfSync", "Unknown"]) {
-        await expect(
-          page.getByRole("menuitem", { name: status }),
-        ).toBeVisible();
-      }
-      await uiHelper.clickButtonByLabel("Filter by Sync status");
+  test("Verify deployment lifecycle on CD tab shows revisions", async ({
+    uiHelper,
+  }) => {
+    await uiHelper.verifyText(/Revision \d+/);
+  });
 
-      for (const status of ["OutOfSync", "Unknown"]) {
-        await toggleCheckboxFilter(page, "Sync status", [status]);
-        await expect(toolbar).toContainText("Filter by Sync status 1");
-        await uiHelper.verifyText("No Resources found");
-        await uiHelper.clickButtonByLabel("Clear all filters");
-      }
+  test("Verify bluegreen rollout details and analysis runs", async ({
+    page,
+  }) => {
+    await expandAllSections(page);
 
-      await switchFilter(page, "Sync status", "Health status");
-      await uiHelper.clickByDataTestId("health-status-toggle");
-      for (const status of [
-        "Healthy",
-        "Degraded",
-        "Suspended",
-        "Progressing",
-        "Missing",
-        "Unknown",
-      ]) {
-        await expect(
-          page.getByRole("menuitem", { name: status }),
-        ).toBeVisible();
-      }
-      await uiHelper.clickByDataTestId("health-status-toggle");
-    });
+    const bluegreen = page.locator('[data-testid^="rollout-bluegreen-"]');
+    await expect(
+      bluegreen.getByText(/Traffic to image argoproj\//).first(),
+    ).toBeVisible();
+    await expect(bluegreen.getByText("Stable").first()).toBeVisible();
+    await expect(bluegreen.getByText("Analysis Runs").first()).toBeVisible();
+    await expect(bluegreen.getByText(/Analysis \d+-pre/).first()).toBeVisible();
+  });
 
-    test("Verify deployment lifecycle on CD tab shows revisions", async ({
-      uiHelper,
-    }) => {
-      await uiHelper.verifyText(/Revision \d+/);
-    });
+  test("Verify canary rollout details and analysis runs", async ({ page }) => {
+    await expandAllSections(page);
 
-    test("Verify bluegreen rollout details and analysis runs", async ({
-      page,
-    }) => {
-      await expandAllSections(page);
-
-      const bluegreen = page.locator('[data-testid^="rollout-bluegreen-"]');
-      await expect(
-        bluegreen.getByText(/Traffic to image argoproj\//).first(),
-      ).toBeVisible();
-      await expect(bluegreen.getByText("Stable").first()).toBeVisible();
-      await expect(bluegreen.getByText("Analysis Runs").first()).toBeVisible();
-      await expect(
-        bluegreen.getByText(/Analysis \d+-pre/).first(),
-      ).toBeVisible();
-    });
-
-    test("Verify canary rollout details and analysis runs", async ({
-      page,
-    }) => {
-      await expandAllSections(page);
-
-      const canary = page.locator('[data-testid^="canary-rollout-analysis-"]');
-      await expect(canary.getByText("Stable").first()).toBeVisible();
-      await expect(
-        canary.getByText(/Traffic to image argoproj\//).first(),
-      ).toBeVisible();
-      await expect(canary.getByText("Analysis Runs").first()).toBeVisible();
-      await expect(canary.getByText(/Analysis \d+-/).first()).toBeVisible();
-    });
-  },
-);
+    const canary = page.locator('[data-testid^="canary-rollout-analysis-"]');
+    await expect(canary.getByText("Stable").first()).toBeVisible();
+    await expect(
+      canary.getByText(/Traffic to image argoproj\//).first(),
+    ).toBeVisible();
+    await expect(canary.getByText("Analysis Runs").first()).toBeVisible();
+    await expect(canary.getByText(/Analysis \d+-/).first()).toBeVisible();
+  });
+});

--- a/workspaces/argocd/e2e-tests/tests/specs/argocd.spec.ts
+++ b/workspaces/argocd/e2e-tests/tests/specs/argocd.spec.ts
@@ -15,7 +15,15 @@ const setupScript = path.join(
 );
 const $pipe = $({ stdio: "pipe" });
 
-test.describe("Test ArgoCD plugin", () => {
+test.describe(
+  "Test ArgoCD plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "argocd" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     test.setTimeout(900_000);
 

--- a/workspaces/backstage/e2e-tests/tests/specs/github-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-discovery.spec.ts
@@ -3,72 +3,65 @@ import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { GitHubApiHelper } from "../../support/api/github-api-helper";
 import { RHDH_GITHUB_TEST_ORGANIZATION } from "../../support/constants/github/organization";
 
-test.describe(
-  "Github Discovery Catalog",
-  {
-    annotation: [
+test.describe("Github Discovery Catalog", () => {
+  let catalogPage: CatalogPage;
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "backstage" },
-    ],
-  },
-  () => {
-    let catalogPage: CatalogPage;
+    );
+    // Allow time for deployment + 1 min provider refresh delay + browser setup
+    test.setTimeout(10 * 60 * 1000);
 
-    test.beforeAll(async ({ rhdh }) => {
-      // Allow time for deployment + 1 min provider refresh delay + browser setup
-      test.setTimeout(10 * 60 * 1000);
-
-      await rhdh.configure({
-        auth: "guest",
-        appConfig: "tests/config/github-discovery/app-config-rhdh.yaml",
-        secrets: "tests/config/github-discovery/rhdh-secrets.yaml",
-        dynamicPlugins: "tests/config/github-discovery/dynamic-plugins.yaml",
-      });
-      await rhdh.deploy();
-      // Wait 1 minute for github provider to refresh entities before running tests
-      await new Promise((resolve) => setTimeout(resolve, 1 * 60 * 1000));
+    await rhdh.configure({
+      auth: "guest",
+      appConfig: "tests/config/github-discovery/app-config-rhdh.yaml",
+      secrets: "tests/config/github-discovery/rhdh-secrets.yaml",
+      dynamicPlugins: "tests/config/github-discovery/dynamic-plugins.yaml",
     });
+    await rhdh.deploy();
+    // Wait 1 minute for github provider to refresh entities before running tests
+    await new Promise((resolve) => setTimeout(resolve, 1 * 60 * 1000));
+  });
 
-    test.beforeEach(async ({ loginHelper, page }) => {
-      await loginHelper.loginAsGuest();
-      catalogPage = new CatalogPage(page);
-      await catalogPage.go();
-    });
+  test.beforeEach(async ({ loginHelper, page }) => {
+    await loginHelper.loginAsGuest();
+    catalogPage = new CatalogPage(page);
+    await catalogPage.go();
+  });
 
-    test(`Discover Organization's Catalog`, async () => {
-      const organizationRepos = await GitHubApiHelper.getReposFromOrg(
-        RHDH_GITHUB_TEST_ORGANIZATION,
-      );
-      const reposNames: string[] = (
-        organizationRepos as Array<{ name?: string }>
+  test(`Discover Organization's Catalog`, async () => {
+    const organizationRepos = await GitHubApiHelper.getReposFromOrg(
+      RHDH_GITHUB_TEST_ORGANIZATION,
+    );
+    const reposNames: string[] = (organizationRepos as Array<{ name?: string }>)
+      .map((repo) => repo.name)
+      .filter((name): name is string => typeof name === "string")
+      // filter for subset of organization repositories where the repository name matches the entity name
+      .filter((name) => name.startsWith("test-annotator"))
+      .slice(0, 5);
+
+    const reposWithCatalogInfo: string[] = (
+      await Promise.all(
+        reposNames.map(async (repo) =>
+          (await GitHubApiHelper.fileExistsInRepo(
+            RHDH_GITHUB_TEST_ORGANIZATION,
+            repo,
+            "catalog-info.yaml",
+          ))
+            ? repo
+            : null,
+        ),
       )
-        .map((repo) => repo.name)
-        .filter((name): name is string => typeof name === "string")
-        // filter for subset of organization repositories where the repository name matches the entity name
-        .filter((name) => name.startsWith("test-annotator"))
-        .slice(0, 5);
+    ).filter((repo): repo is string => typeof repo === "string");
 
-      const reposWithCatalogInfo: string[] = (
-        await Promise.all(
-          reposNames.map(async (repo) =>
-            (await GitHubApiHelper.fileExistsInRepo(
-              RHDH_GITHUB_TEST_ORGANIZATION,
-              repo,
-              "catalog-info.yaml",
-            ))
-              ? repo
-              : null,
-          ),
-        )
-      ).filter((repo): repo is string => typeof repo === "string");
+    expect(reposWithCatalogInfo.length).toBeGreaterThan(0);
 
-      expect(reposWithCatalogInfo.length).toBeGreaterThan(0);
-
-      for (const repo of reposWithCatalogInfo) {
-        await catalogPage.search(repo);
-        const row = await catalogPage.tableRow(repo);
-        await expect(row).toBeVisible();
-      }
-    });
-  },
-);
+    for (const repo of reposWithCatalogInfo) {
+      await catalogPage.search(repo);
+      const row = await catalogPage.tableRow(repo);
+      await expect(row).toBeVisible();
+    }
+  });
+});

--- a/workspaces/backstage/e2e-tests/tests/specs/github-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-discovery.spec.ts
@@ -3,7 +3,15 @@ import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { GitHubApiHelper } from "../../support/api/github-api-helper";
 import { RHDH_GITHUB_TEST_ORGANIZATION } from "../../support/constants/github/organization";
 
-test.describe("Github Discovery Catalog", () => {
+test.describe(
+  "Github Discovery Catalog",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "backstage" },
+    ],
+  },
+  () => {
   let catalogPage: CatalogPage;
 
   test.beforeAll(async ({ rhdh }) => {

--- a/workspaces/backstage/e2e-tests/tests/specs/github-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-discovery.spec.ts
@@ -12,60 +12,63 @@ test.describe(
     ],
   },
   () => {
-  let catalogPage: CatalogPage;
+    let catalogPage: CatalogPage;
 
-  test.beforeAll(async ({ rhdh }) => {
-    // Allow time for deployment + 1 min provider refresh delay + browser setup
-    test.setTimeout(10 * 60 * 1000);
+    test.beforeAll(async ({ rhdh }) => {
+      // Allow time for deployment + 1 min provider refresh delay + browser setup
+      test.setTimeout(10 * 60 * 1000);
 
-    await rhdh.configure({
-      auth: "guest",
-      appConfig: "tests/config/github-discovery/app-config-rhdh.yaml",
-      secrets: "tests/config/github-discovery/rhdh-secrets.yaml",
-      dynamicPlugins: "tests/config/github-discovery/dynamic-plugins.yaml",
+      await rhdh.configure({
+        auth: "guest",
+        appConfig: "tests/config/github-discovery/app-config-rhdh.yaml",
+        secrets: "tests/config/github-discovery/rhdh-secrets.yaml",
+        dynamicPlugins: "tests/config/github-discovery/dynamic-plugins.yaml",
+      });
+      await rhdh.deploy();
+      // Wait 1 minute for github provider to refresh entities before running tests
+      await new Promise((resolve) => setTimeout(resolve, 1 * 60 * 1000));
     });
-    await rhdh.deploy();
-    // Wait 1 minute for github provider to refresh entities before running tests
-    await new Promise((resolve) => setTimeout(resolve, 1 * 60 * 1000));
-  });
 
-  test.beforeEach(async ({ loginHelper, page }) => {
-    await loginHelper.loginAsGuest();
-    catalogPage = new CatalogPage(page);
-    await catalogPage.go();
-  });
+    test.beforeEach(async ({ loginHelper, page }) => {
+      await loginHelper.loginAsGuest();
+      catalogPage = new CatalogPage(page);
+      await catalogPage.go();
+    });
 
-  test(`Discover Organization's Catalog`, async () => {
-    const organizationRepos = await GitHubApiHelper.getReposFromOrg(
-      RHDH_GITHUB_TEST_ORGANIZATION,
-    );
-    const reposNames: string[] = (organizationRepos as Array<{ name?: string }>)
-      .map((repo) => repo.name)
-      .filter((name): name is string => typeof name === "string")
-      // filter for subset of organization repositories where the repository name matches the entity name
-      .filter((name) => name.startsWith("test-annotator"))
-      .slice(0, 5);
-
-    const reposWithCatalogInfo: string[] = (
-      await Promise.all(
-        reposNames.map(async (repo) =>
-          (await GitHubApiHelper.fileExistsInRepo(
-            RHDH_GITHUB_TEST_ORGANIZATION,
-            repo,
-            "catalog-info.yaml",
-          ))
-            ? repo
-            : null,
-        ),
+    test(`Discover Organization's Catalog`, async () => {
+      const organizationRepos = await GitHubApiHelper.getReposFromOrg(
+        RHDH_GITHUB_TEST_ORGANIZATION,
+      );
+      const reposNames: string[] = (
+        organizationRepos as Array<{ name?: string }>
       )
-    ).filter((repo): repo is string => typeof repo === "string");
+        .map((repo) => repo.name)
+        .filter((name): name is string => typeof name === "string")
+        // filter for subset of organization repositories where the repository name matches the entity name
+        .filter((name) => name.startsWith("test-annotator"))
+        .slice(0, 5);
 
-    expect(reposWithCatalogInfo.length).toBeGreaterThan(0);
+      const reposWithCatalogInfo: string[] = (
+        await Promise.all(
+          reposNames.map(async (repo) =>
+            (await GitHubApiHelper.fileExistsInRepo(
+              RHDH_GITHUB_TEST_ORGANIZATION,
+              repo,
+              "catalog-info.yaml",
+            ))
+              ? repo
+              : null,
+          ),
+        )
+      ).filter((repo): repo is string => typeof repo === "string");
 
-    for (const repo of reposWithCatalogInfo) {
-      await catalogPage.search(repo);
-      const row = await catalogPage.tableRow(repo);
-      await expect(row).toBeVisible();
-    }
-  });
-});
+      expect(reposWithCatalogInfo.length).toBeGreaterThan(0);
+
+      for (const repo of reposWithCatalogInfo) {
+        await catalogPage.search(repo);
+        const row = await catalogPage.tableRow(repo);
+        await expect(row).toBeVisible();
+      }
+    });
+  },
+);

--- a/workspaces/backstage/e2e-tests/tests/specs/github-events-module.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-events-module.spec.ts
@@ -10,7 +10,15 @@ import { GitHubEventsHelper } from "../../support/api/github-events";
 import { requireEnv } from "@red-hat-developer-hub/e2e-test-utils/utils";
 import { GitHubApiHelper } from "../../support/api/github-api-helper";
 
-test.describe("GitHub Events Module", () => {
+test.describe(
+  "GitHub Events Module",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "backstage" },
+    ],
+  },
+  () => {
   let githubEventsHelper: GitHubEventsHelper;
   let staticToken: string;
   let rhdhBaseUrl: string;

--- a/workspaces/backstage/e2e-tests/tests/specs/github-events-module.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-events-module.spec.ts
@@ -10,92 +10,88 @@ import { GitHubEventsHelper } from "../../support/api/github-events";
 import { requireEnv } from "@red-hat-developer-hub/e2e-test-utils/utils";
 import { GitHubApiHelper } from "../../support/api/github-api-helper";
 
-test.describe(
-  "GitHub Events Module",
-  {
-    annotation: [
+test.describe("GitHub Events Module", () => {
+  let githubEventsHelper: GitHubEventsHelper;
+  let staticToken: string;
+  let rhdhBaseUrl: string;
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "backstage" },
-    ],
-  },
-  () => {
-    let githubEventsHelper: GitHubEventsHelper;
-    let staticToken: string;
-    let rhdhBaseUrl: string;
+    );
+    requireEnv("VAULT_GITHUB_APP_WEBHOOK_SECRET");
 
-    test.beforeAll(async ({ rhdh }) => {
-      requireEnv("VAULT_GITHUB_APP_WEBHOOK_SECRET");
-
-      await rhdh.configure({
-        auth: "keycloak",
-        appConfig: "tests/config/github-events/app-config-rhdh.yaml",
-        secrets: "tests/config/github-events/rhdh-secrets.yaml",
-        dynamicPlugins: "tests/config/github-events/dynamic-plugins.yaml",
-      });
-
-      await rhdh.deploy();
-
-      githubEventsHelper = await GitHubEventsHelper.build(
-        rhdh.rhdhUrl,
-        process.env.VAULT_GITHUB_APP_WEBHOOK_SECRET!,
-      );
-      rhdhBaseUrl = rhdh.rhdhUrl;
+    await rhdh.configure({
+      auth: "keycloak",
+      appConfig: "tests/config/github-events/app-config-rhdh.yaml",
+      secrets: "tests/config/github-events/rhdh-secrets.yaml",
+      dynamicPlugins: "tests/config/github-events/dynamic-plugins.yaml",
     });
 
-    test.beforeEach(async ({ loginHelper }) => {
-      await loginHelper.loginAsKeycloakUser();
-    });
+    await rhdh.deploy();
 
-    test("Events endpoint accepts signed GitHub webhook payloads", async () => {
-      const rawBody = JSON.stringify({
-        zen: "Test Payload.",
+    githubEventsHelper = await GitHubEventsHelper.build(
+      rhdh.rhdhUrl,
+      process.env.VAULT_GITHUB_APP_WEBHOOK_SECRET!,
+    );
+    rhdhBaseUrl = rhdh.rhdhUrl;
+  });
+
+  test.beforeEach(async ({ loginHelper }) => {
+    await loginHelper.loginAsKeycloakUser();
+  });
+
+  test("Events endpoint accepts signed GitHub webhook payloads", async () => {
+    const rawBody = JSON.stringify({
+      zen: "Test Payload.",
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      hook_id: 123456,
+      repository: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        hook_id: 123456,
-        repository: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          full_name: "test/repo",
-        },
-        organization: {
-          login: "test-org",
-        },
-      });
-
-      const secret = process.env.VAULT_GITHUB_APP_WEBHOOK_SECRET!;
-      const signature =
-        "sha256=" +
-        createHmac("sha256", secret).update(rawBody, "utf8").digest("hex");
-
-      const context = await request.newContext({
-        ignoreHTTPSErrors: true,
-      });
-
-      const response = await context.post("/api/events/http/github", {
-        headers: {
-          "Content-Type": "application/json",
-          "X-GitHub-Event": "ping",
-          "X-GitHub-Delivery": "test-delivery-id",
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          "X-Hub-Signature-256": signature,
-        },
-        data: rawBody,
-      });
-
-      expect(response.status()).toBe(202);
-
-      await context.dispose();
+        full_name: "test/repo",
+      },
+      organization: {
+        login: "test-org",
+      },
     });
 
-    test.describe.serial("GitHub Discovery", () => {
-      const catalogRepoName = `janus-test-github-events-test-${Date.now()}`;
-      const catalogRepoDetails = {
-        name: catalogRepoName,
-        url: `github.com/janus-qe/${catalogRepoName}`,
-        org: `github.com/janus-qe`,
-        owner: "janus-qe",
-      };
+    const secret = process.env.VAULT_GITHUB_APP_WEBHOOK_SECRET!;
+    const signature =
+      "sha256=" +
+      createHmac("sha256", secret).update(rawBody, "utf8").digest("hex");
 
-      test("Adding a new entity to the catalog", async ({ page, uiHelper }) => {
-        const catalogInfoYamlContent = `apiVersion: backstage.io/v1alpha1
+    const context = await request.newContext({
+      ignoreHTTPSErrors: true,
+    });
+
+    const response = await context.post("/api/events/http/github", {
+      headers: {
+        "Content-Type": "application/json",
+        "X-GitHub-Event": "ping",
+        "X-GitHub-Delivery": "test-delivery-id",
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        "X-Hub-Signature-256": signature,
+      },
+      data: rawBody,
+    });
+
+    expect(response.status()).toBe(202);
+
+    await context.dispose();
+  });
+
+  test.describe.serial("GitHub Discovery", () => {
+    const catalogRepoName = `janus-test-github-events-test-${Date.now()}`;
+    const catalogRepoDetails = {
+      name: catalogRepoName,
+      url: `github.com/janus-qe/${catalogRepoName}`,
+      org: `github.com/janus-qe`,
+      owner: "janus-qe",
+    };
+
+    test("Adding a new entity to the catalog", async ({ page, uiHelper }) => {
+      const catalogInfoYamlContent = `apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: ${catalogRepoName}
@@ -107,41 +103,41 @@ spec:
   lifecycle: unknown
   owner: user:default/janus-qe`;
 
-        await GitHubApiHelper.createGitHubRepoWithFile(
-          catalogRepoDetails.owner,
-          catalogRepoDetails.name,
-          "catalog-info.yaml",
-          catalogInfoYamlContent,
-        );
+      await GitHubApiHelper.createGitHubRepoWithFile(
+        catalogRepoDetails.owner,
+        catalogRepoDetails.name,
+        "catalog-info.yaml",
+        catalogInfoYamlContent,
+      );
 
-        await githubEventsHelper.sendPushEvent(
-          `janus-qe/${catalogRepoName}`,
-          "added",
-        );
+      await githubEventsHelper.sendPushEvent(
+        `janus-qe/${catalogRepoName}`,
+        "added",
+      );
 
-        await expect
-          .poll(
-            async () => {
-              await page.reload();
-              await uiHelper.openSidebar("Catalog");
-              await uiHelper.selectMuiBox("Kind", "Component");
-              await uiHelper.searchInputPlaceholder(catalogRepoName);
-              return await page
-                .getByRole("link", { name: catalogRepoName })
-                .isVisible();
-            },
-            {
-              message: `Component ${catalogRepoName} should appear in catalog`,
-              timeout: 60000,
-              intervals: [10000],
-            },
-          )
-          .toBe(true);
-      });
+      await expect
+        .poll(
+          async () => {
+            await page.reload();
+            await uiHelper.openSidebar("Catalog");
+            await uiHelper.selectMuiBox("Kind", "Component");
+            await uiHelper.searchInputPlaceholder(catalogRepoName);
+            return await page
+              .getByRole("link", { name: catalogRepoName })
+              .isVisible();
+          },
+          {
+            message: `Component ${catalogRepoName} should appear in catalog`,
+            timeout: 60000,
+            intervals: [10000],
+          },
+        )
+        .toBe(true);
+    });
 
-      test("Updating an entity in the catalog", async ({ page, uiHelper }) => {
-        const updatedDescription = "updated description";
-        const updatedCatalogInfoYaml = `apiVersion: backstage.io/v1alpha1
+    test("Updating an entity in the catalog", async ({ page, uiHelper }) => {
+      const updatedDescription = "updated description";
+      const updatedCatalogInfoYaml = `apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: ${catalogRepoName}
@@ -152,33 +148,102 @@ spec:
   type: other
   lifecycle: unknown
   owner: user:default/janus-qe`;
-        await GitHubApiHelper.updateFileInRepo(
-          catalogRepoDetails.owner,
-          catalogRepoDetails.name,
-          "catalog-info.yaml",
-          updatedCatalogInfoYaml,
-          "Update catalog-info.yaml description",
-        );
-        await githubEventsHelper.sendPushEvent(
-          `janus-qe/${catalogRepoName}`,
-          "modified",
-        );
+      await GitHubApiHelper.updateFileInRepo(
+        catalogRepoDetails.owner,
+        catalogRepoDetails.name,
+        "catalog-info.yaml",
+        updatedCatalogInfoYaml,
+        "Update catalog-info.yaml description",
+      );
+      await githubEventsHelper.sendPushEvent(
+        `janus-qe/${catalogRepoName}`,
+        "modified",
+      );
+
+      await expect
+        .poll(
+          async () => {
+            await page.reload();
+            await uiHelper.openSidebar("Catalog");
+            await uiHelper.selectMuiBox("Kind", "Component");
+            await uiHelper.searchInputPlaceholder(catalogRepoName);
+
+            await page.getByRole("link", { name: catalogRepoName }).click();
+            // wait for page to load
+            await uiHelper.verifyHeading("description");
+            return await page.getByText(updatedDescription).isVisible();
+          },
+          {
+            message: `Component ${catalogRepoName} should be updated with new description`,
+            timeout: 60000,
+            intervals: [10000],
+          },
+        )
+        .toBe(true);
+    });
+
+    test("Deleting an entity from the catalog", async ({ page, uiHelper }) => {
+      await GitHubApiHelper.deleteFileInRepo(
+        catalogRepoDetails.owner,
+        catalogRepoDetails.name,
+        "catalog-info.yaml",
+        "Remove catalog-info.yaml",
+      );
+      await githubEventsHelper.sendPushEvent(
+        `janus-qe/${catalogRepoName}`,
+        "removed",
+      );
+
+      await expect
+        .poll(
+          async () => {
+            await page.reload();
+            await uiHelper.openSidebar("Catalog");
+            await uiHelper.selectMuiBox("Kind", "Component");
+            await uiHelper.searchInputPlaceholder(catalogRepoName);
+            return await page
+              .getByRole("link", { name: catalogRepoName })
+              .isVisible();
+          },
+          {
+            message: `Component ${catalogRepoName} should be removed from catalog`,
+            timeout: 60000,
+            intervals: [10000],
+          },
+        )
+        .toBe(false);
+    });
+
+    test.afterAll(async () => {
+      await GitHubApiHelper.deleteGitHubRepo(
+        catalogRepoDetails.owner,
+        catalogRepoDetails.name,
+      );
+    });
+  });
+
+  test.describe("GitHub Organizational Data", () => {
+    // eslint-disable-next-line playwright/max-nested-describe
+    test.describe("Teams", () => {
+      const teamName = "test-team-" + Date.now();
+
+      test("Adding a new group", async ({ page, uiHelper }) => {
+        await GitHubApiHelper.createTeamInOrg("janus-qe", teamName);
+        await githubEventsHelper.sendTeamEvent("created", teamName, "janus-qe");
 
         await expect
           .poll(
             async () => {
               await page.reload();
               await uiHelper.openSidebar("Catalog");
-              await uiHelper.selectMuiBox("Kind", "Component");
-              await uiHelper.searchInputPlaceholder(catalogRepoName);
-
-              await page.getByRole("link", { name: catalogRepoName }).click();
-              // wait for page to load
-              await uiHelper.verifyHeading("description");
-              return await page.getByText(updatedDescription).isVisible();
+              await uiHelper.selectMuiBox("Kind", "Group");
+              await uiHelper.searchInputPlaceholder(teamName);
+              return await page
+                .getByRole("link", { name: teamName })
+                .isVisible();
             },
             {
-              message: `Component ${catalogRepoName} should be updated with new description`,
+              message: `Team ${teamName} should appear in catalog`,
               timeout: 60000,
               intervals: [10000],
             },
@@ -186,281 +251,196 @@ spec:
           .toBe(true);
       });
 
-      test("Deleting an entity from the catalog", async ({
-        page,
-        uiHelper,
-      }) => {
-        await GitHubApiHelper.deleteFileInRepo(
-          catalogRepoDetails.owner,
-          catalogRepoDetails.name,
-          "catalog-info.yaml",
-          "Remove catalog-info.yaml",
-        );
-        await githubEventsHelper.sendPushEvent(
-          `janus-qe/${catalogRepoName}`,
-          "removed",
-        );
+      test("Deleting a group", async ({ page, uiHelper }) => {
+        await GitHubApiHelper.deleteTeamFromOrg("janus-qe", teamName);
+
+        await githubEventsHelper.sendTeamEvent("deleted", teamName, "janus-qe");
 
         await expect
           .poll(
             async () => {
               await page.reload();
               await uiHelper.openSidebar("Catalog");
-              await uiHelper.selectMuiBox("Kind", "Component");
-              await uiHelper.searchInputPlaceholder(catalogRepoName);
+              await uiHelper.selectMuiBox("Kind", "Group");
+              await uiHelper.searchInputPlaceholder(teamName);
               return await page
-                .getByRole("link", { name: catalogRepoName })
+                .getByRole("link", { name: teamName })
                 .isVisible();
             },
             {
-              message: `Component ${catalogRepoName} should be removed from catalog`,
+              message: `Team ${teamName} should be removed from catalog`,
               timeout: 60000,
               intervals: [10000],
             },
           )
           .toBe(false);
       });
-
-      test.afterAll(async () => {
-        await GitHubApiHelper.deleteGitHubRepo(
-          catalogRepoDetails.owner,
-          catalogRepoDetails.name,
-        );
-      });
     });
 
-    test.describe("GitHub Organizational Data", () => {
-      // eslint-disable-next-line playwright/max-nested-describe
-      test.describe("Teams", () => {
-        const teamName = "test-team-" + Date.now();
+    // eslint-disable-next-line playwright/max-nested-describe
+    test.describe("Team Membership", () => {
+      let teamCreated = false;
+      let userAddedToTeam = false;
+      let teamName: string;
 
-        test("Adding a new group", async ({ page, uiHelper }) => {
-          await GitHubApiHelper.createTeamInOrg("janus-qe", teamName);
-          await githubEventsHelper.sendTeamEvent(
-            "created",
-            teamName,
-            "janus-qe",
-          );
+      test.beforeEach(async ({ page, uiHelper }) => {
+        if (!staticToken) {
+          const authApiHelper = new AuthApiHelper(page);
+          await page.goto(rhdhBaseUrl);
 
+          // Wait for page to be ready and user to be logged in
+          await uiHelper.waitForLoad();
+          await page.locator("nav").first().waitFor({ state: "visible" });
+
+          // Wait for user settings or profile button to appear
+          await page
+            .locator(
+              'button[data-testid="user-settings-menu"], [aria-label*="user"]',
+            )
+            .first()
+            .waitFor({ state: "visible", timeout: 10000 })
+            .catch(() => {});
+
+          // Retry getting token until session is ready
           await expect
             .poll(
               async () => {
-                await page.reload();
-                await uiHelper.openSidebar("Catalog");
-                await uiHelper.selectMuiBox("Kind", "Group");
-                await uiHelper.searchInputPlaceholder(teamName);
-                return await page
-                  .getByRole("link", { name: teamName })
-                  .isVisible();
+                try {
+                  const token = await authApiHelper.getToken();
+                  if (token && token.length > 0) {
+                    staticToken = token;
+                    return true;
+                  }
+                  return false;
+                } catch {
+                  return false;
+                }
               },
               {
-                message: `Team ${teamName} should appear in catalog`,
-                timeout: 60000,
-                intervals: [10000],
+                message:
+                  "Token should be retrieved after session is established",
+                timeout: 30000,
+                intervals: [2000],
               },
             )
             .toBe(true);
-        });
+        }
 
-        test("Deleting a group", async ({ page, uiHelper }) => {
-          await GitHubApiHelper.deleteTeamFromOrg("janus-qe", teamName);
+        teamName = "test-team-" + Date.now();
 
-          await githubEventsHelper.sendTeamEvent(
-            "deleted",
-            teamName,
-            "janus-qe",
-          );
+        await GitHubApiHelper.createTeamInOrg("janus-qe", teamName);
+        teamCreated = true;
 
-          await expect
-            .poll(
-              async () => {
-                await page.reload();
-                await uiHelper.openSidebar("Catalog");
-                await uiHelper.selectMuiBox("Kind", "Group");
-                await uiHelper.searchInputPlaceholder(teamName);
-                return await page
-                  .getByRole("link", { name: teamName })
-                  .isVisible();
-              },
-              {
-                message: `Team ${teamName} should be removed from catalog`,
-                timeout: 60000,
-                intervals: [10000],
-              },
-            )
-            .toBe(false);
-        });
+        await githubEventsHelper.sendTeamEvent("created", teamName, "janus-qe");
+
+        await new Promise((resolve) => setTimeout(resolve, 2000));
       });
 
-      // eslint-disable-next-line playwright/max-nested-describe
-      test.describe("Team Membership", () => {
-        let teamCreated = false;
-        let userAddedToTeam = false;
-        let teamName: string;
-
-        test.beforeEach(async ({ page, uiHelper }) => {
-          if (!staticToken) {
-            const authApiHelper = new AuthApiHelper(page);
-            await page.goto(rhdhBaseUrl);
-
-            // Wait for page to be ready and user to be logged in
-            await uiHelper.waitForLoad();
-            await page.locator("nav").first().waitFor({ state: "visible" });
-
-            // Wait for user settings or profile button to appear
-            await page
-              .locator(
-                'button[data-testid="user-settings-menu"], [aria-label*="user"]',
-              )
-              .first()
-              .waitFor({ state: "visible", timeout: 10000 })
-              .catch(() => {});
-
-            // Retry getting token until session is ready
-            await expect
-              .poll(
-                async () => {
-                  try {
-                    const token = await authApiHelper.getToken();
-                    if (token && token.length > 0) {
-                      staticToken = token;
-                      return true;
-                    }
-                    return false;
-                  } catch {
-                    return false;
-                  }
-                },
-                {
-                  message:
-                    "Token should be retrieved after session is established",
-                  timeout: 30000,
-                  intervals: [2000],
-                },
-              )
-              .toBe(true);
-          }
-
-          teamName = "test-team-" + Date.now();
-
-          await GitHubApiHelper.createTeamInOrg("janus-qe", teamName);
-          teamCreated = true;
-
-          await githubEventsHelper.sendTeamEvent(
-            "created",
-            teamName,
-            "janus-qe",
-          );
-
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-        });
-
-        test.afterEach(async () => {
-          if (userAddedToTeam) {
-            await GitHubApiHelper.removeUserFromTeam(
-              "janus-qe",
-              teamName,
-              "rhdh-qe",
-            );
-            userAddedToTeam = false;
-          }
-
-          if (teamCreated) {
-            await GitHubApiHelper.deleteTeamFromOrg("janus-qe", teamName);
-            teamCreated = false;
-          }
-        });
-
-        test("Adding a user to a group", async ({ uiHelper }) => {
-          await GitHubApiHelper.addUserToTeam("janus-qe", teamName, "rhdh-qe");
-          userAddedToTeam = true;
-
-          await githubEventsHelper.sendMembershipEvent(
-            "added",
-            "rhdh-qe",
-            teamName,
-            "janus-qe",
-          );
-
-          await uiHelper.waitForLoad(10000);
-
-          await expect
-            .poll(
-              () =>
-                CatalogApiHelper.getGroupMembers(
-                  rhdhBaseUrl,
-                  staticToken,
-                  teamName,
-                ),
-              {
-                message: "User should be added to group",
-                timeout: 60000,
-                intervals: [3000],
-              },
-            )
-            .toContain("rhdh-qe");
-        });
-
-        test("Removing a user from a group", async ({ uiHelper }) => {
-          await GitHubApiHelper.addUserToTeam("janus-qe", teamName, "rhdh-qe");
-          userAddedToTeam = true;
-
-          await githubEventsHelper.sendMembershipEvent(
-            "added",
-            "rhdh-qe",
-            teamName,
-            "janus-qe",
-          );
-
-          await expect
-            .poll(
-              () =>
-                CatalogApiHelper.getGroupMembers(
-                  rhdhBaseUrl,
-                  staticToken,
-                  teamName,
-                ),
-              {
-                message: "User should be added to group before removal test",
-                timeout: 60000,
-                intervals: [3000],
-              },
-            )
-            .toContain("rhdh-qe");
-
+      test.afterEach(async () => {
+        if (userAddedToTeam) {
           await GitHubApiHelper.removeUserFromTeam(
             "janus-qe",
             teamName,
             "rhdh-qe",
           );
           userAddedToTeam = false;
+        }
 
-          await githubEventsHelper.sendMembershipEvent(
-            "removed",
-            "rhdh-qe",
-            teamName,
-            "janus-qe",
-          );
+        if (teamCreated) {
+          await GitHubApiHelper.deleteTeamFromOrg("janus-qe", teamName);
+          teamCreated = false;
+        }
+      });
 
-          await uiHelper.waitForLoad(10000);
+      test("Adding a user to a group", async ({ uiHelper }) => {
+        await GitHubApiHelper.addUserToTeam("janus-qe", teamName, "rhdh-qe");
+        userAddedToTeam = true;
 
-          await expect
-            .poll(
-              () =>
-                CatalogApiHelper.getGroupMembers(
-                  rhdhBaseUrl,
-                  staticToken,
-                  teamName,
-                ),
-              {
-                message: "User should be removed from group",
-                timeout: 60000,
-                intervals: [3000],
-              },
-            )
-            .not.toContain("rhdh-qe");
-        });
+        await githubEventsHelper.sendMembershipEvent(
+          "added",
+          "rhdh-qe",
+          teamName,
+          "janus-qe",
+        );
+
+        await uiHelper.waitForLoad(10000);
+
+        await expect
+          .poll(
+            () =>
+              CatalogApiHelper.getGroupMembers(
+                rhdhBaseUrl,
+                staticToken,
+                teamName,
+              ),
+            {
+              message: "User should be added to group",
+              timeout: 60000,
+              intervals: [3000],
+            },
+          )
+          .toContain("rhdh-qe");
+      });
+
+      test("Removing a user from a group", async ({ uiHelper }) => {
+        await GitHubApiHelper.addUserToTeam("janus-qe", teamName, "rhdh-qe");
+        userAddedToTeam = true;
+
+        await githubEventsHelper.sendMembershipEvent(
+          "added",
+          "rhdh-qe",
+          teamName,
+          "janus-qe",
+        );
+
+        await expect
+          .poll(
+            () =>
+              CatalogApiHelper.getGroupMembers(
+                rhdhBaseUrl,
+                staticToken,
+                teamName,
+              ),
+            {
+              message: "User should be added to group before removal test",
+              timeout: 60000,
+              intervals: [3000],
+            },
+          )
+          .toContain("rhdh-qe");
+
+        await GitHubApiHelper.removeUserFromTeam(
+          "janus-qe",
+          teamName,
+          "rhdh-qe",
+        );
+        userAddedToTeam = false;
+
+        await githubEventsHelper.sendMembershipEvent(
+          "removed",
+          "rhdh-qe",
+          teamName,
+          "janus-qe",
+        );
+
+        await uiHelper.waitForLoad(10000);
+
+        await expect
+          .poll(
+            () =>
+              CatalogApiHelper.getGroupMembers(
+                rhdhBaseUrl,
+                staticToken,
+                teamName,
+              ),
+            {
+              message: "User should be removed from group",
+              timeout: 60000,
+              intervals: [3000],
+            },
+          )
+          .not.toContain("rhdh-qe");
       });
     });
-  },
-);
+  });
+});

--- a/workspaces/backstage/e2e-tests/tests/specs/github-events-module.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-events-module.spec.ts
@@ -19,83 +19,83 @@ test.describe(
     ],
   },
   () => {
-  let githubEventsHelper: GitHubEventsHelper;
-  let staticToken: string;
-  let rhdhBaseUrl: string;
+    let githubEventsHelper: GitHubEventsHelper;
+    let staticToken: string;
+    let rhdhBaseUrl: string;
 
-  test.beforeAll(async ({ rhdh }) => {
-    requireEnv("VAULT_GITHUB_APP_WEBHOOK_SECRET");
+    test.beforeAll(async ({ rhdh }) => {
+      requireEnv("VAULT_GITHUB_APP_WEBHOOK_SECRET");
 
-    await rhdh.configure({
-      auth: "keycloak",
-      appConfig: "tests/config/github-events/app-config-rhdh.yaml",
-      secrets: "tests/config/github-events/rhdh-secrets.yaml",
-      dynamicPlugins: "tests/config/github-events/dynamic-plugins.yaml",
+      await rhdh.configure({
+        auth: "keycloak",
+        appConfig: "tests/config/github-events/app-config-rhdh.yaml",
+        secrets: "tests/config/github-events/rhdh-secrets.yaml",
+        dynamicPlugins: "tests/config/github-events/dynamic-plugins.yaml",
+      });
+
+      await rhdh.deploy();
+
+      githubEventsHelper = await GitHubEventsHelper.build(
+        rhdh.rhdhUrl,
+        process.env.VAULT_GITHUB_APP_WEBHOOK_SECRET!,
+      );
+      rhdhBaseUrl = rhdh.rhdhUrl;
     });
 
-    await rhdh.deploy();
+    test.beforeEach(async ({ loginHelper }) => {
+      await loginHelper.loginAsKeycloakUser();
+    });
 
-    githubEventsHelper = await GitHubEventsHelper.build(
-      rhdh.rhdhUrl,
-      process.env.VAULT_GITHUB_APP_WEBHOOK_SECRET!,
-    );
-    rhdhBaseUrl = rhdh.rhdhUrl;
-  });
-
-  test.beforeEach(async ({ loginHelper }) => {
-    await loginHelper.loginAsKeycloakUser();
-  });
-
-  test("Events endpoint accepts signed GitHub webhook payloads", async () => {
-    const rawBody = JSON.stringify({
-      zen: "Test Payload.",
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      hook_id: 123456,
-      repository: {
+    test("Events endpoint accepts signed GitHub webhook payloads", async () => {
+      const rawBody = JSON.stringify({
+        zen: "Test Payload.",
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        full_name: "test/repo",
-      },
-      organization: {
-        login: "test-org",
-      },
+        hook_id: 123456,
+        repository: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          full_name: "test/repo",
+        },
+        organization: {
+          login: "test-org",
+        },
+      });
+
+      const secret = process.env.VAULT_GITHUB_APP_WEBHOOK_SECRET!;
+      const signature =
+        "sha256=" +
+        createHmac("sha256", secret).update(rawBody, "utf8").digest("hex");
+
+      const context = await request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+
+      const response = await context.post("/api/events/http/github", {
+        headers: {
+          "Content-Type": "application/json",
+          "X-GitHub-Event": "ping",
+          "X-GitHub-Delivery": "test-delivery-id",
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          "X-Hub-Signature-256": signature,
+        },
+        data: rawBody,
+      });
+
+      expect(response.status()).toBe(202);
+
+      await context.dispose();
     });
 
-    const secret = process.env.VAULT_GITHUB_APP_WEBHOOK_SECRET!;
-    const signature =
-      "sha256=" +
-      createHmac("sha256", secret).update(rawBody, "utf8").digest("hex");
+    test.describe.serial("GitHub Discovery", () => {
+      const catalogRepoName = `janus-test-github-events-test-${Date.now()}`;
+      const catalogRepoDetails = {
+        name: catalogRepoName,
+        url: `github.com/janus-qe/${catalogRepoName}`,
+        org: `github.com/janus-qe`,
+        owner: "janus-qe",
+      };
 
-    const context = await request.newContext({
-      ignoreHTTPSErrors: true,
-    });
-
-    const response = await context.post("/api/events/http/github", {
-      headers: {
-        "Content-Type": "application/json",
-        "X-GitHub-Event": "ping",
-        "X-GitHub-Delivery": "test-delivery-id",
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        "X-Hub-Signature-256": signature,
-      },
-      data: rawBody,
-    });
-
-    expect(response.status()).toBe(202);
-
-    await context.dispose();
-  });
-
-  test.describe.serial("GitHub Discovery", () => {
-    const catalogRepoName = `janus-test-github-events-test-${Date.now()}`;
-    const catalogRepoDetails = {
-      name: catalogRepoName,
-      url: `github.com/janus-qe/${catalogRepoName}`,
-      org: `github.com/janus-qe`,
-      owner: "janus-qe",
-    };
-
-    test("Adding a new entity to the catalog", async ({ page, uiHelper }) => {
-      const catalogInfoYamlContent = `apiVersion: backstage.io/v1alpha1
+      test("Adding a new entity to the catalog", async ({ page, uiHelper }) => {
+        const catalogInfoYamlContent = `apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: ${catalogRepoName}
@@ -107,41 +107,41 @@ spec:
   lifecycle: unknown
   owner: user:default/janus-qe`;
 
-      await GitHubApiHelper.createGitHubRepoWithFile(
-        catalogRepoDetails.owner,
-        catalogRepoDetails.name,
-        "catalog-info.yaml",
-        catalogInfoYamlContent,
-      );
+        await GitHubApiHelper.createGitHubRepoWithFile(
+          catalogRepoDetails.owner,
+          catalogRepoDetails.name,
+          "catalog-info.yaml",
+          catalogInfoYamlContent,
+        );
 
-      await githubEventsHelper.sendPushEvent(
-        `janus-qe/${catalogRepoName}`,
-        "added",
-      );
+        await githubEventsHelper.sendPushEvent(
+          `janus-qe/${catalogRepoName}`,
+          "added",
+        );
 
-      await expect
-        .poll(
-          async () => {
-            await page.reload();
-            await uiHelper.openSidebar("Catalog");
-            await uiHelper.selectMuiBox("Kind", "Component");
-            await uiHelper.searchInputPlaceholder(catalogRepoName);
-            return await page
-              .getByRole("link", { name: catalogRepoName })
-              .isVisible();
-          },
-          {
-            message: `Component ${catalogRepoName} should appear in catalog`,
-            timeout: 60000,
-            intervals: [10000],
-          },
-        )
-        .toBe(true);
-    });
+        await expect
+          .poll(
+            async () => {
+              await page.reload();
+              await uiHelper.openSidebar("Catalog");
+              await uiHelper.selectMuiBox("Kind", "Component");
+              await uiHelper.searchInputPlaceholder(catalogRepoName);
+              return await page
+                .getByRole("link", { name: catalogRepoName })
+                .isVisible();
+            },
+            {
+              message: `Component ${catalogRepoName} should appear in catalog`,
+              timeout: 60000,
+              intervals: [10000],
+            },
+          )
+          .toBe(true);
+      });
 
-    test("Updating an entity in the catalog", async ({ page, uiHelper }) => {
-      const updatedDescription = "updated description";
-      const updatedCatalogInfoYaml = `apiVersion: backstage.io/v1alpha1
+      test("Updating an entity in the catalog", async ({ page, uiHelper }) => {
+        const updatedDescription = "updated description";
+        const updatedCatalogInfoYaml = `apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: ${catalogRepoName}
@@ -152,102 +152,33 @@ spec:
   type: other
   lifecycle: unknown
   owner: user:default/janus-qe`;
-      await GitHubApiHelper.updateFileInRepo(
-        catalogRepoDetails.owner,
-        catalogRepoDetails.name,
-        "catalog-info.yaml",
-        updatedCatalogInfoYaml,
-        "Update catalog-info.yaml description",
-      );
-      await githubEventsHelper.sendPushEvent(
-        `janus-qe/${catalogRepoName}`,
-        "modified",
-      );
-
-      await expect
-        .poll(
-          async () => {
-            await page.reload();
-            await uiHelper.openSidebar("Catalog");
-            await uiHelper.selectMuiBox("Kind", "Component");
-            await uiHelper.searchInputPlaceholder(catalogRepoName);
-
-            await page.getByRole("link", { name: catalogRepoName }).click();
-            // wait for page to load
-            await uiHelper.verifyHeading("description");
-            return await page.getByText(updatedDescription).isVisible();
-          },
-          {
-            message: `Component ${catalogRepoName} should be updated with new description`,
-            timeout: 60000,
-            intervals: [10000],
-          },
-        )
-        .toBe(true);
-    });
-
-    test("Deleting an entity from the catalog", async ({ page, uiHelper }) => {
-      await GitHubApiHelper.deleteFileInRepo(
-        catalogRepoDetails.owner,
-        catalogRepoDetails.name,
-        "catalog-info.yaml",
-        "Remove catalog-info.yaml",
-      );
-      await githubEventsHelper.sendPushEvent(
-        `janus-qe/${catalogRepoName}`,
-        "removed",
-      );
-
-      await expect
-        .poll(
-          async () => {
-            await page.reload();
-            await uiHelper.openSidebar("Catalog");
-            await uiHelper.selectMuiBox("Kind", "Component");
-            await uiHelper.searchInputPlaceholder(catalogRepoName);
-            return await page
-              .getByRole("link", { name: catalogRepoName })
-              .isVisible();
-          },
-          {
-            message: `Component ${catalogRepoName} should be removed from catalog`,
-            timeout: 60000,
-            intervals: [10000],
-          },
-        )
-        .toBe(false);
-    });
-
-    test.afterAll(async () => {
-      await GitHubApiHelper.deleteGitHubRepo(
-        catalogRepoDetails.owner,
-        catalogRepoDetails.name,
-      );
-    });
-  });
-
-  test.describe("GitHub Organizational Data", () => {
-    // eslint-disable-next-line playwright/max-nested-describe
-    test.describe("Teams", () => {
-      const teamName = "test-team-" + Date.now();
-
-      test("Adding a new group", async ({ page, uiHelper }) => {
-        await GitHubApiHelper.createTeamInOrg("janus-qe", teamName);
-        await githubEventsHelper.sendTeamEvent("created", teamName, "janus-qe");
+        await GitHubApiHelper.updateFileInRepo(
+          catalogRepoDetails.owner,
+          catalogRepoDetails.name,
+          "catalog-info.yaml",
+          updatedCatalogInfoYaml,
+          "Update catalog-info.yaml description",
+        );
+        await githubEventsHelper.sendPushEvent(
+          `janus-qe/${catalogRepoName}`,
+          "modified",
+        );
 
         await expect
           .poll(
             async () => {
               await page.reload();
               await uiHelper.openSidebar("Catalog");
-              await uiHelper.selectMuiBox("Kind", "Group");
-              await uiHelper.searchInputPlaceholder(teamName);
-              return await page
-                .getByRole("link", { name: teamName })
-                .isVisible();
+              await uiHelper.selectMuiBox("Kind", "Component");
+              await uiHelper.searchInputPlaceholder(catalogRepoName);
+
+              await page.getByRole("link", { name: catalogRepoName }).click();
+              // wait for page to load
+              await uiHelper.verifyHeading("description");
+              return await page.getByText(updatedDescription).isVisible();
             },
             {
-              message: `Team ${teamName} should appear in catalog`,
+              message: `Component ${catalogRepoName} should be updated with new description`,
               timeout: 60000,
               intervals: [10000],
             },
@@ -255,196 +186,281 @@ spec:
           .toBe(true);
       });
 
-      test("Deleting a group", async ({ page, uiHelper }) => {
-        await GitHubApiHelper.deleteTeamFromOrg("janus-qe", teamName);
-
-        await githubEventsHelper.sendTeamEvent("deleted", teamName, "janus-qe");
+      test("Deleting an entity from the catalog", async ({
+        page,
+        uiHelper,
+      }) => {
+        await GitHubApiHelper.deleteFileInRepo(
+          catalogRepoDetails.owner,
+          catalogRepoDetails.name,
+          "catalog-info.yaml",
+          "Remove catalog-info.yaml",
+        );
+        await githubEventsHelper.sendPushEvent(
+          `janus-qe/${catalogRepoName}`,
+          "removed",
+        );
 
         await expect
           .poll(
             async () => {
               await page.reload();
               await uiHelper.openSidebar("Catalog");
-              await uiHelper.selectMuiBox("Kind", "Group");
-              await uiHelper.searchInputPlaceholder(teamName);
+              await uiHelper.selectMuiBox("Kind", "Component");
+              await uiHelper.searchInputPlaceholder(catalogRepoName);
               return await page
-                .getByRole("link", { name: teamName })
+                .getByRole("link", { name: catalogRepoName })
                 .isVisible();
             },
             {
-              message: `Team ${teamName} should be removed from catalog`,
+              message: `Component ${catalogRepoName} should be removed from catalog`,
               timeout: 60000,
               intervals: [10000],
             },
           )
           .toBe(false);
       });
+
+      test.afterAll(async () => {
+        await GitHubApiHelper.deleteGitHubRepo(
+          catalogRepoDetails.owner,
+          catalogRepoDetails.name,
+        );
+      });
     });
 
-    // eslint-disable-next-line playwright/max-nested-describe
-    test.describe("Team Membership", () => {
-      let teamCreated = false;
-      let userAddedToTeam = false;
-      let teamName: string;
+    test.describe("GitHub Organizational Data", () => {
+      // eslint-disable-next-line playwright/max-nested-describe
+      test.describe("Teams", () => {
+        const teamName = "test-team-" + Date.now();
 
-      test.beforeEach(async ({ page, uiHelper }) => {
-        if (!staticToken) {
-          const authApiHelper = new AuthApiHelper(page);
-          await page.goto(rhdhBaseUrl);
+        test("Adding a new group", async ({ page, uiHelper }) => {
+          await GitHubApiHelper.createTeamInOrg("janus-qe", teamName);
+          await githubEventsHelper.sendTeamEvent(
+            "created",
+            teamName,
+            "janus-qe",
+          );
 
-          // Wait for page to be ready and user to be logged in
-          await uiHelper.waitForLoad();
-          await page.locator("nav").first().waitFor({ state: "visible" });
-
-          // Wait for user settings or profile button to appear
-          await page
-            .locator(
-              'button[data-testid="user-settings-menu"], [aria-label*="user"]',
-            )
-            .first()
-            .waitFor({ state: "visible", timeout: 10000 })
-            .catch(() => {});
-
-          // Retry getting token until session is ready
           await expect
             .poll(
               async () => {
-                try {
-                  const token = await authApiHelper.getToken();
-                  if (token && token.length > 0) {
-                    staticToken = token;
-                    return true;
-                  }
-                  return false;
-                } catch {
-                  return false;
-                }
+                await page.reload();
+                await uiHelper.openSidebar("Catalog");
+                await uiHelper.selectMuiBox("Kind", "Group");
+                await uiHelper.searchInputPlaceholder(teamName);
+                return await page
+                  .getByRole("link", { name: teamName })
+                  .isVisible();
               },
               {
-                message:
-                  "Token should be retrieved after session is established",
-                timeout: 30000,
-                intervals: [2000],
+                message: `Team ${teamName} should appear in catalog`,
+                timeout: 60000,
+                intervals: [10000],
               },
             )
             .toBe(true);
-        }
+        });
 
-        teamName = "test-team-" + Date.now();
+        test("Deleting a group", async ({ page, uiHelper }) => {
+          await GitHubApiHelper.deleteTeamFromOrg("janus-qe", teamName);
 
-        await GitHubApiHelper.createTeamInOrg("janus-qe", teamName);
-        teamCreated = true;
+          await githubEventsHelper.sendTeamEvent(
+            "deleted",
+            teamName,
+            "janus-qe",
+          );
 
-        await githubEventsHelper.sendTeamEvent("created", teamName, "janus-qe");
-
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+          await expect
+            .poll(
+              async () => {
+                await page.reload();
+                await uiHelper.openSidebar("Catalog");
+                await uiHelper.selectMuiBox("Kind", "Group");
+                await uiHelper.searchInputPlaceholder(teamName);
+                return await page
+                  .getByRole("link", { name: teamName })
+                  .isVisible();
+              },
+              {
+                message: `Team ${teamName} should be removed from catalog`,
+                timeout: 60000,
+                intervals: [10000],
+              },
+            )
+            .toBe(false);
+        });
       });
 
-      test.afterEach(async () => {
-        if (userAddedToTeam) {
+      // eslint-disable-next-line playwright/max-nested-describe
+      test.describe("Team Membership", () => {
+        let teamCreated = false;
+        let userAddedToTeam = false;
+        let teamName: string;
+
+        test.beforeEach(async ({ page, uiHelper }) => {
+          if (!staticToken) {
+            const authApiHelper = new AuthApiHelper(page);
+            await page.goto(rhdhBaseUrl);
+
+            // Wait for page to be ready and user to be logged in
+            await uiHelper.waitForLoad();
+            await page.locator("nav").first().waitFor({ state: "visible" });
+
+            // Wait for user settings or profile button to appear
+            await page
+              .locator(
+                'button[data-testid="user-settings-menu"], [aria-label*="user"]',
+              )
+              .first()
+              .waitFor({ state: "visible", timeout: 10000 })
+              .catch(() => {});
+
+            // Retry getting token until session is ready
+            await expect
+              .poll(
+                async () => {
+                  try {
+                    const token = await authApiHelper.getToken();
+                    if (token && token.length > 0) {
+                      staticToken = token;
+                      return true;
+                    }
+                    return false;
+                  } catch {
+                    return false;
+                  }
+                },
+                {
+                  message:
+                    "Token should be retrieved after session is established",
+                  timeout: 30000,
+                  intervals: [2000],
+                },
+              )
+              .toBe(true);
+          }
+
+          teamName = "test-team-" + Date.now();
+
+          await GitHubApiHelper.createTeamInOrg("janus-qe", teamName);
+          teamCreated = true;
+
+          await githubEventsHelper.sendTeamEvent(
+            "created",
+            teamName,
+            "janus-qe",
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        });
+
+        test.afterEach(async () => {
+          if (userAddedToTeam) {
+            await GitHubApiHelper.removeUserFromTeam(
+              "janus-qe",
+              teamName,
+              "rhdh-qe",
+            );
+            userAddedToTeam = false;
+          }
+
+          if (teamCreated) {
+            await GitHubApiHelper.deleteTeamFromOrg("janus-qe", teamName);
+            teamCreated = false;
+          }
+        });
+
+        test("Adding a user to a group", async ({ uiHelper }) => {
+          await GitHubApiHelper.addUserToTeam("janus-qe", teamName, "rhdh-qe");
+          userAddedToTeam = true;
+
+          await githubEventsHelper.sendMembershipEvent(
+            "added",
+            "rhdh-qe",
+            teamName,
+            "janus-qe",
+          );
+
+          await uiHelper.waitForLoad(10000);
+
+          await expect
+            .poll(
+              () =>
+                CatalogApiHelper.getGroupMembers(
+                  rhdhBaseUrl,
+                  staticToken,
+                  teamName,
+                ),
+              {
+                message: "User should be added to group",
+                timeout: 60000,
+                intervals: [3000],
+              },
+            )
+            .toContain("rhdh-qe");
+        });
+
+        test("Removing a user from a group", async ({ uiHelper }) => {
+          await GitHubApiHelper.addUserToTeam("janus-qe", teamName, "rhdh-qe");
+          userAddedToTeam = true;
+
+          await githubEventsHelper.sendMembershipEvent(
+            "added",
+            "rhdh-qe",
+            teamName,
+            "janus-qe",
+          );
+
+          await expect
+            .poll(
+              () =>
+                CatalogApiHelper.getGroupMembers(
+                  rhdhBaseUrl,
+                  staticToken,
+                  teamName,
+                ),
+              {
+                message: "User should be added to group before removal test",
+                timeout: 60000,
+                intervals: [3000],
+              },
+            )
+            .toContain("rhdh-qe");
+
           await GitHubApiHelper.removeUserFromTeam(
             "janus-qe",
             teamName,
             "rhdh-qe",
           );
           userAddedToTeam = false;
-        }
 
-        if (teamCreated) {
-          await GitHubApiHelper.deleteTeamFromOrg("janus-qe", teamName);
-          teamCreated = false;
-        }
-      });
+          await githubEventsHelper.sendMembershipEvent(
+            "removed",
+            "rhdh-qe",
+            teamName,
+            "janus-qe",
+          );
 
-      test("Adding a user to a group", async ({ uiHelper }) => {
-        await GitHubApiHelper.addUserToTeam("janus-qe", teamName, "rhdh-qe");
-        userAddedToTeam = true;
+          await uiHelper.waitForLoad(10000);
 
-        await githubEventsHelper.sendMembershipEvent(
-          "added",
-          "rhdh-qe",
-          teamName,
-          "janus-qe",
-        );
-
-        await uiHelper.waitForLoad(10000);
-
-        await expect
-          .poll(
-            () =>
-              CatalogApiHelper.getGroupMembers(
-                rhdhBaseUrl,
-                staticToken,
-                teamName,
-              ),
-            {
-              message: "User should be added to group",
-              timeout: 60000,
-              intervals: [3000],
-            },
-          )
-          .toContain("rhdh-qe");
-      });
-
-      test("Removing a user from a group", async ({ uiHelper }) => {
-        await GitHubApiHelper.addUserToTeam("janus-qe", teamName, "rhdh-qe");
-        userAddedToTeam = true;
-
-        await githubEventsHelper.sendMembershipEvent(
-          "added",
-          "rhdh-qe",
-          teamName,
-          "janus-qe",
-        );
-
-        await expect
-          .poll(
-            () =>
-              CatalogApiHelper.getGroupMembers(
-                rhdhBaseUrl,
-                staticToken,
-                teamName,
-              ),
-            {
-              message: "User should be added to group before removal test",
-              timeout: 60000,
-              intervals: [3000],
-            },
-          )
-          .toContain("rhdh-qe");
-
-        await GitHubApiHelper.removeUserFromTeam(
-          "janus-qe",
-          teamName,
-          "rhdh-qe",
-        );
-        userAddedToTeam = false;
-
-        await githubEventsHelper.sendMembershipEvent(
-          "removed",
-          "rhdh-qe",
-          teamName,
-          "janus-qe",
-        );
-
-        await uiHelper.waitForLoad(10000);
-
-        await expect
-          .poll(
-            () =>
-              CatalogApiHelper.getGroupMembers(
-                rhdhBaseUrl,
-                staticToken,
-                teamName,
-              ),
-            {
-              message: "User should be removed from group",
-              timeout: 60000,
-              intervals: [3000],
-            },
-          )
-          .not.toContain("rhdh-qe");
+          await expect
+            .poll(
+              () =>
+                CatalogApiHelper.getGroupMembers(
+                  rhdhBaseUrl,
+                  staticToken,
+                  teamName,
+                ),
+              {
+                message: "User should be removed from group",
+                timeout: 60000,
+                intervals: [3000],
+              },
+            )
+            .not.toContain("rhdh-qe");
+        });
       });
     });
-  });
-});
+  },
+);

--- a/workspaces/backstage/e2e-tests/tests/specs/github-org-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-org-discovery.spec.ts
@@ -1,78 +1,72 @@
 import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { type UIhelper } from "@red-hat-developer-hub/e2e-test-utils/helpers";
 
-test.describe(
-  "GitHub Integration Org",
-  {
-    annotation: [
+test.describe("GitHub Integration Org", () => {
+  const verifyAppearanceInCatalog = async (
+    uiHelper: UIhelper,
+    kind: "Group" | "User",
+    checks: Array<{ search: string; expectedRows: string[] }>,
+  ) => {
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.selectMuiBox("Kind", kind);
+
+    for (const check of checks) {
+      await uiHelper.searchInputPlaceholder(check.search);
+      await uiHelper.verifyRowsInTable(check.expectedRows);
+    }
+  };
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "backstage" },
-    ],
-  },
-  () => {
-    const verifyAppearanceInCatalog = async (
-      uiHelper: UIhelper,
-      kind: "Group" | "User",
-      checks: Array<{ search: string; expectedRows: string[] }>,
-    ) => {
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.selectMuiBox("Kind", kind);
-
-      for (const check of checks) {
-        await uiHelper.searchInputPlaceholder(check.search);
-        await uiHelper.verifyRowsInTable(check.expectedRows);
-      }
-    };
-
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({
-        auth: "guest",
-        appConfig: "tests/config/github-org-discovery/app-config-rhdh.yaml",
-        secrets: "tests/config/github-org-discovery/rhdh-secrets.yaml",
-        dynamicPlugins:
-          "tests/config/github-org-discovery/dynamic-plugins.yaml",
-      });
-      await rhdh.deploy();
-      // Wait 1 minute for github provider to refresh entities before running tests
-      await new Promise((resolve) => setTimeout(resolve, 60_000));
+    );
+    await rhdh.configure({
+      auth: "guest",
+      appConfig: "tests/config/github-org-discovery/app-config-rhdh.yaml",
+      secrets: "tests/config/github-org-discovery/rhdh-secrets.yaml",
+      dynamicPlugins: "tests/config/github-org-discovery/dynamic-plugins.yaml",
     });
+    await rhdh.deploy();
+    // Wait 1 minute for github provider to refresh entities before running tests
+    await new Promise((resolve) => setTimeout(resolve, 60_000));
+  });
 
-    test.beforeEach(async ({ loginHelper }, testInfo) => {
-      if (testInfo.retry > 0) {
-        // Progressively increase timeout for retries.
-        test.setTimeout(testInfo.timeout + testInfo.timeout * 0.25);
-      }
+  test.beforeEach(async ({ loginHelper }, testInfo) => {
+    if (testInfo.retry > 0) {
+      // Progressively increase timeout for retries.
+      test.setTimeout(testInfo.timeout + testInfo.timeout * 0.25);
+    }
 
-      await loginHelper.loginAsGuest();
-    });
+    await loginHelper.loginAsGuest();
+  });
 
-    // eslint-disable-next-line playwright/expect-expect
-    test("Verify that fetching the groups of the first org works", async ({
-      uiHelper,
-    }) => {
-      await verifyAppearanceInCatalog(uiHelper, "Group", [
-        { search: "maintainers", expectedRows: ["maintainers"] },
-        { search: "r", expectedRows: ["rhdh-qes"] },
-      ]);
-    });
+  // eslint-disable-next-line playwright/expect-expect
+  test("Verify that fetching the groups of the first org works", async ({
+    uiHelper,
+  }) => {
+    await verifyAppearanceInCatalog(uiHelper, "Group", [
+      { search: "maintainers", expectedRows: ["maintainers"] },
+      { search: "r", expectedRows: ["rhdh-qes"] },
+    ]);
+  });
 
-    // eslint-disable-next-line playwright/expect-expect
-    test("Verify that fetching the groups of the second org works", async ({
-      uiHelper,
-    }) => {
-      await verifyAppearanceInCatalog(uiHelper, "Group", [
-        { search: "c", expectedRows: ["catalog-group"] },
-        { search: "j", expectedRows: ["janus-test"] },
-      ]);
-    });
+  // eslint-disable-next-line playwright/expect-expect
+  test("Verify that fetching the groups of the second org works", async ({
+    uiHelper,
+  }) => {
+    await verifyAppearanceInCatalog(uiHelper, "Group", [
+      { search: "c", expectedRows: ["catalog-group"] },
+      { search: "j", expectedRows: ["janus-test"] },
+    ]);
+  });
 
-    // eslint-disable-next-line playwright/expect-expect
-    test("Verify that fetching the users of the orgs works", async ({
-      uiHelper,
-    }) => {
-      await verifyAppearanceInCatalog(uiHelper, "User", [
-        { search: "r", expectedRows: ["rhdh-qe"] },
-      ]);
-    });
-  },
-);
+  // eslint-disable-next-line playwright/expect-expect
+  test("Verify that fetching the users of the orgs works", async ({
+    uiHelper,
+  }) => {
+    await verifyAppearanceInCatalog(uiHelper, "User", [
+      { search: "r", expectedRows: ["rhdh-qe"] },
+    ]);
+  });
+});

--- a/workspaces/backstage/e2e-tests/tests/specs/github-org-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-org-discovery.spec.ts
@@ -1,7 +1,15 @@
 import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { type UIhelper } from "@red-hat-developer-hub/e2e-test-utils/helpers";
 
-test.describe("GitHub Integration Org", () => {
+test.describe(
+  "GitHub Integration Org",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "backstage" },
+    ],
+  },
+  () => {
   const verifyAppearanceInCatalog = async (
     uiHelper: UIhelper,
     kind: "Group" | "User",

--- a/workspaces/backstage/e2e-tests/tests/specs/github-org-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/github-org-discovery.spec.ts
@@ -10,67 +10,69 @@ test.describe(
     ],
   },
   () => {
-  const verifyAppearanceInCatalog = async (
-    uiHelper: UIhelper,
-    kind: "Group" | "User",
-    checks: Array<{ search: string; expectedRows: string[] }>,
-  ) => {
-    await uiHelper.openSidebar("Catalog");
-    await uiHelper.selectMuiBox("Kind", kind);
+    const verifyAppearanceInCatalog = async (
+      uiHelper: UIhelper,
+      kind: "Group" | "User",
+      checks: Array<{ search: string; expectedRows: string[] }>,
+    ) => {
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.selectMuiBox("Kind", kind);
 
-    for (const check of checks) {
-      await uiHelper.searchInputPlaceholder(check.search);
-      await uiHelper.verifyRowsInTable(check.expectedRows);
-    }
-  };
+      for (const check of checks) {
+        await uiHelper.searchInputPlaceholder(check.search);
+        await uiHelper.verifyRowsInTable(check.expectedRows);
+      }
+    };
 
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({
-      auth: "guest",
-      appConfig: "tests/config/github-org-discovery/app-config-rhdh.yaml",
-      secrets: "tests/config/github-org-discovery/rhdh-secrets.yaml",
-      dynamicPlugins: "tests/config/github-org-discovery/dynamic-plugins.yaml",
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({
+        auth: "guest",
+        appConfig: "tests/config/github-org-discovery/app-config-rhdh.yaml",
+        secrets: "tests/config/github-org-discovery/rhdh-secrets.yaml",
+        dynamicPlugins:
+          "tests/config/github-org-discovery/dynamic-plugins.yaml",
+      });
+      await rhdh.deploy();
+      // Wait 1 minute for github provider to refresh entities before running tests
+      await new Promise((resolve) => setTimeout(resolve, 60_000));
     });
-    await rhdh.deploy();
-    // Wait 1 minute for github provider to refresh entities before running tests
-    await new Promise((resolve) => setTimeout(resolve, 60_000));
-  });
 
-  test.beforeEach(async ({ loginHelper }, testInfo) => {
-    if (testInfo.retry > 0) {
-      // Progressively increase timeout for retries.
-      test.setTimeout(testInfo.timeout + testInfo.timeout * 0.25);
-    }
+    test.beforeEach(async ({ loginHelper }, testInfo) => {
+      if (testInfo.retry > 0) {
+        // Progressively increase timeout for retries.
+        test.setTimeout(testInfo.timeout + testInfo.timeout * 0.25);
+      }
 
-    await loginHelper.loginAsGuest();
-  });
+      await loginHelper.loginAsGuest();
+    });
 
-  // eslint-disable-next-line playwright/expect-expect
-  test("Verify that fetching the groups of the first org works", async ({
-    uiHelper,
-  }) => {
-    await verifyAppearanceInCatalog(uiHelper, "Group", [
-      { search: "maintainers", expectedRows: ["maintainers"] },
-      { search: "r", expectedRows: ["rhdh-qes"] },
-    ]);
-  });
+    // eslint-disable-next-line playwright/expect-expect
+    test("Verify that fetching the groups of the first org works", async ({
+      uiHelper,
+    }) => {
+      await verifyAppearanceInCatalog(uiHelper, "Group", [
+        { search: "maintainers", expectedRows: ["maintainers"] },
+        { search: "r", expectedRows: ["rhdh-qes"] },
+      ]);
+    });
 
-  // eslint-disable-next-line playwright/expect-expect
-  test("Verify that fetching the groups of the second org works", async ({
-    uiHelper,
-  }) => {
-    await verifyAppearanceInCatalog(uiHelper, "Group", [
-      { search: "c", expectedRows: ["catalog-group"] },
-      { search: "j", expectedRows: ["janus-test"] },
-    ]);
-  });
+    // eslint-disable-next-line playwright/expect-expect
+    test("Verify that fetching the groups of the second org works", async ({
+      uiHelper,
+    }) => {
+      await verifyAppearanceInCatalog(uiHelper, "Group", [
+        { search: "c", expectedRows: ["catalog-group"] },
+        { search: "j", expectedRows: ["janus-test"] },
+      ]);
+    });
 
-  // eslint-disable-next-line playwright/expect-expect
-  test("Verify that fetching the users of the orgs works", async ({
-    uiHelper,
-  }) => {
-    await verifyAppearanceInCatalog(uiHelper, "User", [
-      { search: "r", expectedRows: ["rhdh-qe"] },
-    ]);
-  });
-});
+    // eslint-disable-next-line playwright/expect-expect
+    test("Verify that fetching the users of the orgs works", async ({
+      uiHelper,
+    }) => {
+      await verifyAppearanceInCatalog(uiHelper, "User", [
+        { search: "r", expectedRows: ["rhdh-qe"] },
+      ]);
+    });
+  },
+);

--- a/workspaces/backstage/e2e-tests/tests/specs/gitlab-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/gitlab-discovery.spec.ts
@@ -1,52 +1,45 @@
 import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { requireEnv } from "@red-hat-developer-hub/e2e-test-utils/utils";
 
-test.describe(
-  "gitlab discovery UI tests",
-  {
-    annotation: [
+test.describe("gitlab discovery UI tests", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "backstage" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      requireEnv("VAULT_GITLAB_TOKEN_DECODED");
+    );
+    requireEnv("VAULT_GITLAB_TOKEN_DECODED");
 
-      await rhdh.configure({
-        auth: "guest",
-        appConfig: "tests/config/gitlab-discovery/app-config-rhdh.yaml",
-        secrets: "tests/config/gitlab-discovery/rhdh-secrets.yaml",
-        dynamicPlugins: "tests/config/gitlab-discovery/dynamic-plugins.yaml",
-      });
-
-      await rhdh.deploy();
+    await rhdh.configure({
+      auth: "guest",
+      appConfig: "tests/config/gitlab-discovery/app-config-rhdh.yaml",
+      secrets: "tests/config/gitlab-discovery/rhdh-secrets.yaml",
+      dynamicPlugins: "tests/config/gitlab-discovery/dynamic-plugins.yaml",
     });
 
-    test.beforeEach(async ({ loginHelper, uiHelper }) => {
-      await loginHelper.loginAsGuest();
-      await uiHelper.openSidebar("Catalog");
-    });
+    await rhdh.deploy();
+  });
 
-    test("GitLab integration for discovering catalog entities from GitLab", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.dismissQuickstartIfVisible();
+  test.beforeEach(async ({ loginHelper, uiHelper }) => {
+    await loginHelper.loginAsGuest();
+    await uiHelper.openSidebar("Catalog");
+  });
 
-      await page
-        .getByRole("textbox", { name: "Search" })
-        .waitFor({ state: "visible" });
-      await uiHelper.searchInputPlaceholder("scaffoldedForm");
-      await uiHelper.verifyTextVisible("scaffoldedForm-test", true, 10_000);
-      await uiHelper.clickLink("scaffoldedForm-test");
-      await uiHelper.verifyHeading("scaffoldedForm-test");
-      await uiHelper.verifyText("My Description");
-      await uiHelper.verifyText("experimental");
-      await uiHelper.verifyText("website");
-      await expect(
-        page.getByRole("link", { name: "View Source" }),
-      ).toBeVisible();
-    });
-  },
-);
+  test("GitLab integration for discovering catalog entities from GitLab", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.dismissQuickstartIfVisible();
+
+    await page
+      .getByRole("textbox", { name: "Search" })
+      .waitFor({ state: "visible" });
+    await uiHelper.searchInputPlaceholder("scaffoldedForm");
+    await uiHelper.verifyTextVisible("scaffoldedForm-test", true, 10_000);
+    await uiHelper.clickLink("scaffoldedForm-test");
+    await uiHelper.verifyHeading("scaffoldedForm-test");
+    await uiHelper.verifyText("My Description");
+    await uiHelper.verifyText("experimental");
+    await uiHelper.verifyText("website");
+    await expect(page.getByRole("link", { name: "View Source" })).toBeVisible();
+  });
+});

--- a/workspaces/backstage/e2e-tests/tests/specs/gitlab-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/gitlab-discovery.spec.ts
@@ -10,40 +10,43 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    requireEnv("VAULT_GITLAB_TOKEN_DECODED");
+    test.beforeAll(async ({ rhdh }) => {
+      requireEnv("VAULT_GITLAB_TOKEN_DECODED");
 
-    await rhdh.configure({
-      auth: "guest",
-      appConfig: "tests/config/gitlab-discovery/app-config-rhdh.yaml",
-      secrets: "tests/config/gitlab-discovery/rhdh-secrets.yaml",
-      dynamicPlugins: "tests/config/gitlab-discovery/dynamic-plugins.yaml",
+      await rhdh.configure({
+        auth: "guest",
+        appConfig: "tests/config/gitlab-discovery/app-config-rhdh.yaml",
+        secrets: "tests/config/gitlab-discovery/rhdh-secrets.yaml",
+        dynamicPlugins: "tests/config/gitlab-discovery/dynamic-plugins.yaml",
+      });
+
+      await rhdh.deploy();
     });
 
-    await rhdh.deploy();
-  });
+    test.beforeEach(async ({ loginHelper, uiHelper }) => {
+      await loginHelper.loginAsGuest();
+      await uiHelper.openSidebar("Catalog");
+    });
 
-  test.beforeEach(async ({ loginHelper, uiHelper }) => {
-    await loginHelper.loginAsGuest();
-    await uiHelper.openSidebar("Catalog");
-  });
+    test("GitLab integration for discovering catalog entities from GitLab", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.dismissQuickstartIfVisible();
 
-  test("GitLab integration for discovering catalog entities from GitLab", async ({
-    page,
-    uiHelper,
-  }) => {
-    await uiHelper.dismissQuickstartIfVisible();
-
-    await page
-      .getByRole("textbox", { name: "Search" })
-      .waitFor({ state: "visible" });
-    await uiHelper.searchInputPlaceholder("scaffoldedForm");
-    await uiHelper.verifyTextVisible("scaffoldedForm-test", true, 10_000);
-    await uiHelper.clickLink("scaffoldedForm-test");
-    await uiHelper.verifyHeading("scaffoldedForm-test");
-    await uiHelper.verifyText("My Description");
-    await uiHelper.verifyText("experimental");
-    await uiHelper.verifyText("website");
-    await expect(page.getByRole("link", { name: "View Source" })).toBeVisible();
-  });
-});
+      await page
+        .getByRole("textbox", { name: "Search" })
+        .waitFor({ state: "visible" });
+      await uiHelper.searchInputPlaceholder("scaffoldedForm");
+      await uiHelper.verifyTextVisible("scaffoldedForm-test", true, 10_000);
+      await uiHelper.clickLink("scaffoldedForm-test");
+      await uiHelper.verifyHeading("scaffoldedForm-test");
+      await uiHelper.verifyText("My Description");
+      await uiHelper.verifyText("experimental");
+      await uiHelper.verifyText("website");
+      await expect(
+        page.getByRole("link", { name: "View Source" }),
+      ).toBeVisible();
+    });
+  },
+);

--- a/workspaces/backstage/e2e-tests/tests/specs/gitlab-discovery.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/gitlab-discovery.spec.ts
@@ -1,7 +1,15 @@
 import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { requireEnv } from "@red-hat-developer-hub/e2e-test-utils/utils";
 
-test.describe("gitlab discovery UI tests", () => {
+test.describe(
+  "gitlab discovery UI tests",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "backstage" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     requireEnv("VAULT_GITLAB_TOKEN_DECODED");
 

--- a/workspaces/backstage/e2e-tests/tests/specs/kubernetes-rbac.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/kubernetes-rbac.spec.ts
@@ -11,182 +11,169 @@ import { KUBERNETES_COMPONENTS } from "../../support/pages/kubernetes-po";
 
 const $pipe = $({ stdio: "pipe" });
 
-test.describe(
-  "Kubernetes",
-  {
-    annotation: [
+test.describe("Kubernetes", () => {
+  let kubernetesPage: KubernetesPage;
+  let clusterName: string;
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "backstage" },
-    ],
-  },
-  () => {
-    let kubernetesPage: KubernetesPage;
-    let clusterName: string;
+    );
+    requireEnv(
+      "KEYCLOAK_BASE_URL",
+      "KEYCLOAK_REALM",
+      "VAULT_KEYCLOAK_ADMIN_USERNAME",
+      "VAULT_KEYCLOAK_ADMIN_PASSWORD",
+    );
+    const namespace = rhdh.deploymentConfig.namespace;
 
-    test.beforeAll(async ({ rhdh }) => {
-      requireEnv(
-        "KEYCLOAK_BASE_URL",
-        "KEYCLOAK_REALM",
-        "VAULT_KEYCLOAK_ADMIN_USERNAME",
-        "VAULT_KEYCLOAK_ADMIN_PASSWORD",
+    // Setup Cluster Service Account
+    const rbacConfigsPath = WorkspacePaths.resolve(
+      "tests/config/kubernetes/rbac/",
+    );
+    await $`kubectl apply -f ${rbacConfigsPath}/service-account.yaml -n ${namespace}`;
+    await $`kubectl apply -f ${rbacConfigsPath}/service-account-secret.yaml -n ${namespace}`;
+
+    // Setup ClusterRoles and ClusterRoleBindings
+    await $`kubectl apply -f ${rbacConfigsPath}/cluster-role-k8s.yaml -n ${namespace}`;
+    await $`kubectl apply -f ${rbacConfigsPath}/cluster-role-binding-k8s.yaml -n ${namespace}`;
+
+    // Setup Kubernetes test resources
+    const resourcesConfigsPath = WorkspacePaths.resolve(
+      "tests/config/kubernetes/resources/",
+    );
+    await $`kubectl apply -f ${resourcesConfigsPath}/kubernetes-test.yaml -n ${namespace}`;
+    await $`kubectl apply -f ${resourcesConfigsPath}/kubernetes-test-ingress.yaml -n ${namespace}`;
+
+    // Setup variables
+    const clusterUrl = (
+      await $pipe`kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'`
+    ).stdout.trim();
+
+    const tokenB64 = (
+      await $pipe`kubectl -n ${namespace} get secret rhdh-k8s-plugin-secret -o jsonpath='{.data.token}'`
+    ).stdout.trim();
+
+    process.env.K8S_CLUSTER_URL = clusterUrl;
+    process.env.K8S_CLUSTER_NAME ??= "test-cluster";
+    clusterName = process.env.K8S_CLUSTER_NAME;
+    process.env.K8S_CLUSTER_TOKEN = Buffer.from(tokenB64, "base64").toString();
+
+    // Setup users
+    const keycloak = new KeycloakHelper();
+    await keycloak.connect({
+      baseUrl: process.env.KEYCLOAK_BASE_URL!,
+      username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
+      password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
+    });
+    for (const user of Object.values(KUBERNETES_USERS)) {
+      await keycloak.createUser(process.env.KEYCLOAK_REALM!, user);
+    }
+    // Setup RHDH RBAC permissions
+    await $`kubectl apply -f ${rbacConfigsPath}/rbac-configmap.yaml -n ${namespace}`;
+
+    await rhdh.configure({
+      auth: "keycloak",
+      appConfig: "tests/config/kubernetes/app-config-rhdh.yaml",
+      dynamicPlugins: "tests/config/kubernetes/dynamic-plugins.yaml",
+      secrets: "tests/config/kubernetes/rhdh-secrets.yaml",
+      valueFile: "tests/config/kubernetes/value_file.yaml",
+    });
+
+    await rhdh.deploy();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    kubernetesPage = new KubernetesPage(page);
+  });
+
+  test.describe("Verify that a user with permissions is able to access the Kubernetes plugin", () => {
+    test.beforeEach(async ({ page, loginHelper }) => {
+      await loginHelper.loginAsKeycloakUser(
+        KUBERNETES_USERS.kubernetesLogsReader.username,
+        KUBERNETES_USERS.kubernetesLogsReader.password,
       );
-      const namespace = rhdh.deploymentConfig.namespace;
+      await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
 
-      // Setup Cluster Service Account
-      const rbacConfigsPath = WorkspacePaths.resolve(
-        "tests/config/kubernetes/rbac/",
+      await page
+        .locator(KUBERNETES_COMPONENTS.MuiAccordion)
+        .getByRole("button", { name: `${clusterName} Cluster` })
+        .click();
+    });
+
+    // eslint-disable-next-line playwright/expect-expect
+    test("Verify pods visibility in the Kubernetes tab", async () => {
+      await kubernetesPage.verifyDeployment("kubernetes-test");
+    });
+
+    // eslint-disable-next-line playwright/expect-expect
+    test("Verify pod logs visibility in the Kubernetes tab", async () => {
+      await kubernetesPage.verifyPodLogs(
+        "kubernetes-test",
+        "kubernetes-test",
+        true,
       );
-      await $`kubectl apply -f ${rbacConfigsPath}/service-account.yaml -n ${namespace}`;
-      await $`kubectl apply -f ${rbacConfigsPath}/service-account-secret.yaml -n ${namespace}`;
+    });
+  });
 
-      // Setup ClusterRoles and ClusterRoleBindings
-      await $`kubectl apply -f ${rbacConfigsPath}/cluster-role-k8s.yaml -n ${namespace}`;
-      await $`kubectl apply -f ${rbacConfigsPath}/cluster-role-binding-k8s.yaml -n ${namespace}`;
-
-      // Setup Kubernetes test resources
-      const resourcesConfigsPath = WorkspacePaths.resolve(
-        "tests/config/kubernetes/resources/",
+  test.describe("Verify that a user without permissions is not able to access parts of the Kubernetes plugin", () => {
+    // User is able to read from the catalog
+    // User is unable to read kubernetes resources / clusters and use kubernetes proxy (needed for pod logs)
+    test("Verify pods are not visible in the Kubernetes tab", async ({
+      page,
+      loginHelper,
+    }) => {
+      await loginHelper.loginAsKeycloakUser(
+        KUBERNETES_USERS.noKubernetesAccess.username,
+        KUBERNETES_USERS.noKubernetesAccess.password,
       );
-      await $`kubectl apply -f ${resourcesConfigsPath}/kubernetes-test.yaml -n ${namespace}`;
-      await $`kubectl apply -f ${resourcesConfigsPath}/kubernetes-test-ingress.yaml -n ${namespace}`;
+      await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
 
-      // Setup variables
-      const clusterUrl = (
-        await $pipe`kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'`
-      ).stdout.trim();
-
-      const tokenB64 = (
-        await $pipe`kubectl -n ${namespace} get secret rhdh-k8s-plugin-secret -o jsonpath='{.data.token}'`
-      ).stdout.trim();
-
-      process.env.K8S_CLUSTER_URL = clusterUrl;
-      process.env.K8S_CLUSTER_NAME ??= "test-cluster";
-      clusterName = process.env.K8S_CLUSTER_NAME;
-      process.env.K8S_CLUSTER_TOKEN = Buffer.from(
-        tokenB64,
-        "base64",
-      ).toString();
-
-      // Setup users
-      const keycloak = new KeycloakHelper();
-      await keycloak.connect({
-        baseUrl: process.env.KEYCLOAK_BASE_URL!,
-        username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
-        password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
-      });
-      for (const user of Object.values(KUBERNETES_USERS)) {
-        await keycloak.createUser(process.env.KEYCLOAK_REALM!, user);
-      }
-      // Setup RHDH RBAC permissions
-      await $`kubectl apply -f ${rbacConfigsPath}/rbac-configmap.yaml -n ${namespace}`;
-
-      await rhdh.configure({
-        auth: "keycloak",
-        appConfig: "tests/config/kubernetes/app-config-rhdh.yaml",
-        dynamicPlugins: "tests/config/kubernetes/dynamic-plugins.yaml",
-        secrets: "tests/config/kubernetes/rhdh-secrets.yaml",
-        valueFile: "tests/config/kubernetes/value_file.yaml",
-      });
-
-      await rhdh.deploy();
+      await expect(
+        page.locator("h6").filter({ hasText: "Warning: Permission required" }),
+      ).toBeVisible();
     });
 
-    test.beforeEach(async ({ page }) => {
-      kubernetesPage = new KubernetesPage(page);
-    });
-
-    test.describe("Verify that a user with permissions is able to access the Kubernetes plugin", () => {
-      test.beforeEach(async ({ page, loginHelper }) => {
-        await loginHelper.loginAsKeycloakUser(
-          KUBERNETES_USERS.kubernetesLogsReader.username,
-          KUBERNETES_USERS.kubernetesLogsReader.password,
-        );
-        await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
-
-        await page
-          .locator(KUBERNETES_COMPONENTS.MuiAccordion)
-          .getByRole("button", { name: `${clusterName} Cluster` })
-          .click();
-      });
-
-      // eslint-disable-next-line playwright/expect-expect
-      test("Verify pods visibility in the Kubernetes tab", async () => {
-        await kubernetesPage.verifyDeployment("kubernetes-test");
-      });
-
-      // eslint-disable-next-line playwright/expect-expect
-      test("Verify pod logs visibility in the Kubernetes tab", async () => {
-        await kubernetesPage.verifyPodLogs(
-          "kubernetes-test",
-          "kubernetes-test",
-          true,
-        );
-      });
-    });
-
-    test.describe("Verify that a user without permissions is not able to access parts of the Kubernetes plugin", () => {
-      // User is able to read from the catalog
-      // User is unable to read kubernetes resources / clusters and use kubernetes proxy (needed for pod logs)
-      test("Verify pods are not visible in the Kubernetes tab", async ({
-        page,
-        loginHelper,
-      }) => {
-        await loginHelper.loginAsKeycloakUser(
-          KUBERNETES_USERS.noKubernetesAccess.username,
-          KUBERNETES_USERS.noKubernetesAccess.password,
-        );
-        await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
-
-        await expect(
-          page
-            .locator("h6")
-            .filter({ hasText: "Warning: Permission required" }),
-        ).toBeVisible();
-      });
-
-      // User is able to read from the catalog and read kubernetes resources and kubernetes clusters
-      // User is unable to use kubernetes proxy (needed for pod logs)
-      // eslint-disable-next-line playwright/expect-expect
-      test("Verify pod logs are not visible in the Kubernetes tab", async ({
-        page,
-        loginHelper,
-      }) => {
-        await loginHelper.loginAsKeycloakUser(
-          KUBERNETES_USERS.kubernetesReader.username,
-          KUBERNETES_USERS.kubernetesReader.password,
-        );
-        await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
-
-        await page
-          .locator(KUBERNETES_COMPONENTS.MuiAccordion)
-          .getByRole("button", { name: `${clusterName} Cluster` })
-          .click();
-        await kubernetesPage.verifyPodLogs(
-          "kubernetes-test",
-          "kubernetes-test",
-        );
-      });
-    });
-
-    test.afterAll(async () => {
-      requireEnv(
-        "KEYCLOAK_BASE_URL",
-        "KEYCLOAK_REALM",
-        "VAULT_KEYCLOAK_ADMIN_USERNAME",
-        "VAULT_KEYCLOAK_ADMIN_PASSWORD",
+    // User is able to read from the catalog and read kubernetes resources and kubernetes clusters
+    // User is unable to use kubernetes proxy (needed for pod logs)
+    // eslint-disable-next-line playwright/expect-expect
+    test("Verify pod logs are not visible in the Kubernetes tab", async ({
+      page,
+      loginHelper,
+    }) => {
+      await loginHelper.loginAsKeycloakUser(
+        KUBERNETES_USERS.kubernetesReader.username,
+        KUBERNETES_USERS.kubernetesReader.password,
       );
+      await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
 
-      // Need to re-authenticate anyway since admin access tokens expire
-      const keycloak = new KeycloakHelper();
-      await keycloak.connect({
-        baseUrl: process.env.KEYCLOAK_BASE_URL!,
-        username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
-        password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
-      });
-
-      for (const user of Object.values(KUBERNETES_USERS)) {
-        await keycloak.deleteUser(process.env.KEYCLOAK_REALM!, user.username);
-      }
+      await page
+        .locator(KUBERNETES_COMPONENTS.MuiAccordion)
+        .getByRole("button", { name: `${clusterName} Cluster` })
+        .click();
+      await kubernetesPage.verifyPodLogs("kubernetes-test", "kubernetes-test");
     });
-  },
-);
+  });
+
+  test.afterAll(async () => {
+    requireEnv(
+      "KEYCLOAK_BASE_URL",
+      "KEYCLOAK_REALM",
+      "VAULT_KEYCLOAK_ADMIN_USERNAME",
+      "VAULT_KEYCLOAK_ADMIN_PASSWORD",
+    );
+
+    // Need to re-authenticate anyway since admin access tokens expire
+    const keycloak = new KeycloakHelper();
+    await keycloak.connect({
+      baseUrl: process.env.KEYCLOAK_BASE_URL!,
+      username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
+      password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
+    });
+
+    for (const user of Object.values(KUBERNETES_USERS)) {
+      await keycloak.deleteUser(process.env.KEYCLOAK_REALM!, user.username);
+    }
+  });
+});

--- a/workspaces/backstage/e2e-tests/tests/specs/kubernetes-rbac.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/kubernetes-rbac.spec.ts
@@ -20,164 +20,173 @@ test.describe(
     ],
   },
   () => {
-  let kubernetesPage: KubernetesPage;
-  let clusterName: string;
+    let kubernetesPage: KubernetesPage;
+    let clusterName: string;
 
-  test.beforeAll(async ({ rhdh }) => {
-    requireEnv(
-      "KEYCLOAK_BASE_URL",
-      "KEYCLOAK_REALM",
-      "VAULT_KEYCLOAK_ADMIN_USERNAME",
-      "VAULT_KEYCLOAK_ADMIN_PASSWORD",
-    );
-    const namespace = rhdh.deploymentConfig.namespace;
-
-    // Setup Cluster Service Account
-    const rbacConfigsPath = WorkspacePaths.resolve(
-      "tests/config/kubernetes/rbac/",
-    );
-    await $`kubectl apply -f ${rbacConfigsPath}/service-account.yaml -n ${namespace}`;
-    await $`kubectl apply -f ${rbacConfigsPath}/service-account-secret.yaml -n ${namespace}`;
-
-    // Setup ClusterRoles and ClusterRoleBindings
-    await $`kubectl apply -f ${rbacConfigsPath}/cluster-role-k8s.yaml -n ${namespace}`;
-    await $`kubectl apply -f ${rbacConfigsPath}/cluster-role-binding-k8s.yaml -n ${namespace}`;
-
-    // Setup Kubernetes test resources
-    const resourcesConfigsPath = WorkspacePaths.resolve(
-      "tests/config/kubernetes/resources/",
-    );
-    await $`kubectl apply -f ${resourcesConfigsPath}/kubernetes-test.yaml -n ${namespace}`;
-    await $`kubectl apply -f ${resourcesConfigsPath}/kubernetes-test-ingress.yaml -n ${namespace}`;
-
-    // Setup variables
-    const clusterUrl = (
-      await $pipe`kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'`
-    ).stdout.trim();
-
-    const tokenB64 = (
-      await $pipe`kubectl -n ${namespace} get secret rhdh-k8s-plugin-secret -o jsonpath='{.data.token}'`
-    ).stdout.trim();
-
-    process.env.K8S_CLUSTER_URL = clusterUrl;
-    process.env.K8S_CLUSTER_NAME ??= "test-cluster";
-    clusterName = process.env.K8S_CLUSTER_NAME;
-    process.env.K8S_CLUSTER_TOKEN = Buffer.from(tokenB64, "base64").toString();
-
-    // Setup users
-    const keycloak = new KeycloakHelper();
-    await keycloak.connect({
-      baseUrl: process.env.KEYCLOAK_BASE_URL!,
-      username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
-      password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
-    });
-    for (const user of Object.values(KUBERNETES_USERS)) {
-      await keycloak.createUser(process.env.KEYCLOAK_REALM!, user);
-    }
-    // Setup RHDH RBAC permissions
-    await $`kubectl apply -f ${rbacConfigsPath}/rbac-configmap.yaml -n ${namespace}`;
-
-    await rhdh.configure({
-      auth: "keycloak",
-      appConfig: "tests/config/kubernetes/app-config-rhdh.yaml",
-      dynamicPlugins: "tests/config/kubernetes/dynamic-plugins.yaml",
-      secrets: "tests/config/kubernetes/rhdh-secrets.yaml",
-      valueFile: "tests/config/kubernetes/value_file.yaml",
-    });
-
-    await rhdh.deploy();
-  });
-
-  test.beforeEach(async ({ page }) => {
-    kubernetesPage = new KubernetesPage(page);
-  });
-
-  test.describe("Verify that a user with permissions is able to access the Kubernetes plugin", () => {
-    test.beforeEach(async ({ page, loginHelper }) => {
-      await loginHelper.loginAsKeycloakUser(
-        KUBERNETES_USERS.kubernetesLogsReader.username,
-        KUBERNETES_USERS.kubernetesLogsReader.password,
+    test.beforeAll(async ({ rhdh }) => {
+      requireEnv(
+        "KEYCLOAK_BASE_URL",
+        "KEYCLOAK_REALM",
+        "VAULT_KEYCLOAK_ADMIN_USERNAME",
+        "VAULT_KEYCLOAK_ADMIN_PASSWORD",
       );
-      await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
+      const namespace = rhdh.deploymentConfig.namespace;
 
-      await page
-        .locator(KUBERNETES_COMPONENTS.MuiAccordion)
-        .getByRole("button", { name: `${clusterName} Cluster` })
-        .click();
-    });
-
-    // eslint-disable-next-line playwright/expect-expect
-    test("Verify pods visibility in the Kubernetes tab", async () => {
-      await kubernetesPage.verifyDeployment("kubernetes-test");
-    });
-
-    // eslint-disable-next-line playwright/expect-expect
-    test("Verify pod logs visibility in the Kubernetes tab", async () => {
-      await kubernetesPage.verifyPodLogs(
-        "kubernetes-test",
-        "kubernetes-test",
-        true,
+      // Setup Cluster Service Account
+      const rbacConfigsPath = WorkspacePaths.resolve(
+        "tests/config/kubernetes/rbac/",
       );
-    });
-  });
+      await $`kubectl apply -f ${rbacConfigsPath}/service-account.yaml -n ${namespace}`;
+      await $`kubectl apply -f ${rbacConfigsPath}/service-account-secret.yaml -n ${namespace}`;
 
-  test.describe("Verify that a user without permissions is not able to access parts of the Kubernetes plugin", () => {
-    // User is able to read from the catalog
-    // User is unable to read kubernetes resources / clusters and use kubernetes proxy (needed for pod logs)
-    test("Verify pods are not visible in the Kubernetes tab", async ({
-      page,
-      loginHelper,
-    }) => {
-      await loginHelper.loginAsKeycloakUser(
-        KUBERNETES_USERS.noKubernetesAccess.username,
-        KUBERNETES_USERS.noKubernetesAccess.password,
+      // Setup ClusterRoles and ClusterRoleBindings
+      await $`kubectl apply -f ${rbacConfigsPath}/cluster-role-k8s.yaml -n ${namespace}`;
+      await $`kubectl apply -f ${rbacConfigsPath}/cluster-role-binding-k8s.yaml -n ${namespace}`;
+
+      // Setup Kubernetes test resources
+      const resourcesConfigsPath = WorkspacePaths.resolve(
+        "tests/config/kubernetes/resources/",
       );
-      await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
+      await $`kubectl apply -f ${resourcesConfigsPath}/kubernetes-test.yaml -n ${namespace}`;
+      await $`kubectl apply -f ${resourcesConfigsPath}/kubernetes-test-ingress.yaml -n ${namespace}`;
 
-      await expect(
-        page.locator("h6").filter({ hasText: "Warning: Permission required" }),
-      ).toBeVisible();
+      // Setup variables
+      const clusterUrl = (
+        await $pipe`kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'`
+      ).stdout.trim();
+
+      const tokenB64 = (
+        await $pipe`kubectl -n ${namespace} get secret rhdh-k8s-plugin-secret -o jsonpath='{.data.token}'`
+      ).stdout.trim();
+
+      process.env.K8S_CLUSTER_URL = clusterUrl;
+      process.env.K8S_CLUSTER_NAME ??= "test-cluster";
+      clusterName = process.env.K8S_CLUSTER_NAME;
+      process.env.K8S_CLUSTER_TOKEN = Buffer.from(
+        tokenB64,
+        "base64",
+      ).toString();
+
+      // Setup users
+      const keycloak = new KeycloakHelper();
+      await keycloak.connect({
+        baseUrl: process.env.KEYCLOAK_BASE_URL!,
+        username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
+        password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
+      });
+      for (const user of Object.values(KUBERNETES_USERS)) {
+        await keycloak.createUser(process.env.KEYCLOAK_REALM!, user);
+      }
+      // Setup RHDH RBAC permissions
+      await $`kubectl apply -f ${rbacConfigsPath}/rbac-configmap.yaml -n ${namespace}`;
+
+      await rhdh.configure({
+        auth: "keycloak",
+        appConfig: "tests/config/kubernetes/app-config-rhdh.yaml",
+        dynamicPlugins: "tests/config/kubernetes/dynamic-plugins.yaml",
+        secrets: "tests/config/kubernetes/rhdh-secrets.yaml",
+        valueFile: "tests/config/kubernetes/value_file.yaml",
+      });
+
+      await rhdh.deploy();
     });
 
-    // User is able to read from the catalog and read kubernetes resources and kubernetes clusters
-    // User is unable to use kubernetes proxy (needed for pod logs)
-    // eslint-disable-next-line playwright/expect-expect
-    test("Verify pod logs are not visible in the Kubernetes tab", async ({
-      page,
-      loginHelper,
-    }) => {
-      await loginHelper.loginAsKeycloakUser(
-        KUBERNETES_USERS.kubernetesReader.username,
-        KUBERNETES_USERS.kubernetesReader.password,
+    test.beforeEach(async ({ page }) => {
+      kubernetesPage = new KubernetesPage(page);
+    });
+
+    test.describe("Verify that a user with permissions is able to access the Kubernetes plugin", () => {
+      test.beforeEach(async ({ page, loginHelper }) => {
+        await loginHelper.loginAsKeycloakUser(
+          KUBERNETES_USERS.kubernetesLogsReader.username,
+          KUBERNETES_USERS.kubernetesLogsReader.password,
+        );
+        await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
+
+        await page
+          .locator(KUBERNETES_COMPONENTS.MuiAccordion)
+          .getByRole("button", { name: `${clusterName} Cluster` })
+          .click();
+      });
+
+      // eslint-disable-next-line playwright/expect-expect
+      test("Verify pods visibility in the Kubernetes tab", async () => {
+        await kubernetesPage.verifyDeployment("kubernetes-test");
+      });
+
+      // eslint-disable-next-line playwright/expect-expect
+      test("Verify pod logs visibility in the Kubernetes tab", async () => {
+        await kubernetesPage.verifyPodLogs(
+          "kubernetes-test",
+          "kubernetes-test",
+          true,
+        );
+      });
+    });
+
+    test.describe("Verify that a user without permissions is not able to access parts of the Kubernetes plugin", () => {
+      // User is able to read from the catalog
+      // User is unable to read kubernetes resources / clusters and use kubernetes proxy (needed for pod logs)
+      test("Verify pods are not visible in the Kubernetes tab", async ({
+        page,
+        loginHelper,
+      }) => {
+        await loginHelper.loginAsKeycloakUser(
+          KUBERNETES_USERS.noKubernetesAccess.username,
+          KUBERNETES_USERS.noKubernetesAccess.password,
+        );
+        await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
+
+        await expect(
+          page
+            .locator("h6")
+            .filter({ hasText: "Warning: Permission required" }),
+        ).toBeVisible();
+      });
+
+      // User is able to read from the catalog and read kubernetes resources and kubernetes clusters
+      // User is unable to use kubernetes proxy (needed for pod logs)
+      // eslint-disable-next-line playwright/expect-expect
+      test("Verify pod logs are not visible in the Kubernetes tab", async ({
+        page,
+        loginHelper,
+      }) => {
+        await loginHelper.loginAsKeycloakUser(
+          KUBERNETES_USERS.kubernetesReader.username,
+          KUBERNETES_USERS.kubernetesReader.password,
+        );
+        await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
+
+        await page
+          .locator(KUBERNETES_COMPONENTS.MuiAccordion)
+          .getByRole("button", { name: `${clusterName} Cluster` })
+          .click();
+        await kubernetesPage.verifyPodLogs(
+          "kubernetes-test",
+          "kubernetes-test",
+        );
+      });
+    });
+
+    test.afterAll(async () => {
+      requireEnv(
+        "KEYCLOAK_BASE_URL",
+        "KEYCLOAK_REALM",
+        "VAULT_KEYCLOAK_ADMIN_USERNAME",
+        "VAULT_KEYCLOAK_ADMIN_PASSWORD",
       );
-      await kubernetesPage.navigateToTabForComponent("Red Hat Developer Hub");
 
-      await page
-        .locator(KUBERNETES_COMPONENTS.MuiAccordion)
-        .getByRole("button", { name: `${clusterName} Cluster` })
-        .click();
-      await kubernetesPage.verifyPodLogs("kubernetes-test", "kubernetes-test");
+      // Need to re-authenticate anyway since admin access tokens expire
+      const keycloak = new KeycloakHelper();
+      await keycloak.connect({
+        baseUrl: process.env.KEYCLOAK_BASE_URL!,
+        username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
+        password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
+      });
+
+      for (const user of Object.values(KUBERNETES_USERS)) {
+        await keycloak.deleteUser(process.env.KEYCLOAK_REALM!, user.username);
+      }
     });
-  });
-
-  test.afterAll(async () => {
-    requireEnv(
-      "KEYCLOAK_BASE_URL",
-      "KEYCLOAK_REALM",
-      "VAULT_KEYCLOAK_ADMIN_USERNAME",
-      "VAULT_KEYCLOAK_ADMIN_PASSWORD",
-    );
-
-    // Need to re-authenticate anyway since admin access tokens expire
-    const keycloak = new KeycloakHelper();
-    await keycloak.connect({
-      baseUrl: process.env.KEYCLOAK_BASE_URL!,
-      username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
-      password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
-    });
-
-    for (const user of Object.values(KUBERNETES_USERS)) {
-      await keycloak.deleteUser(process.env.KEYCLOAK_REALM!, user.username);
-    }
-  });
-});
+  },
+);

--- a/workspaces/backstage/e2e-tests/tests/specs/kubernetes-rbac.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/kubernetes-rbac.spec.ts
@@ -11,7 +11,15 @@ import { KUBERNETES_COMPONENTS } from "../../support/pages/kubernetes-po";
 
 const $pipe = $({ stdio: "pipe" });
 
-test.describe("Kubernetes", () => {
+test.describe(
+  "Kubernetes",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "backstage" },
+    ],
+  },
+  () => {
   let kubernetesPage: KubernetesPage;
   let clusterName: string;
 

--- a/workspaces/backstage/e2e-tests/tests/specs/notifications.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/notifications.spec.ts
@@ -42,86 +42,87 @@ test.describe(
     ],
   },
   () => {
-  let notificationPage: NotificationPage;
+    let notificationPage: NotificationPage;
 
-  test.beforeAll(async ({ rhdh }) => {
-    const configBase = path.resolve(
-      process.cwd(),
-      "tests/config/notifications/",
-    );
-    await rhdh.configure({
-      valueFile: `${configBase}/value-file.yaml`,
-      dynamicPlugins: `${configBase}/dynamic-plugins.yaml`,
-      auth: "keycloak",
+    test.beforeAll(async ({ rhdh }) => {
+      const configBase = path.resolve(
+        process.cwd(),
+        "tests/config/notifications/",
+      );
+      await rhdh.configure({
+        valueFile: `${configBase}/value-file.yaml`,
+        dynamicPlugins: `${configBase}/dynamic-plugins.yaml`,
+        auth: "keycloak",
+      });
+      await rhdh.deploy();
     });
-    await rhdh.deploy();
-  });
 
-  test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-    notificationPage = new NotificationPage(page, uiHelper);
-    await loginHelper.loginAsKeycloakUser();
-  });
+    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+      notificationPage = new NotificationPage(page, uiHelper);
+      await loginHelper.loginAsKeycloakUser();
+    });
 
-  test.describe("Filter notifications", () => {
-    const severities = ["Critical", "High", "Normal", "Low"];
-    const notificationTitle = "UI Notification By Severity";
+    test.describe("Filter notifications", () => {
+      const severities = ["Critical", "High", "Normal", "Low"];
+      const notificationTitle = "UI Notification By Severity";
 
-    for (const severity of severities) {
-      test(`Filter notifications by severity - ${severity}`, async () => {
+      for (const severity of severities) {
+        test(`Filter notifications by severity - ${severity}`, async () => {
+          const notificationId = await createNotification(
+            notificationTitle,
+            severity,
+          );
+          await notificationPage.clickNotificationsNavBarItem();
+          await notificationPage.selectSeverity(severity);
+          await notificationPage.notificationContains(notificationId);
+        });
+      }
+    });
+
+    test.describe("Mark notification tests", () => {
+      test("Mark notification as read", async () => {
         const notificationId = await createNotification(
-          notificationTitle,
-          severity,
+          "UI Notification Mark as read",
         );
         await notificationPage.clickNotificationsNavBarItem();
-        await notificationPage.selectSeverity(severity);
-        await notificationPage.notificationContains(notificationId);
+        await notificationPage.notificationContains(`${notificationId}`);
+        await notificationPage.markNotificationAsRead(`${notificationId}`);
+        await notificationPage.viewRead();
+        await notificationPage.notificationContains(
+          new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
+        );
       });
-    }
-  });
 
-  test.describe("Mark notification tests", () => {
-    test("Mark notification as read", async () => {
-      const notificationId = await createNotification(
-        "UI Notification Mark as read",
-      );
-      await notificationPage.clickNotificationsNavBarItem();
-      await notificationPage.notificationContains(`${notificationId}`);
-      await notificationPage.markNotificationAsRead(`${notificationId}`);
-      await notificationPage.viewRead();
-      await notificationPage.notificationContains(
-        new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
-      );
-    });
+      test("Mark notification as unread", async () => {
+        const notificationId = await createNotification(
+          "UI Notification Mark as unread",
+        );
+        await notificationPage.clickNotificationsNavBarItem();
+        await notificationPage.notificationContains(`${notificationId}`);
+        await notificationPage.markNotificationAsRead(`${notificationId}`);
+        await notificationPage.viewRead();
+        await notificationPage.notificationContains(
+          new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
+        );
+        await notificationPage.markLastNotificationAsUnRead();
+        await notificationPage.viewUnRead();
+        await notificationPage.notificationContains(
+          new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
+        );
+      });
 
-    test("Mark notification as unread", async () => {
-      const notificationId = await createNotification(
-        "UI Notification Mark as unread",
-      );
-      await notificationPage.clickNotificationsNavBarItem();
-      await notificationPage.notificationContains(`${notificationId}`);
-      await notificationPage.markNotificationAsRead(`${notificationId}`);
-      await notificationPage.viewRead();
-      await notificationPage.notificationContains(
-        new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
-      );
-      await notificationPage.markLastNotificationAsUnRead();
-      await notificationPage.viewUnRead();
-      await notificationPage.notificationContains(
-        new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
-      );
+      test("Mark notification as saved", async () => {
+        const notificationId = await createNotification(
+          "UI Notification Mark as saved",
+        );
+        await notificationPage.clickNotificationsNavBarItem();
+        await notificationPage.selectNotification();
+        await notificationPage.saveSelected();
+        await notificationPage.viewSaved();
+        await notificationPage.notificationContains(
+          new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
+        );
+      });
     });
-
-    test("Mark notification as saved", async () => {
-      const notificationId = await createNotification(
-        "UI Notification Mark as saved",
-      );
-      await notificationPage.clickNotificationsNavBarItem();
-      await notificationPage.selectNotification();
-      await notificationPage.saveSelected();
-      await notificationPage.viewSaved();
-      await notificationPage.notificationContains(
-        new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
-      );
-    });
-  });
-});
+  },
+);

--- a/workspaces/backstage/e2e-tests/tests/specs/notifications.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/notifications.spec.ts
@@ -33,7 +33,15 @@ async function createNotification(
   return title;
 }
 
-test.describe("Backstage Notifications Plugin", () => {
+test.describe(
+  "Backstage Notifications Plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "backstage" },
+    ],
+  },
+  () => {
   let notificationPage: NotificationPage;
 
   test.beforeAll(async ({ rhdh }) => {

--- a/workspaces/backstage/e2e-tests/tests/specs/notifications.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/notifications.spec.ts
@@ -33,96 +33,91 @@ async function createNotification(
   return title;
 }
 
-test.describe(
-  "Backstage Notifications Plugin",
-  {
-    annotation: [
+test.describe("Backstage Notifications Plugin", () => {
+  let notificationPage: NotificationPage;
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "backstage" },
-    ],
-  },
-  () => {
-    let notificationPage: NotificationPage;
+    );
+    const configBase = path.resolve(
+      process.cwd(),
+      "tests/config/notifications/",
+    );
+    await rhdh.configure({
+      valueFile: `${configBase}/value-file.yaml`,
+      dynamicPlugins: `${configBase}/dynamic-plugins.yaml`,
+      auth: "keycloak",
+    });
+    await rhdh.deploy();
+  });
 
-    test.beforeAll(async ({ rhdh }) => {
-      const configBase = path.resolve(
-        process.cwd(),
-        "tests/config/notifications/",
+  test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+    notificationPage = new NotificationPage(page, uiHelper);
+    await loginHelper.loginAsKeycloakUser();
+  });
+
+  test.describe("Filter notifications", () => {
+    const severities = ["Critical", "High", "Normal", "Low"];
+    const notificationTitle = "UI Notification By Severity";
+
+    for (const severity of severities) {
+      test(`Filter notifications by severity - ${severity}`, async () => {
+        const notificationId = await createNotification(
+          notificationTitle,
+          severity,
+        );
+        await notificationPage.clickNotificationsNavBarItem();
+        await notificationPage.selectSeverity(severity);
+        await notificationPage.notificationContains(notificationId);
+      });
+    }
+  });
+
+  test.describe("Mark notification tests", () => {
+    test("Mark notification as read", async () => {
+      const notificationId = await createNotification(
+        "UI Notification Mark as read",
       );
-      await rhdh.configure({
-        valueFile: `${configBase}/value-file.yaml`,
-        dynamicPlugins: `${configBase}/dynamic-plugins.yaml`,
-        auth: "keycloak",
-      });
-      await rhdh.deploy();
+      await notificationPage.clickNotificationsNavBarItem();
+      await notificationPage.notificationContains(`${notificationId}`);
+      await notificationPage.markNotificationAsRead(`${notificationId}`);
+      await notificationPage.viewRead();
+      await notificationPage.notificationContains(
+        new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
+      );
     });
 
-    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-      notificationPage = new NotificationPage(page, uiHelper);
-      await loginHelper.loginAsKeycloakUser();
+    test("Mark notification as unread", async () => {
+      const notificationId = await createNotification(
+        "UI Notification Mark as unread",
+      );
+      await notificationPage.clickNotificationsNavBarItem();
+      await notificationPage.notificationContains(`${notificationId}`);
+      await notificationPage.markNotificationAsRead(`${notificationId}`);
+      await notificationPage.viewRead();
+      await notificationPage.notificationContains(
+        new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
+      );
+      await notificationPage.markLastNotificationAsUnRead();
+      await notificationPage.viewUnRead();
+      await notificationPage.notificationContains(
+        new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
+      );
     });
 
-    test.describe("Filter notifications", () => {
-      const severities = ["Critical", "High", "Normal", "Low"];
-      const notificationTitle = "UI Notification By Severity";
-
-      for (const severity of severities) {
-        test(`Filter notifications by severity - ${severity}`, async () => {
-          const notificationId = await createNotification(
-            notificationTitle,
-            severity,
-          );
-          await notificationPage.clickNotificationsNavBarItem();
-          await notificationPage.selectSeverity(severity);
-          await notificationPage.notificationContains(notificationId);
-        });
-      }
+    test("Mark notification as saved", async () => {
+      const notificationId = await createNotification(
+        "UI Notification Mark as saved",
+      );
+      await notificationPage.clickNotificationsNavBarItem();
+      await notificationPage.selectNotification();
+      await notificationPage.saveSelected();
+      await notificationPage.viewSaved();
+      await notificationPage.notificationContains(
+        new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
+      );
     });
-
-    test.describe("Mark notification tests", () => {
-      test("Mark notification as read", async () => {
-        const notificationId = await createNotification(
-          "UI Notification Mark as read",
-        );
-        await notificationPage.clickNotificationsNavBarItem();
-        await notificationPage.notificationContains(`${notificationId}`);
-        await notificationPage.markNotificationAsRead(`${notificationId}`);
-        await notificationPage.viewRead();
-        await notificationPage.notificationContains(
-          new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
-        );
-      });
-
-      test("Mark notification as unread", async () => {
-        const notificationId = await createNotification(
-          "UI Notification Mark as unread",
-        );
-        await notificationPage.clickNotificationsNavBarItem();
-        await notificationPage.notificationContains(`${notificationId}`);
-        await notificationPage.markNotificationAsRead(`${notificationId}`);
-        await notificationPage.viewRead();
-        await notificationPage.notificationContains(
-          new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
-        );
-        await notificationPage.markLastNotificationAsUnRead();
-        await notificationPage.viewUnRead();
-        await notificationPage.notificationContains(
-          new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
-        );
-      });
-
-      test("Mark notification as saved", async () => {
-        const notificationId = await createNotification(
-          "UI Notification Mark as saved",
-        );
-        await notificationPage.clickNotificationsNavBarItem();
-        await notificationPage.selectNotification();
-        await notificationPage.saveSelected();
-        await notificationPage.viewSaved();
-        await notificationPage.notificationContains(
-          new RegExp(`${notificationId}.*(a few seconds ago)|(a minute ago)`),
-        );
-      });
-    });
-  },
-);
+  });
+});

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -26,69 +26,70 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    // Allow time for deployment + 1 min provider refresh delay + browser setup
-    test.setTimeout(10 * 60 * 1000);
+    test.beforeAll(async ({ rhdh }) => {
+      // Allow time for deployment + 1 min provider refresh delay + browser setup
+      test.setTimeout(10 * 60 * 1000);
 
-    await rhdh.configure({
-      auth: "keycloak",
-      appConfig: "tests/config/techdocs/app-config-rhdh.yaml",
-      dynamicPlugins: "tests/config/techdocs/dynamic-plugins.yaml",
+      await rhdh.configure({
+        auth: "keycloak",
+        appConfig: "tests/config/techdocs/app-config-rhdh.yaml",
+        dynamicPlugins: "tests/config/techdocs/dynamic-plugins.yaml",
+      });
+
+      await rhdh.deploy();
     });
 
-    await rhdh.deploy();
-  });
+    test.beforeEach(async ({ loginHelper }) => {
+      await loginHelper.loginAsKeycloakUser();
+    });
 
-  test.beforeEach(async ({ loginHelper }) => {
-    await loginHelper.loginAsKeycloakUser();
-  });
+    test("Verify that TechDocs is visible in sidebar", async ({ uiHelper }) => {
+      await uiHelper.openSidebar("Docs");
+    });
 
-  test("Verify that TechDocs is visible in sidebar", async ({ uiHelper }) => {
-    await uiHelper.openSidebar("Docs");
-  });
+    test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.openSidebar("Docs");
+      await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
+      await uiHelper.waitForTitle("Getting Started running RHDH", 1);
+    });
 
-  test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({
-    page,
-    uiHelper,
-  }) => {
-    await uiHelper.openSidebar("Docs");
-    await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
-    await uiHelper.waitForTitle("Getting Started running RHDH", 1);
-  });
+    test("Verify that TechDocs entity tab page for Red Hat Developer Hub works", async ({
+      uiHelper,
+    }) => {
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.selectMuiBox("Kind", "Component");
+      await uiHelper.clickLink("Red Hat Developer Hub");
+      await uiHelper.clickTab("Docs");
+      await uiHelper.waitForTitle("Getting Started running RHDH", 1);
+    });
 
-  test("Verify that TechDocs entity tab page for Red Hat Developer Hub works", async ({
-    uiHelper,
-  }) => {
-    await uiHelper.openSidebar("Catalog");
-    await uiHelper.selectMuiBox("Kind", "Component");
-    await uiHelper.clickLink("Red Hat Developer Hub");
-    await uiHelper.clickTab("Docs");
-    await uiHelper.waitForTitle("Getting Started running RHDH", 1);
-  });
+    test("Verify that TechDocs Docs page for ReportIssue addon works", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.openSidebar("Docs");
+      await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
+      await page.waitForSelector("article a");
+      await docsTextHighlight(page);
+      const link = await page.waitForSelector("text=Open new Github issue");
+      expect(await link?.isVisible()).toBeTruthy();
+    });
 
-  test("Verify that TechDocs Docs page for ReportIssue addon works", async ({
-    page,
-    uiHelper,
-  }) => {
-    await uiHelper.openSidebar("Docs");
-    await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
-    await page.waitForSelector("article a");
-    await docsTextHighlight(page);
-    const link = await page.waitForSelector("text=Open new Github issue");
-    expect(await link?.isVisible()).toBeTruthy();
-  });
-
-  test("Verify that TechDocs entity tab page for ReportIssue addon works", async ({
-    page,
-    uiHelper,
-  }) => {
-    await uiHelper.openSidebar("Catalog");
-    await uiHelper.selectMuiBox("Kind", "Component");
-    await uiHelper.clickLink("Red Hat Developer Hub");
-    await uiHelper.clickTab("Docs");
-    await page.waitForSelector("article a");
-    await docsTextHighlight(page);
-    const link = await page.waitForSelector("text=Open new Github issue");
-    expect(await link?.isVisible()).toBeTruthy();
-  });
-});
+    test("Verify that TechDocs entity tab page for ReportIssue addon works", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.selectMuiBox("Kind", "Component");
+      await uiHelper.clickLink("Red Hat Developer Hub");
+      await uiHelper.clickTab("Docs");
+      await page.waitForSelector("article a");
+      await docsTextHighlight(page);
+      const link = await page.waitForSelector("text=Open new Github issue");
+      expect(await link?.isVisible()).toBeTruthy();
+    });
+  },
+);

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -17,7 +17,15 @@ async function docsTextHighlight(page: Page) {
   });
 }
 
-test.describe("TechDocs", () => {
+test.describe(
+  "TechDocs",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "backstage" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     // Allow time for deployment + 1 min provider refresh delay + browser setup
     test.setTimeout(10 * 60 * 1000);

--- a/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/techdocs.spec.ts
@@ -17,79 +17,74 @@ async function docsTextHighlight(page: Page) {
   });
 }
 
-test.describe(
-  "TechDocs",
-  {
-    annotation: [
+test.describe("TechDocs", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "backstage" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      // Allow time for deployment + 1 min provider refresh delay + browser setup
-      test.setTimeout(10 * 60 * 1000);
+    );
+    // Allow time for deployment + 1 min provider refresh delay + browser setup
+    test.setTimeout(10 * 60 * 1000);
 
-      await rhdh.configure({
-        auth: "keycloak",
-        appConfig: "tests/config/techdocs/app-config-rhdh.yaml",
-        dynamicPlugins: "tests/config/techdocs/dynamic-plugins.yaml",
-      });
-
-      await rhdh.deploy();
+    await rhdh.configure({
+      auth: "keycloak",
+      appConfig: "tests/config/techdocs/app-config-rhdh.yaml",
+      dynamicPlugins: "tests/config/techdocs/dynamic-plugins.yaml",
     });
 
-    test.beforeEach(async ({ loginHelper }) => {
-      await loginHelper.loginAsKeycloakUser();
-    });
+    await rhdh.deploy();
+  });
 
-    test("Verify that TechDocs is visible in sidebar", async ({ uiHelper }) => {
-      await uiHelper.openSidebar("Docs");
-    });
+  test.beforeEach(async ({ loginHelper }) => {
+    await loginHelper.loginAsKeycloakUser();
+  });
 
-    test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.openSidebar("Docs");
-      await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
-      await uiHelper.waitForTitle("Getting Started running RHDH", 1);
-    });
+  test("Verify that TechDocs is visible in sidebar", async ({ uiHelper }) => {
+    await uiHelper.openSidebar("Docs");
+  });
 
-    test("Verify that TechDocs entity tab page for Red Hat Developer Hub works", async ({
-      uiHelper,
-    }) => {
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.selectMuiBox("Kind", "Component");
-      await uiHelper.clickLink("Red Hat Developer Hub");
-      await uiHelper.clickTab("Docs");
-      await uiHelper.waitForTitle("Getting Started running RHDH", 1);
-    });
+  test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.openSidebar("Docs");
+    await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
+    await uiHelper.waitForTitle("Getting Started running RHDH", 1);
+  });
 
-    test("Verify that TechDocs Docs page for ReportIssue addon works", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.openSidebar("Docs");
-      await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
-      await page.waitForSelector("article a");
-      await docsTextHighlight(page);
-      const link = await page.waitForSelector("text=Open new Github issue");
-      expect(await link?.isVisible()).toBeTruthy();
-    });
+  test("Verify that TechDocs entity tab page for Red Hat Developer Hub works", async ({
+    uiHelper,
+  }) => {
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.selectMuiBox("Kind", "Component");
+    await uiHelper.clickLink("Red Hat Developer Hub");
+    await uiHelper.clickTab("Docs");
+    await uiHelper.waitForTitle("Getting Started running RHDH", 1);
+  });
 
-    test("Verify that TechDocs entity tab page for ReportIssue addon works", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.selectMuiBox("Kind", "Component");
-      await uiHelper.clickLink("Red Hat Developer Hub");
-      await uiHelper.clickTab("Docs");
-      await page.waitForSelector("article a");
-      await docsTextHighlight(page);
-      const link = await page.waitForSelector("text=Open new Github issue");
-      expect(await link?.isVisible()).toBeTruthy();
-    });
-  },
-);
+  test("Verify that TechDocs Docs page for ReportIssue addon works", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.openSidebar("Docs");
+    await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
+    await page.waitForSelector("article a");
+    await docsTextHighlight(page);
+    const link = await page.waitForSelector("text=Open new Github issue");
+    expect(await link?.isVisible()).toBeTruthy();
+  });
+
+  test("Verify that TechDocs entity tab page for ReportIssue addon works", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.selectMuiBox("Kind", "Component");
+    await uiHelper.clickLink("Red Hat Developer Hub");
+    await uiHelper.clickTab("Docs");
+    await page.waitForSelector("article a");
+    await docsTextHighlight(page);
+    const link = await page.waitForSelector("text=Open new Github issue");
+    expect(await link?.isVisible()).toBeTruthy();
+  });
+});

--- a/workspaces/github/e2e-tests/tests/specs/github-actions.spec.ts
+++ b/workspaces/github/e2e-tests/tests/specs/github-actions.spec.ts
@@ -14,41 +14,42 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({
-      auth: "github",
-      appConfig: `${WorkspacePaths.configDir}/github-actions/app-config-rhdh.yaml`,
-      dynamicPlugins: `${WorkspacePaths.configDir}/github-actions/dynamic-plugins.yaml`,
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({
+        auth: "github",
+        appConfig: `${WorkspacePaths.configDir}/github-actions/app-config-rhdh.yaml`,
+        dynamicPlugins: `${WorkspacePaths.configDir}/github-actions/dynamic-plugins.yaml`,
+      });
+      await rhdh.deploy();
     });
-    await rhdh.deploy();
-  });
 
-  test("Verify that the CI tab renders 5 most recent github actions", async ({
-    page,
-    loginHelper,
-    uiHelper,
-  }) => {
-    const component = "Red Hat Developer Hub";
-    await loginHelper.loginAsGithubUser();
+    test("Verify that the CI tab renders 5 most recent github actions", async ({
+      page,
+      loginHelper,
+      uiHelper,
+    }) => {
+      const component = "Red Hat Developer Hub";
+      await loginHelper.loginAsGithubUser();
 
-    await uiHelper.openSidebar("Catalog");
-    await uiHelper.selectMuiBox("Kind", "Component");
-    await uiHelper.searchInputPlaceholder(component);
-    await uiHelper.clickLink(component);
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.selectMuiBox("Kind", "Component");
+      await uiHelper.searchInputPlaceholder(component);
+      await uiHelper.clickLink(component);
 
-    await page.locator("a").getByText("CI", { exact: true }).first().click();
-    await page.getByRole("button", { name: "Log in" }).click();
-    await loginHelper.checkAndReauthorizeGithubApp();
+      await page.locator("a").getByText("CI", { exact: true }).first().click();
+      await page.getByRole("button", { name: "Log in" }).click();
+      await loginHelper.checkAndReauthorizeGithubApp();
 
-    const response = await APIHelper.githubRequest(
-      "GET",
-      GITHUB_API_ENDPOINTS.workflowRuns,
-    );
-    const json = await response.json();
-    const workflowRuns = json.workflow_runs;
+      const response = await APIHelper.githubRequest(
+        "GET",
+        GITHUB_API_ENDPOINTS.workflowRuns,
+      );
+      const json = await response.json();
+      const workflowRuns = json.workflow_runs;
 
-    for (const workflowRun of workflowRuns.slice(0, 5)) {
-      await uiHelper.verifyText(workflowRun.id);
-    }
-  });
-});
+      for (const workflowRun of workflowRuns.slice(0, 5)) {
+        await uiHelper.verifyText(workflowRun.id);
+      }
+    });
+  },
+);

--- a/workspaces/github/e2e-tests/tests/specs/github-actions.spec.ts
+++ b/workspaces/github/e2e-tests/tests/specs/github-actions.spec.ts
@@ -5,7 +5,15 @@ import {
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
 import { WorkspacePaths } from "@red-hat-developer-hub/e2e-test-utils/utils";
 
-test.describe("Test github-actions", () => {
+test.describe(
+  "Test github-actions",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "github" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({
       auth: "github",

--- a/workspaces/github/e2e-tests/tests/specs/github-actions.spec.ts
+++ b/workspaces/github/e2e-tests/tests/specs/github-actions.spec.ts
@@ -5,51 +5,46 @@ import {
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
 import { WorkspacePaths } from "@red-hat-developer-hub/e2e-test-utils/utils";
 
-test.describe(
-  "Test github-actions",
-  {
-    annotation: [
+test.describe("Test github-actions", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "github" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({
-        auth: "github",
-        appConfig: `${WorkspacePaths.configDir}/github-actions/app-config-rhdh.yaml`,
-        dynamicPlugins: `${WorkspacePaths.configDir}/github-actions/dynamic-plugins.yaml`,
-      });
-      await rhdh.deploy();
+    );
+    await rhdh.configure({
+      auth: "github",
+      appConfig: `${WorkspacePaths.configDir}/github-actions/app-config-rhdh.yaml`,
+      dynamicPlugins: `${WorkspacePaths.configDir}/github-actions/dynamic-plugins.yaml`,
     });
+    await rhdh.deploy();
+  });
 
-    test("Verify that the CI tab renders 5 most recent github actions", async ({
-      page,
-      loginHelper,
-      uiHelper,
-    }) => {
-      const component = "Red Hat Developer Hub";
-      await loginHelper.loginAsGithubUser();
+  test("Verify that the CI tab renders 5 most recent github actions", async ({
+    page,
+    loginHelper,
+    uiHelper,
+  }) => {
+    const component = "Red Hat Developer Hub";
+    await loginHelper.loginAsGithubUser();
 
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.selectMuiBox("Kind", "Component");
-      await uiHelper.searchInputPlaceholder(component);
-      await uiHelper.clickLink(component);
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.selectMuiBox("Kind", "Component");
+    await uiHelper.searchInputPlaceholder(component);
+    await uiHelper.clickLink(component);
 
-      await page.locator("a").getByText("CI", { exact: true }).first().click();
-      await page.getByRole("button", { name: "Log in" }).click();
-      await loginHelper.checkAndReauthorizeGithubApp();
+    await page.locator("a").getByText("CI", { exact: true }).first().click();
+    await page.getByRole("button", { name: "Log in" }).click();
+    await loginHelper.checkAndReauthorizeGithubApp();
 
-      const response = await APIHelper.githubRequest(
-        "GET",
-        GITHUB_API_ENDPOINTS.workflowRuns,
-      );
-      const json = await response.json();
-      const workflowRuns = json.workflow_runs;
+    const response = await APIHelper.githubRequest(
+      "GET",
+      GITHUB_API_ENDPOINTS.workflowRuns,
+    );
+    const json = await response.json();
+    const workflowRuns = json.workflow_runs;
 
-      for (const workflowRun of workflowRuns.slice(0, 5)) {
-        await uiHelper.verifyText(workflowRun.id);
-      }
-    });
-  },
-);
+    for (const workflowRun of workflowRuns.slice(0, 5)) {
+      await uiHelper.verifyText(workflowRun.id);
+    }
+  });
+});

--- a/workspaces/github/e2e-tests/tests/specs/github-issues.spec.ts
+++ b/workspaces/github/e2e-tests/tests/specs/github-issues.spec.ts
@@ -10,7 +10,15 @@ interface GHIssue {
   title: string;
 }
 
-test.describe("Test github-issues", () => {
+test.describe(
+  "Test github-issues",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "github" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({
       auth: "github",

--- a/workspaces/github/e2e-tests/tests/specs/github-issues.spec.ts
+++ b/workspaces/github/e2e-tests/tests/specs/github-issues.spec.ts
@@ -19,43 +19,44 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({
-      auth: "github",
-      appConfig: `${WorkspacePaths.configDir}/github-issues/app-config-rhdh.yaml`,
-      dynamicPlugins: `${WorkspacePaths.configDir}/github-issues/dynamic-plugins.yaml`,
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({
+        auth: "github",
+        appConfig: `${WorkspacePaths.configDir}/github-issues/app-config-rhdh.yaml`,
+        dynamicPlugins: `${WorkspacePaths.configDir}/github-issues/dynamic-plugins.yaml`,
+      });
+      await rhdh.deploy();
     });
-    await rhdh.deploy();
-  });
 
-  test("Verify that the Issues tab renders all the open github issues in the repository", async ({
-    loginHelper,
-    page,
-    uiHelper,
-  }) => {
-    const component = "Red Hat Developer Hub";
-    await loginHelper.loginAsGithubUser();
+    test("Verify that the Issues tab renders all the open github issues in the repository", async ({
+      loginHelper,
+      page,
+      uiHelper,
+    }) => {
+      const component = "Red Hat Developer Hub";
+      await loginHelper.loginAsGithubUser();
 
-    await uiHelper.openSidebar("Catalog");
-    await uiHelper.selectMuiBox("Kind", "Component");
-    await uiHelper.clickLink(component);
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.selectMuiBox("Kind", "Component");
+      await uiHelper.clickLink(component);
 
-    await uiHelper.clickTab("Issues");
-    await page.getByRole("button", { name: "Log in" }).click();
-    await loginHelper.checkAndReauthorizeGithubApp();
+      await uiHelper.clickTab("Issues");
+      await page.getByRole("button", { name: "Log in" }).click();
+      await loginHelper.checkAndReauthorizeGithubApp();
 
-    const response = (await APIHelper.getGithubPaginatedRequest(
-      GITHUB_API_ENDPOINTS.issues("open"),
-    )) as GHIssue[];
-    const openIssues = response.filter((issue) => !issue.pull_request);
+      const response = (await APIHelper.getGithubPaginatedRequest(
+        GITHUB_API_ENDPOINTS.issues("open"),
+      )) as GHIssue[];
+      const openIssues = response.filter((issue) => !issue.pull_request);
 
-    const issuesCountText = new RegExp(
-      `All repositories \\(${openIssues.length} Issue.*\\)`,
-    );
-    await expect(page.getByText(issuesCountText)).toBeVisible();
+      const issuesCountText = new RegExp(
+        `All repositories \\(${openIssues.length} Issue.*\\)`,
+      );
+      await expect(page.getByText(issuesCountText)).toBeVisible();
 
-    for (const issue of openIssues.slice(0, 5)) {
-      await uiHelper.verifyText(issue.title.replace(/\s+/g, " "));
-    }
-  });
-});
+      for (const issue of openIssues.slice(0, 5)) {
+        await uiHelper.verifyText(issue.title.replace(/\s+/g, " "));
+      }
+    });
+  },
+);

--- a/workspaces/github/e2e-tests/tests/specs/github-issues.spec.ts
+++ b/workspaces/github/e2e-tests/tests/specs/github-issues.spec.ts
@@ -10,53 +10,48 @@ interface GHIssue {
   title: string;
 }
 
-test.describe(
-  "Test github-issues",
-  {
-    annotation: [
+test.describe("Test github-issues", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "github" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({
-        auth: "github",
-        appConfig: `${WorkspacePaths.configDir}/github-issues/app-config-rhdh.yaml`,
-        dynamicPlugins: `${WorkspacePaths.configDir}/github-issues/dynamic-plugins.yaml`,
-      });
-      await rhdh.deploy();
+    );
+    await rhdh.configure({
+      auth: "github",
+      appConfig: `${WorkspacePaths.configDir}/github-issues/app-config-rhdh.yaml`,
+      dynamicPlugins: `${WorkspacePaths.configDir}/github-issues/dynamic-plugins.yaml`,
     });
+    await rhdh.deploy();
+  });
 
-    test("Verify that the Issues tab renders all the open github issues in the repository", async ({
-      loginHelper,
-      page,
-      uiHelper,
-    }) => {
-      const component = "Red Hat Developer Hub";
-      await loginHelper.loginAsGithubUser();
+  test("Verify that the Issues tab renders all the open github issues in the repository", async ({
+    loginHelper,
+    page,
+    uiHelper,
+  }) => {
+    const component = "Red Hat Developer Hub";
+    await loginHelper.loginAsGithubUser();
 
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.selectMuiBox("Kind", "Component");
-      await uiHelper.clickLink(component);
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.selectMuiBox("Kind", "Component");
+    await uiHelper.clickLink(component);
 
-      await uiHelper.clickTab("Issues");
-      await page.getByRole("button", { name: "Log in" }).click();
-      await loginHelper.checkAndReauthorizeGithubApp();
+    await uiHelper.clickTab("Issues");
+    await page.getByRole("button", { name: "Log in" }).click();
+    await loginHelper.checkAndReauthorizeGithubApp();
 
-      const response = (await APIHelper.getGithubPaginatedRequest(
-        GITHUB_API_ENDPOINTS.issues("open"),
-      )) as GHIssue[];
-      const openIssues = response.filter((issue) => !issue.pull_request);
+    const response = (await APIHelper.getGithubPaginatedRequest(
+      GITHUB_API_ENDPOINTS.issues("open"),
+    )) as GHIssue[];
+    const openIssues = response.filter((issue) => !issue.pull_request);
 
-      const issuesCountText = new RegExp(
-        `All repositories \\(${openIssues.length} Issue.*\\)`,
-      );
-      await expect(page.getByText(issuesCountText)).toBeVisible();
+    const issuesCountText = new RegExp(
+      `All repositories \\(${openIssues.length} Issue.*\\)`,
+    );
+    await expect(page.getByText(issuesCountText)).toBeVisible();
 
-      for (const issue of openIssues.slice(0, 5)) {
-        await uiHelper.verifyText(issue.title.replace(/\s+/g, " "));
-      }
-    });
-  },
-);
+    for (const issue of openIssues.slice(0, 5)) {
+      await uiHelper.verifyText(issue.title.replace(/\s+/g, " "));
+    }
+  });
+});

--- a/workspaces/global-header/e2e-tests/tests/specs/default-global-header.spec.ts
+++ b/workspaces/global-header/e2e-tests/tests/specs/default-global-header.spec.ts
@@ -5,7 +5,15 @@ import {
 } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { NotificationPage } from "@red-hat-developer-hub/e2e-test-utils/pages";
 
-test.describe("Default Global Header", () => {
+test.describe(
+  "Default Global Header",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "global-header" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({
       auth: "keycloak",

--- a/workspaces/global-header/e2e-tests/tests/specs/default-global-header.spec.ts
+++ b/workspaces/global-header/e2e-tests/tests/specs/default-global-header.spec.ts
@@ -14,182 +14,188 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({
-      auth: "keycloak",
-      disableWrappers: ["red-hat-developer-hub-backstage-plugin-global-header"],
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({
+        auth: "keycloak",
+        disableWrappers: [
+          "red-hat-developer-hub-backstage-plugin-global-header",
+        ],
+      });
+      await rhdh.deploy();
     });
-    await rhdh.deploy();
-  });
 
-  test.beforeEach(async ({ loginHelper, page }) => {
-    await loginHelper.loginAsKeycloakUser(
-      process.env.GH_USER2_ID,
-      process.env.GH_USER2_PASS,
-    );
-    await expect(page.getByRole("navigation").first()).toBeVisible();
-  });
+    test.beforeEach(async ({ loginHelper, page }) => {
+      await loginHelper.loginAsKeycloakUser(
+        process.env.GH_USER2_ID,
+        process.env.GH_USER2_PASS,
+      );
+      await expect(page.getByRole("navigation").first()).toBeVisible();
+    });
 
-  test("Verify that global header and default header components are visible", async ({
-    page,
-    uiHelper,
-  }) => {
-    await expect(page.getByPlaceholder("Search")).toBeVisible();
-    await uiHelper.verifyLink({ label: "Self-service" });
+    test("Verify that global header and default header components are visible", async ({
+      page,
+      uiHelper,
+    }) => {
+      await expect(page.getByPlaceholder("Search")).toBeVisible();
+      await uiHelper.verifyLink({ label: "Self-service" });
 
-    const globalHeader = page.getByRole("navigation").first();
-    const helpDropdownButton = globalHeader
-      .getByRole("button", {
-        name: "Help",
-      })
-      .or(
-        globalHeader.getByRole("button").filter({
-          has: page.getByTestId("HelpOutlineIcon"),
+      const globalHeader = page.getByRole("navigation").first();
+      const helpDropdownButton = globalHeader
+        .getByRole("button", {
+          name: "Help",
+        })
+        .or(
+          globalHeader.getByRole("button").filter({
+            has: page.getByTestId("HelpOutlineIcon"),
+          }),
+        )
+        .first();
+
+      await expect(helpDropdownButton).toBeVisible();
+      await uiHelper.verifyLink({ label: "Notifications" });
+      expect(await uiHelper.isBtnVisible("Test User1")).toBeTruthy();
+    });
+
+    test("Verify that search modal and settings button in sidebar are not visible", async ({
+      uiHelper,
+    }) => {
+      expect(await uiHelper.isBtnVisible("Search")).toBeFalsy();
+      expect(await uiHelper.isBtnVisible("Settings")).toBeFalsy();
+    });
+
+    test("Verify that clicking on Self-service button opens the Templates page", async ({
+      uiHelper,
+    }) => {
+      await uiHelper.clickLink({ ariaLabel: "Self-service" });
+      await uiHelper.verifyHeading("Self-service");
+    });
+
+    test("Verify that clicking on Support button in HelpDropdown opens a new tab", async ({
+      uiHelper,
+      context,
+      page,
+    }) => {
+      const globalHeader = page.getByRole("navigation").first();
+
+      const helpDropdownButton = globalHeader
+        .getByRole("button", {
+          name: "Help",
+        })
+        .or(
+          globalHeader.getByRole("button").filter({
+            has: page.getByTestId("HelpOutlineIcon"),
+          }),
+        )
+        .first();
+
+      await helpDropdownButton.click();
+      await page
+        .getByTestId("support-button")
+        .waitFor({ state: "visible", timeout: 10000 });
+      await uiHelper.verifyTextVisible("Support", false);
+
+      const [newTab] = await Promise.all([
+        context.waitForEvent("page"),
+        uiHelper.clickByDataTestId("support-button"),
+      ]);
+
+      expect(newTab).not.toBeNull();
+      await newTab.waitForLoadState();
+      expect(newTab.url()).toContain(
+        "https://github.com/redhat-developer/rhdh/issues",
+      );
+      await newTab.close();
+    });
+
+    test("Verify Profile Dropdown behaves as expected", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.openProfileDropdown();
+      await uiHelper.verifyLinkVisible("Settings");
+      await uiHelper.verifyTextVisible("Sign out");
+
+      await page
+        .getByRole("menuitem", {
+          name: "Settings",
+        })
+        .click();
+      await uiHelper.verifyHeading("Settings");
+
+      await expect(page.locator("nav[id='global-header']")).toBeVisible();
+      await uiHelper.openProfileDropdown();
+      await uiHelper.clickLink("My profile");
+      await uiHelper.verifyTextInSelector("header > div > p", "user");
+      await uiHelper.verifyHeading(process.env.GH_USER2_ID!);
+      await expect(
+        page.getByRole("tab", {
+          name: "Overview",
         }),
-      )
-      .first();
+      ).toBeVisible();
 
-    await expect(helpDropdownButton).toBeVisible();
-    await uiHelper.verifyLink({ label: "Notifications" });
-    expect(await uiHelper.isBtnVisible("Test User1")).toBeTruthy();
-  });
+      await uiHelper.openProfileDropdown();
+      await page.getByRole("menu").getByText("Sign out").click();
+      await uiHelper.verifyHeading("Select a sign-in method");
+    });
 
-  test("Verify that search modal and settings button in sidebar are not visible", async ({
-    uiHelper,
-  }) => {
-    expect(await uiHelper.isBtnVisible("Search")).toBeFalsy();
-    expect(await uiHelper.isBtnVisible("Settings")).toBeFalsy();
-  });
+    test("Verify Search bar behaves as expected", async ({
+      page,
+      uiHelper,
+    }) => {
+      const searchBar = page.getByPlaceholder("Search");
+      await searchBar.click();
+      await searchBar.fill("test query term");
+      expect(await uiHelper.isBtnVisibleByTitle("Clear")).toBeTruthy();
+      const dropdownList = page.getByRole("listbox");
+      await expect(dropdownList).toBeVisible();
+      await searchBar.press("Enter");
+      await uiHelper.verifyHeading("Search");
 
-  test("Verify that clicking on Self-service button opens the Templates page", async ({
-    uiHelper,
-  }) => {
-    await uiHelper.clickLink({ ariaLabel: "Self-service" });
-    await uiHelper.verifyHeading("Self-service");
-  });
+      const searchResultPageInput = page.locator("#search-bar-text-field");
+      await expect(searchResultPageInput).toHaveValue("test query term");
+    });
 
-  test("Verify that clicking on Support button in HelpDropdown opens a new tab", async ({
-    uiHelper,
-    context,
-    page,
-  }) => {
-    const globalHeader = page.getByRole("navigation").first();
+    test("Verify Notifications button behaves as expected", async ({
+      uiHelper,
+      page,
+    }) => {
+      const notificationsBadge = page
+        .getByRole("navigation")
+        .first()
+        .getByRole("link", {
+          name: "Notifications",
+        });
 
-    const helpDropdownButton = globalHeader
-      .getByRole("button", {
-        name: "Help",
-      })
-      .or(
-        globalHeader.getByRole("button").filter({
-          has: page.getByTestId("HelpOutlineIcon"),
-        }),
-      )
-      .first();
+      await uiHelper.clickLink({
+        ariaLabel: "Notifications",
+      });
+      await uiHelper.verifyHeading("Notifications");
+      const notificationPage = new NotificationPage(page);
+      await notificationPage.markAllNotificationsAsRead();
 
-    await helpDropdownButton.click();
-    await page
-      .getByTestId("support-button")
-      .waitFor({ state: "visible", timeout: 10000 });
-    await uiHelper.verifyTextVisible("Support", false);
-
-    const [newTab] = await Promise.all([
-      context.waitForEvent("page"),
-      uiHelper.clickByDataTestId("support-button"),
-    ]);
-
-    expect(newTab).not.toBeNull();
-    await newTab.waitForLoadState();
-    expect(newTab.url()).toContain(
-      "https://github.com/redhat-developer/rhdh/issues",
-    );
-    await newTab.close();
-  });
-
-  test("Verify Profile Dropdown behaves as expected", async ({
-    page,
-    uiHelper,
-  }) => {
-    await uiHelper.openProfileDropdown();
-    await uiHelper.verifyLinkVisible("Settings");
-    await uiHelper.verifyTextVisible("Sign out");
-
-    await page
-      .getByRole("menuitem", {
-        name: "Settings",
-      })
-      .click();
-    await uiHelper.verifyHeading("Settings");
-
-    await expect(page.locator("nav[id='global-header']")).toBeVisible();
-    await uiHelper.openProfileDropdown();
-    await uiHelper.clickLink("My profile");
-    await uiHelper.verifyTextInSelector("header > div > p", "user");
-    await uiHelper.verifyHeading(process.env.GH_USER2_ID!);
-    await expect(
-      page.getByRole("tab", {
-        name: "Overview",
-      }),
-    ).toBeVisible();
-
-    await uiHelper.openProfileDropdown();
-    await page.getByRole("menu").getByText("Sign out").click();
-    await uiHelper.verifyHeading("Select a sign-in method");
-  });
-
-  test("Verify Search bar behaves as expected", async ({ page, uiHelper }) => {
-    const searchBar = page.getByPlaceholder("Search");
-    await searchBar.click();
-    await searchBar.fill("test query term");
-    expect(await uiHelper.isBtnVisibleByTitle("Clear")).toBeTruthy();
-    const dropdownList = page.getByRole("listbox");
-    await expect(dropdownList).toBeVisible();
-    await searchBar.press("Enter");
-    await uiHelper.verifyHeading("Search");
-
-    const searchResultPageInput = page.locator("#search-bar-text-field");
-    await expect(searchResultPageInput).toHaveValue("test query term");
-  });
-
-  test("Verify Notifications button behaves as expected", async ({
-    uiHelper,
-    page,
-  }) => {
-    const notificationsBadge = page
-      .getByRole("navigation")
-      .first()
-      .getByRole("link", {
-        name: "Notifications",
+      const apiContext = await request.newContext({
+        baseURL: `${process.env.RHDH_BASE_URL}/api/`,
+        extraHTTPHeaders: {
+          Accept: "application/json",
+          Authorization: "Bearer test-token",
+        },
       });
 
-    await uiHelper.clickLink({
-      ariaLabel: "Notifications",
-    });
-    await uiHelper.verifyHeading("Notifications");
-    const notificationPage = new NotificationPage(page);
-    await notificationPage.markAllNotificationsAsRead();
-
-    const apiContext = await request.newContext({
-      baseURL: `${process.env.RHDH_BASE_URL}/api/`,
-      extraHTTPHeaders: {
-        Accept: "application/json",
-        Authorization: "Bearer test-token",
-      },
-    });
-
-    const postResponse = await apiContext.post("notifications", {
-      data: {
-        recipients: { type: "broadcast", entityRef: [""] },
-        payload: {
-          title: "Demo test notification message!",
-          link: "http://foo.com/bar", // NOSONAR typescript:S5332 - test fixture URL
-          description: "The demo test notification message",
-          severity: "high",
-          topic: "The topic",
+      const postResponse = await apiContext.post("notifications", {
+        data: {
+          recipients: { type: "broadcast", entityRef: [""] },
+          payload: {
+            title: "Demo test notification message!",
+            link: "http://foo.com/bar", // NOSONAR typescript:S5332 - test fixture URL
+            description: "The demo test notification message",
+            severity: "high",
+            topic: "The topic",
+          },
         },
-      },
-    });
-    expect(postResponse.status()).toBe(200);
+      });
+      expect(postResponse.status()).toBe(200);
 
-    await expect(notificationsBadge).toHaveText("1");
-  });
-});
+      await expect(notificationsBadge).toHaveText("1");
+    });
+  },
+);

--- a/workspaces/global-header/e2e-tests/tests/specs/default-global-header.spec.ts
+++ b/workspaces/global-header/e2e-tests/tests/specs/default-global-header.spec.ts
@@ -5,197 +5,187 @@ import {
 } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { NotificationPage } from "@red-hat-developer-hub/e2e-test-utils/pages";
 
-test.describe(
-  "Default Global Header",
-  {
-    annotation: [
+test.describe("Default Global Header", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "global-header" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({
-        auth: "keycloak",
-        disableWrappers: [
-          "red-hat-developer-hub-backstage-plugin-global-header",
-        ],
-      });
-      await rhdh.deploy();
+    );
+    await rhdh.configure({
+      auth: "keycloak",
+      disableWrappers: ["red-hat-developer-hub-backstage-plugin-global-header"],
     });
+    await rhdh.deploy();
+  });
 
-    test.beforeEach(async ({ loginHelper, page }) => {
-      await loginHelper.loginAsKeycloakUser(
-        process.env.GH_USER2_ID,
-        process.env.GH_USER2_PASS,
-      );
-      await expect(page.getByRole("navigation").first()).toBeVisible();
-    });
+  test.beforeEach(async ({ loginHelper, page }) => {
+    await loginHelper.loginAsKeycloakUser(
+      process.env.GH_USER2_ID,
+      process.env.GH_USER2_PASS,
+    );
+    await expect(page.getByRole("navigation").first()).toBeVisible();
+  });
 
-    test("Verify that global header and default header components are visible", async ({
-      page,
-      uiHelper,
-    }) => {
-      await expect(page.getByPlaceholder("Search")).toBeVisible();
-      await uiHelper.verifyLink({ label: "Self-service" });
+  test("Verify that global header and default header components are visible", async ({
+    page,
+    uiHelper,
+  }) => {
+    await expect(page.getByPlaceholder("Search")).toBeVisible();
+    await uiHelper.verifyLink({ label: "Self-service" });
 
-      const globalHeader = page.getByRole("navigation").first();
-      const helpDropdownButton = globalHeader
-        .getByRole("button", {
-          name: "Help",
-        })
-        .or(
-          globalHeader.getByRole("button").filter({
-            has: page.getByTestId("HelpOutlineIcon"),
-          }),
-        )
-        .first();
-
-      await expect(helpDropdownButton).toBeVisible();
-      await uiHelper.verifyLink({ label: "Notifications" });
-      expect(await uiHelper.isBtnVisible("Test User1")).toBeTruthy();
-    });
-
-    test("Verify that search modal and settings button in sidebar are not visible", async ({
-      uiHelper,
-    }) => {
-      expect(await uiHelper.isBtnVisible("Search")).toBeFalsy();
-      expect(await uiHelper.isBtnVisible("Settings")).toBeFalsy();
-    });
-
-    test("Verify that clicking on Self-service button opens the Templates page", async ({
-      uiHelper,
-    }) => {
-      await uiHelper.clickLink({ ariaLabel: "Self-service" });
-      await uiHelper.verifyHeading("Self-service");
-    });
-
-    test("Verify that clicking on Support button in HelpDropdown opens a new tab", async ({
-      uiHelper,
-      context,
-      page,
-    }) => {
-      const globalHeader = page.getByRole("navigation").first();
-
-      const helpDropdownButton = globalHeader
-        .getByRole("button", {
-          name: "Help",
-        })
-        .or(
-          globalHeader.getByRole("button").filter({
-            has: page.getByTestId("HelpOutlineIcon"),
-          }),
-        )
-        .first();
-
-      await helpDropdownButton.click();
-      await page
-        .getByTestId("support-button")
-        .waitFor({ state: "visible", timeout: 10000 });
-      await uiHelper.verifyTextVisible("Support", false);
-
-      const [newTab] = await Promise.all([
-        context.waitForEvent("page"),
-        uiHelper.clickByDataTestId("support-button"),
-      ]);
-
-      expect(newTab).not.toBeNull();
-      await newTab.waitForLoadState();
-      expect(newTab.url()).toContain(
-        "https://github.com/redhat-developer/rhdh/issues",
-      );
-      await newTab.close();
-    });
-
-    test("Verify Profile Dropdown behaves as expected", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.openProfileDropdown();
-      await uiHelper.verifyLinkVisible("Settings");
-      await uiHelper.verifyTextVisible("Sign out");
-
-      await page
-        .getByRole("menuitem", {
-          name: "Settings",
-        })
-        .click();
-      await uiHelper.verifyHeading("Settings");
-
-      await expect(page.locator("nav[id='global-header']")).toBeVisible();
-      await uiHelper.openProfileDropdown();
-      await uiHelper.clickLink("My profile");
-      await uiHelper.verifyTextInSelector("header > div > p", "user");
-      await uiHelper.verifyHeading(process.env.GH_USER2_ID!);
-      await expect(
-        page.getByRole("tab", {
-          name: "Overview",
+    const globalHeader = page.getByRole("navigation").first();
+    const helpDropdownButton = globalHeader
+      .getByRole("button", {
+        name: "Help",
+      })
+      .or(
+        globalHeader.getByRole("button").filter({
+          has: page.getByTestId("HelpOutlineIcon"),
         }),
-      ).toBeVisible();
+      )
+      .first();
 
-      await uiHelper.openProfileDropdown();
-      await page.getByRole("menu").getByText("Sign out").click();
-      await uiHelper.verifyHeading("Select a sign-in method");
-    });
+    await expect(helpDropdownButton).toBeVisible();
+    await uiHelper.verifyLink({ label: "Notifications" });
+    expect(await uiHelper.isBtnVisible("Test User1")).toBeTruthy();
+  });
 
-    test("Verify Search bar behaves as expected", async ({
-      page,
-      uiHelper,
-    }) => {
-      const searchBar = page.getByPlaceholder("Search");
-      await searchBar.click();
-      await searchBar.fill("test query term");
-      expect(await uiHelper.isBtnVisibleByTitle("Clear")).toBeTruthy();
-      const dropdownList = page.getByRole("listbox");
-      await expect(dropdownList).toBeVisible();
-      await searchBar.press("Enter");
-      await uiHelper.verifyHeading("Search");
+  test("Verify that search modal and settings button in sidebar are not visible", async ({
+    uiHelper,
+  }) => {
+    expect(await uiHelper.isBtnVisible("Search")).toBeFalsy();
+    expect(await uiHelper.isBtnVisible("Settings")).toBeFalsy();
+  });
 
-      const searchResultPageInput = page.locator("#search-bar-text-field");
-      await expect(searchResultPageInput).toHaveValue("test query term");
-    });
+  test("Verify that clicking on Self-service button opens the Templates page", async ({
+    uiHelper,
+  }) => {
+    await uiHelper.clickLink({ ariaLabel: "Self-service" });
+    await uiHelper.verifyHeading("Self-service");
+  });
 
-    test("Verify Notifications button behaves as expected", async ({
-      uiHelper,
-      page,
-    }) => {
-      const notificationsBadge = page
-        .getByRole("navigation")
-        .first()
-        .getByRole("link", {
-          name: "Notifications",
-        });
+  test("Verify that clicking on Support button in HelpDropdown opens a new tab", async ({
+    uiHelper,
+    context,
+    page,
+  }) => {
+    const globalHeader = page.getByRole("navigation").first();
 
-      await uiHelper.clickLink({
-        ariaLabel: "Notifications",
+    const helpDropdownButton = globalHeader
+      .getByRole("button", {
+        name: "Help",
+      })
+      .or(
+        globalHeader.getByRole("button").filter({
+          has: page.getByTestId("HelpOutlineIcon"),
+        }),
+      )
+      .first();
+
+    await helpDropdownButton.click();
+    await page
+      .getByTestId("support-button")
+      .waitFor({ state: "visible", timeout: 10000 });
+    await uiHelper.verifyTextVisible("Support", false);
+
+    const [newTab] = await Promise.all([
+      context.waitForEvent("page"),
+      uiHelper.clickByDataTestId("support-button"),
+    ]);
+
+    expect(newTab).not.toBeNull();
+    await newTab.waitForLoadState();
+    expect(newTab.url()).toContain(
+      "https://github.com/redhat-developer/rhdh/issues",
+    );
+    await newTab.close();
+  });
+
+  test("Verify Profile Dropdown behaves as expected", async ({
+    page,
+    uiHelper,
+  }) => {
+    await uiHelper.openProfileDropdown();
+    await uiHelper.verifyLinkVisible("Settings");
+    await uiHelper.verifyTextVisible("Sign out");
+
+    await page
+      .getByRole("menuitem", {
+        name: "Settings",
+      })
+      .click();
+    await uiHelper.verifyHeading("Settings");
+
+    await expect(page.locator("nav[id='global-header']")).toBeVisible();
+    await uiHelper.openProfileDropdown();
+    await uiHelper.clickLink("My profile");
+    await uiHelper.verifyTextInSelector("header > div > p", "user");
+    await uiHelper.verifyHeading(process.env.GH_USER2_ID!);
+    await expect(
+      page.getByRole("tab", {
+        name: "Overview",
+      }),
+    ).toBeVisible();
+
+    await uiHelper.openProfileDropdown();
+    await page.getByRole("menu").getByText("Sign out").click();
+    await uiHelper.verifyHeading("Select a sign-in method");
+  });
+
+  test("Verify Search bar behaves as expected", async ({ page, uiHelper }) => {
+    const searchBar = page.getByPlaceholder("Search");
+    await searchBar.click();
+    await searchBar.fill("test query term");
+    expect(await uiHelper.isBtnVisibleByTitle("Clear")).toBeTruthy();
+    const dropdownList = page.getByRole("listbox");
+    await expect(dropdownList).toBeVisible();
+    await searchBar.press("Enter");
+    await uiHelper.verifyHeading("Search");
+
+    const searchResultPageInput = page.locator("#search-bar-text-field");
+    await expect(searchResultPageInput).toHaveValue("test query term");
+  });
+
+  test("Verify Notifications button behaves as expected", async ({
+    uiHelper,
+    page,
+  }) => {
+    const notificationsBadge = page
+      .getByRole("navigation")
+      .first()
+      .getByRole("link", {
+        name: "Notifications",
       });
-      await uiHelper.verifyHeading("Notifications");
-      const notificationPage = new NotificationPage(page);
-      await notificationPage.markAllNotificationsAsRead();
 
-      const apiContext = await request.newContext({
-        baseURL: `${process.env.RHDH_BASE_URL}/api/`,
-        extraHTTPHeaders: {
-          Accept: "application/json",
-          Authorization: "Bearer test-token",
+    await uiHelper.clickLink({
+      ariaLabel: "Notifications",
+    });
+    await uiHelper.verifyHeading("Notifications");
+    const notificationPage = new NotificationPage(page);
+    await notificationPage.markAllNotificationsAsRead();
+
+    const apiContext = await request.newContext({
+      baseURL: `${process.env.RHDH_BASE_URL}/api/`,
+      extraHTTPHeaders: {
+        Accept: "application/json",
+        Authorization: "Bearer test-token",
+      },
+    });
+
+    const postResponse = await apiContext.post("notifications", {
+      data: {
+        recipients: { type: "broadcast", entityRef: [""] },
+        payload: {
+          title: "Demo test notification message!",
+          link: "http://foo.com/bar", // NOSONAR typescript:S5332 - test fixture URL
+          description: "The demo test notification message",
+          severity: "high",
+          topic: "The topic",
         },
-      });
-
-      const postResponse = await apiContext.post("notifications", {
-        data: {
-          recipients: { type: "broadcast", entityRef: [""] },
-          payload: {
-            title: "Demo test notification message!",
-            link: "http://foo.com/bar", // NOSONAR typescript:S5332 - test fixture URL
-            description: "The demo test notification message",
-            severity: "high",
-            topic: "The topic",
-          },
-        },
-      });
-      expect(postResponse.status()).toBe(200);
-
-      await expect(notificationsBadge).toHaveText("1");
+      },
     });
-  },
-);
+    expect(postResponse.status()).toBe(200);
+
+    await expect(notificationsBadge).toHaveText("1");
+  });
+});

--- a/workspaces/global-header/e2e-tests/tests/specs/header-mount-points.spec.ts
+++ b/workspaces/global-header/e2e-tests/tests/specs/header-mount-points.spec.ts
@@ -1,6 +1,14 @@
 import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 
-test.describe("Header mount points", () => {
+test.describe(
+  "Header mount points",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "global-header" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({
       auth: "keycloak",

--- a/workspaces/global-header/e2e-tests/tests/specs/header-mount-points.spec.ts
+++ b/workspaces/global-header/e2e-tests/tests/specs/header-mount-points.spec.ts
@@ -1,65 +1,58 @@
 import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 
-test.describe(
-  "Header mount points",
-  {
-    annotation: [
+test.describe("Header mount points", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "global-header" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({
-        auth: "keycloak",
-        disableWrappers: [
-          "red-hat-developer-hub-backstage-plugin-global-header",
-        ],
-      });
-      await rhdh.deploy();
+    );
+    await rhdh.configure({
+      auth: "keycloak",
+      disableWrappers: ["red-hat-developer-hub-backstage-plugin-global-header"],
     });
+    await rhdh.deploy();
+  });
 
-    test.beforeEach(async ({ loginHelper, page, baseURL }) => {
-      if (!baseURL) {
-        throw new Error("Playwright baseURL is not set");
-      }
-      await expect(async () => {
-        await page.goto(baseURL);
-        await expect(
-          page.getByRole("button", { name: "Sign In", exact: true }),
-        ).toBeVisible({ timeout: 15_000 });
-      }).toPass({ timeout: 120_000 });
-
-      await loginHelper.loginAsKeycloakUser();
-      await expect(page.locator("nav[id='global-header']")).toBeVisible();
-    });
-
-    test("Verify that additional logo component in global header is visible", async ({
-      page,
-      uiHelper,
-    }) => {
-      const header = page.locator("nav[id='global-header']");
-      await expect(header).toBeVisible();
-      await uiHelper.verifyLink({ label: "test-logo" });
-    });
-
-    test("Verify that additional header button component from a custom header plugin in global header is visible", async ({
-      page,
-    }) => {
-      const header = page.locator("nav[id='global-header']");
-      await expect(header).toBeVisible();
+  test.beforeEach(async ({ loginHelper, page, baseURL }) => {
+    if (!baseURL) {
+      throw new Error("Playwright baseURL is not set");
+    }
+    await expect(async () => {
+      await page.goto(baseURL);
       await expect(
-        header.locator("button", { hasText: "Test Button" }),
-      ).toHaveCount(1);
-    });
+        page.getByRole("button", { name: "Sign In", exact: true }),
+      ).toBeVisible({ timeout: 15_000 });
+    }).toPass({ timeout: 120_000 });
 
-    test("Verify that additional header from a custom header plugin besides the default one is visible", async ({
-      page,
-    }) => {
-      const header = page.locator("header", {
-        hasText: "This is a test header!",
-      });
-      await expect(header).toBeVisible();
+    await loginHelper.loginAsKeycloakUser();
+    await expect(page.locator("nav[id='global-header']")).toBeVisible();
+  });
+
+  test("Verify that additional logo component in global header is visible", async ({
+    page,
+    uiHelper,
+  }) => {
+    const header = page.locator("nav[id='global-header']");
+    await expect(header).toBeVisible();
+    await uiHelper.verifyLink({ label: "test-logo" });
+  });
+
+  test("Verify that additional header button component from a custom header plugin in global header is visible", async ({
+    page,
+  }) => {
+    const header = page.locator("nav[id='global-header']");
+    await expect(header).toBeVisible();
+    await expect(
+      header.locator("button", { hasText: "Test Button" }),
+    ).toHaveCount(1);
+  });
+
+  test("Verify that additional header from a custom header plugin besides the default one is visible", async ({
+    page,
+  }) => {
+    const header = page.locator("header", {
+      hasText: "This is a test header!",
     });
-  },
-);
+    await expect(header).toBeVisible();
+  });
+});

--- a/workspaces/global-header/e2e-tests/tests/specs/header-mount-points.spec.ts
+++ b/workspaces/global-header/e2e-tests/tests/specs/header-mount-points.spec.ts
@@ -9,54 +9,57 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({
-      auth: "keycloak",
-      disableWrappers: ["red-hat-developer-hub-backstage-plugin-global-header"],
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({
+        auth: "keycloak",
+        disableWrappers: [
+          "red-hat-developer-hub-backstage-plugin-global-header",
+        ],
+      });
+      await rhdh.deploy();
     });
-    await rhdh.deploy();
-  });
 
-  test.beforeEach(async ({ loginHelper, page, baseURL }) => {
-    if (!baseURL) {
-      throw new Error("Playwright baseURL is not set");
-    }
-    await expect(async () => {
-      await page.goto(baseURL);
+    test.beforeEach(async ({ loginHelper, page, baseURL }) => {
+      if (!baseURL) {
+        throw new Error("Playwright baseURL is not set");
+      }
+      await expect(async () => {
+        await page.goto(baseURL);
+        await expect(
+          page.getByRole("button", { name: "Sign In", exact: true }),
+        ).toBeVisible({ timeout: 15_000 });
+      }).toPass({ timeout: 120_000 });
+
+      await loginHelper.loginAsKeycloakUser();
+      await expect(page.locator("nav[id='global-header']")).toBeVisible();
+    });
+
+    test("Verify that additional logo component in global header is visible", async ({
+      page,
+      uiHelper,
+    }) => {
+      const header = page.locator("nav[id='global-header']");
+      await expect(header).toBeVisible();
+      await uiHelper.verifyLink({ label: "test-logo" });
+    });
+
+    test("Verify that additional header button component from a custom header plugin in global header is visible", async ({
+      page,
+    }) => {
+      const header = page.locator("nav[id='global-header']");
+      await expect(header).toBeVisible();
       await expect(
-        page.getByRole("button", { name: "Sign In", exact: true }),
-      ).toBeVisible({ timeout: 15_000 });
-    }).toPass({ timeout: 120_000 });
-
-    await loginHelper.loginAsKeycloakUser();
-    await expect(page.locator("nav[id='global-header']")).toBeVisible();
-  });
-
-  test("Verify that additional logo component in global header is visible", async ({
-    page,
-    uiHelper,
-  }) => {
-    const header = page.locator("nav[id='global-header']");
-    await expect(header).toBeVisible();
-    await uiHelper.verifyLink({ label: "test-logo" });
-  });
-
-  test("Verify that additional header button component from a custom header plugin in global header is visible", async ({
-    page,
-  }) => {
-    const header = page.locator("nav[id='global-header']");
-    await expect(header).toBeVisible();
-    await expect(
-      header.locator("button", { hasText: "Test Button" }),
-    ).toHaveCount(1);
-  });
-
-  test("Verify that additional header from a custom header plugin besides the default one is visible", async ({
-    page,
-  }) => {
-    const header = page.locator("header", {
-      hasText: "This is a test header!",
+        header.locator("button", { hasText: "Test Button" }),
+      ).toHaveCount(1);
     });
-    await expect(header).toBeVisible();
-  });
-});
+
+    test("Verify that additional header from a custom header plugin besides the default one is visible", async ({
+      page,
+    }) => {
+      const header = page.locator("header", {
+        hasText: "This is a test header!",
+      });
+      await expect(header).toBeVisible();
+    });
+  },
+);

--- a/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
+++ b/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
@@ -13,72 +13,67 @@ const DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES: string[] = [
 
 /* Assertions live in DynamicHomePagePo (expect/verify*), matching RHDH core structure. */
 /* eslint-disable playwright/expect-expect -- see DynamicHomePagePo */
-test.describe.serial(
-  "Dynamic home page customization",
-  {
-    annotation: [
+test.describe.serial("Dynamic home page customization", () => {
+  let context: BrowserContext | undefined;
+  let page: Page;
+  let uiHelper: UIhelper;
+  let home: DynamicHomePagePo;
+
+  test.beforeAll(async ({ browser, rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "homepage" },
-    ],
-  },
-  () => {
-    let context: BrowserContext | undefined;
-    let page: Page;
-    let uiHelper: UIhelper;
-    let home: DynamicHomePagePo;
+    );
+    test.setTimeout(10 * 60 * 1000);
 
-    test.beforeAll(async ({ browser, rhdh }) => {
-      test.setTimeout(10 * 60 * 1000);
-
-      await rhdh.configure({
-        auth: "keycloak",
-        // Default chart tag in registry (avoid "next", which is not always published).
-        version: process.env.RHDH_VERSION ?? "1.10",
-        disableWrappers: DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES,
-      });
-      await rhdh.deploy();
-
-      context = await browser.newContext({
-        baseURL: rhdh.rhdhUrl,
-      });
-      page = await context.newPage();
-      uiHelper = new UIhelper(page);
-      const loginHelper = new LoginHelper(page);
-      await loginHelper.loginAsKeycloakUser();
-      home = new DynamicHomePagePo(page, uiHelper);
+    await rhdh.configure({
+      auth: "keycloak",
+      // Default chart tag in registry (avoid "next", which is not always published).
+      version: process.env.RHDH_VERSION ?? "1.10",
+      disableWrappers: DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES,
     });
+    await rhdh.deploy();
 
-    test.afterAll(async () => {
-      await context?.close();
+    context = await browser.newContext({
+      baseURL: rhdh.rhdhUrl,
     });
+    page = await context.newPage();
+    uiHelper = new UIhelper(page);
+    const loginHelper = new LoginHelper(page);
+    await loginHelper.loginAsKeycloakUser();
+    home = new DynamicHomePagePo(page, uiHelper);
+  });
 
-    test("Verify cards display after login", async () => {
-      await home.seedHomePageWidgets();
-      await home.verifyHomePageLoaded();
-      await home.verifyAllCardsDisplayed();
-      await home.verifyEditButtonVisible();
-    });
+  test.afterAll(async () => {
+    await context?.close();
+  });
 
-    test("Verify cards can be individually deleted in edit mode", async () => {
-      await home.enterEditMode();
-      await home.deleteAllCards();
-      await home.verifyCardsDeleted();
-    });
+  test("Verify cards display after login", async () => {
+    await home.seedHomePageWidgets();
+    await home.verifyHomePageLoaded();
+    await home.verifyAllCardsDisplayed();
+    await home.verifyEditButtonVisible();
+  });
 
-    test("Verify cards can be resized in edit mode", async () => {
-      await home.addWidget("Entity Section");
-      await home.resizeFirstCard();
-      await home.exitEditMode();
-    });
+  test("Verify cards can be individually deleted in edit mode", async () => {
+    await home.enterEditMode();
+    await home.deleteAllCards();
+    await home.verifyCardsDeleted();
+  });
 
-    // restore defaults button is not working as expected
-    // eslint-disable-next-line playwright/no-skipped-test -- re-enable when https://issues.redhat.com/browse/RHDHBUGS-2906 is fixed
-    test.skip("Verify restore default cards and deleted with Clear all button", async () => {
-      await home.restoreDefaultCards();
-      await home.verifyCardsRestored();
-      await home.enterEditMode();
-      await home.clearAllCardsWithButton();
-      await home.verifyCardsDeleted();
-    });
-  },
-);
+  test("Verify cards can be resized in edit mode", async () => {
+    await home.addWidget("Entity Section");
+    await home.resizeFirstCard();
+    await home.exitEditMode();
+  });
+
+  // restore defaults button is not working as expected
+  // eslint-disable-next-line playwright/no-skipped-test -- re-enable when https://issues.redhat.com/browse/RHDHBUGS-2906 is fixed
+  test.skip("Verify restore default cards and deleted with Clear all button", async () => {
+    await home.restoreDefaultCards();
+    await home.verifyCardsRestored();
+    await home.enterEditMode();
+    await home.clearAllCardsWithButton();
+    await home.verifyCardsDeleted();
+  });
+});

--- a/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
+++ b/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
@@ -13,7 +13,15 @@ const DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES: string[] = [
 
 /* Assertions live in DynamicHomePagePo (expect/verify*), matching RHDH core structure. */
 /* eslint-disable playwright/expect-expect -- see DynamicHomePagePo */
-test.describe.serial("Dynamic home page customization", () => {
+test.describe.serial(
+  "Dynamic home page customization",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "homepage" },
+    ],
+  },
+  () => {
   let context: BrowserContext | undefined;
   let page: Page;
   let uiHelper: UIhelper;

--- a/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
+++ b/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
@@ -22,62 +22,63 @@ test.describe.serial(
     ],
   },
   () => {
-  let context: BrowserContext | undefined;
-  let page: Page;
-  let uiHelper: UIhelper;
-  let home: DynamicHomePagePo;
+    let context: BrowserContext | undefined;
+    let page: Page;
+    let uiHelper: UIhelper;
+    let home: DynamicHomePagePo;
 
-  test.beforeAll(async ({ browser, rhdh }) => {
-    test.setTimeout(10 * 60 * 1000);
+    test.beforeAll(async ({ browser, rhdh }) => {
+      test.setTimeout(10 * 60 * 1000);
 
-    await rhdh.configure({
-      auth: "keycloak",
-      // Default chart tag in registry (avoid "next", which is not always published).
-      version: process.env.RHDH_VERSION ?? "1.10",
-      disableWrappers: DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES,
+      await rhdh.configure({
+        auth: "keycloak",
+        // Default chart tag in registry (avoid "next", which is not always published).
+        version: process.env.RHDH_VERSION ?? "1.10",
+        disableWrappers: DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES,
+      });
+      await rhdh.deploy();
+
+      context = await browser.newContext({
+        baseURL: rhdh.rhdhUrl,
+      });
+      page = await context.newPage();
+      uiHelper = new UIhelper(page);
+      const loginHelper = new LoginHelper(page);
+      await loginHelper.loginAsKeycloakUser();
+      home = new DynamicHomePagePo(page, uiHelper);
     });
-    await rhdh.deploy();
 
-    context = await browser.newContext({
-      baseURL: rhdh.rhdhUrl,
+    test.afterAll(async () => {
+      await context?.close();
     });
-    page = await context.newPage();
-    uiHelper = new UIhelper(page);
-    const loginHelper = new LoginHelper(page);
-    await loginHelper.loginAsKeycloakUser();
-    home = new DynamicHomePagePo(page, uiHelper);
-  });
 
-  test.afterAll(async () => {
-    await context?.close();
-  });
+    test("Verify cards display after login", async () => {
+      await home.seedHomePageWidgets();
+      await home.verifyHomePageLoaded();
+      await home.verifyAllCardsDisplayed();
+      await home.verifyEditButtonVisible();
+    });
 
-  test("Verify cards display after login", async () => {
-    await home.seedHomePageWidgets();
-    await home.verifyHomePageLoaded();
-    await home.verifyAllCardsDisplayed();
-    await home.verifyEditButtonVisible();
-  });
+    test("Verify cards can be individually deleted in edit mode", async () => {
+      await home.enterEditMode();
+      await home.deleteAllCards();
+      await home.verifyCardsDeleted();
+    });
 
-  test("Verify cards can be individually deleted in edit mode", async () => {
-    await home.enterEditMode();
-    await home.deleteAllCards();
-    await home.verifyCardsDeleted();
-  });
+    test("Verify cards can be resized in edit mode", async () => {
+      await home.addWidget("Entity Section");
+      await home.resizeFirstCard();
+      await home.exitEditMode();
+    });
 
-  test("Verify cards can be resized in edit mode", async () => {
-    await home.addWidget("Entity Section");
-    await home.resizeFirstCard();
-    await home.exitEditMode();
-  });
-
-  // restore defaults button is not working as expected
-  // eslint-disable-next-line playwright/no-skipped-test -- re-enable when https://issues.redhat.com/browse/RHDHBUGS-2906 is fixed
-  test.skip("Verify restore default cards and deleted with Clear all button", async () => {
-    await home.restoreDefaultCards();
-    await home.verifyCardsRestored();
-    await home.enterEditMode();
-    await home.clearAllCardsWithButton();
-    await home.verifyCardsDeleted();
-  });
-});
+    // restore defaults button is not working as expected
+    // eslint-disable-next-line playwright/no-skipped-test -- re-enable when https://issues.redhat.com/browse/RHDHBUGS-2906 is fixed
+    test.skip("Verify restore default cards and deleted with Clear all button", async () => {
+      await home.restoreDefaultCards();
+      await home.verifyCardsRestored();
+      await home.enterEditMode();
+      await home.clearAllCardsWithButton();
+      await home.verifyCardsDeleted();
+    });
+  },
+);

--- a/workspaces/keycloak/e2e-tests/tests/specs/catalog-users.spec.ts
+++ b/workspaces/keycloak/e2e-tests/tests/specs/catalog-users.spec.ts
@@ -14,7 +14,15 @@ import {
 } from "@red-hat-developer-hub/e2e-test-utils/keycloak";
 import { CatalogUsersPO } from "../support/page-objects/catalog-users-obj";
 
-test.describe("Test Keycloak plugin", () => {
+test.describe(
+  "Test Keycloak plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "keycloak" },
+    ],
+  },
+  () => {
   let keycloakHelper: KeycloakHelper;
   let keycloakRealm: string;
 
@@ -110,15 +118,16 @@ async function checkUserDetails(
   await CatalogUsersPO.visitBaseURL(page);
 }
 
-test.describe("Test Keycloak plugin metrics", () => {
+test.describe(
+  "Test Keycloak plugin metrics",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "keycloak" },
+    ],
+  },
+  () => {
   let portForward: ChildProcessWithoutNullStreams;
-
-  test.beforeAll(() => {
-    test.info().annotations.push({
-      type: "component",
-      description: "plugins",
-    });
-  });
 
   test.beforeEach(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
     const namespace = rhdh.deploymentConfig.namespace;

--- a/workspaces/keycloak/e2e-tests/tests/specs/catalog-users.spec.ts
+++ b/workspaces/keycloak/e2e-tests/tests/specs/catalog-users.spec.ts
@@ -23,74 +23,81 @@ test.describe(
     ],
   },
   () => {
-  let keycloakHelper: KeycloakHelper;
-  let keycloakRealm: string;
+    let keycloakHelper: KeycloakHelper;
+    let keycloakRealm: string;
 
-  test.beforeAll(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
-    await rhdh.configure({
-      auth: "keycloak",
-      valueFile: "tests/config/value_file.yaml",
-    });
-    await rhdh.deploy();
+    test.beforeAll(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
+      await rhdh.configure({
+        auth: "keycloak",
+        valueFile: "tests/config/value_file.yaml",
+      });
+      await rhdh.deploy();
 
-    keycloakHelper = new KeycloakHelper();
-    const realm = process.env.KEYCLOAK_REALM;
-    if (!realm) {
-      throw new Error("KEYCLOAK_REALM is required for Keycloak plugin tests");
-    }
-    keycloakRealm = realm;
-    await keycloakHelper.connect({
-      baseUrl: process.env.KEYCLOAK_BASE_URL!,
-      realm: keycloakRealm,
-      clientId: process.env.KEYCLOAK_CLIENT_ID!,
-      clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
-    });
-  });
-
-  test.beforeEach(
-    async ({ page, loginHelper }: { page: Page; loginHelper: LoginHelper }) => {
-      await loginHelper.loginAsKeycloakUser();
-      await CatalogUsersPO.visitBaseURL(page);
-    },
-  );
-
-  test("Users on keycloak should match users on backstage", async ({
-    page,
-    uiHelper,
-  }: {
-    page: Page;
-    uiHelper: UIhelper;
-  }) => {
-    const keycloakUsers = await keycloakHelper.getUsers(keycloakRealm);
-    const backStageUsersLocator = CatalogUsersPO.getListOfUsers(page);
-    await uiHelper.waitForLoad();
-    await backStageUsersLocator.first().waitFor({ state: "visible" });
-    const backStageUsersCount = await backStageUsersLocator.count();
-
-    expect(keycloakUsers.length).toBeGreaterThan(0);
-    expect(backStageUsersCount).toBeGreaterThan(0);
-
-    for (let i = 0; i < backStageUsersCount; i++) {
-      const backStageUser = backStageUsersLocator.nth(i);
-      const backStageUserText = await backStageUser.textContent();
-      const userFound = keycloakUsers.find(
-        (user) => user.username === backStageUserText,
-      );
-      expect(userFound).not.toBeNull();
-
-      // eslint-disable-next-line playwright/no-conditional-in-test
-      if (userFound) {
-        await checkUserDetails(
-          page,
-          userFound,
-          keycloakHelper,
-          keycloakRealm,
-          uiHelper,
-        );
+      keycloakHelper = new KeycloakHelper();
+      const realm = process.env.KEYCLOAK_REALM;
+      if (!realm) {
+        throw new Error("KEYCLOAK_REALM is required for Keycloak plugin tests");
       }
-    }
-  });
-});
+      keycloakRealm = realm;
+      await keycloakHelper.connect({
+        baseUrl: process.env.KEYCLOAK_BASE_URL!,
+        realm: keycloakRealm,
+        clientId: process.env.KEYCLOAK_CLIENT_ID!,
+        clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
+      });
+    });
+
+    test.beforeEach(
+      async ({
+        page,
+        loginHelper,
+      }: {
+        page: Page;
+        loginHelper: LoginHelper;
+      }) => {
+        await loginHelper.loginAsKeycloakUser();
+        await CatalogUsersPO.visitBaseURL(page);
+      },
+    );
+
+    test("Users on keycloak should match users on backstage", async ({
+      page,
+      uiHelper,
+    }: {
+      page: Page;
+      uiHelper: UIhelper;
+    }) => {
+      const keycloakUsers = await keycloakHelper.getUsers(keycloakRealm);
+      const backStageUsersLocator = CatalogUsersPO.getListOfUsers(page);
+      await uiHelper.waitForLoad();
+      await backStageUsersLocator.first().waitFor({ state: "visible" });
+      const backStageUsersCount = await backStageUsersLocator.count();
+
+      expect(keycloakUsers.length).toBeGreaterThan(0);
+      expect(backStageUsersCount).toBeGreaterThan(0);
+
+      for (let i = 0; i < backStageUsersCount; i++) {
+        const backStageUser = backStageUsersLocator.nth(i);
+        const backStageUserText = await backStageUser.textContent();
+        const userFound = keycloakUsers.find(
+          (user) => user.username === backStageUserText,
+        );
+        expect(userFound).not.toBeNull();
+
+        // eslint-disable-next-line playwright/no-conditional-in-test
+        if (userFound) {
+          await checkUserDetails(
+            page,
+            userFound,
+            keycloakHelper,
+            keycloakRealm,
+            uiHelper,
+          );
+        }
+      }
+    });
+  },
+);
 
 async function checkUserDetails(
   page: Page,
@@ -127,100 +134,104 @@ test.describe(
     ],
   },
   () => {
-  let portForward: ChildProcessWithoutNullStreams;
+    let portForward: ChildProcessWithoutNullStreams;
 
-  test.beforeEach(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
-    const namespace = rhdh.deploymentConfig.namespace;
-    const result = await $({
-      stdio: ["pipe", "pipe", "pipe"],
-    })`kubectl get svc -n ${namespace} -o json`;
-    const servicesJson = result.stdout ?? "";
-    const services = JSON.parse(servicesJson) as {
-      items?: Array<{
-        metadata?: { name?: string };
-        spec?: {
-          ports?: Array<{ port?: number; targetPort?: number | string }>;
-        };
-      }>;
-    };
-    const hasPort9464 = (p: { port?: number; targetPort?: number | string }) =>
-      Number(p.port) === 9464 || Number(p.targetPort) === 9464;
-    const metricsSvc = services.items?.find((svc) =>
-      svc.spec?.ports?.some(hasPort9464),
-    );
-    const serviceName = metricsSvc?.metadata?.name;
-    if (!serviceName) {
-      throw new Error(
-        `No RHDH metrics service (port 9464) found in namespace ${namespace}. ` +
-          `List services with: kubectl get svc -n ${namespace}`,
+    test.beforeEach(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
+      const namespace = rhdh.deploymentConfig.namespace;
+      const result = await $({
+        stdio: ["pipe", "pipe", "pipe"],
+      })`kubectl get svc -n ${namespace} -o json`;
+      const servicesJson = result.stdout ?? "";
+      const services = JSON.parse(servicesJson) as {
+        items?: Array<{
+          metadata?: { name?: string };
+          spec?: {
+            ports?: Array<{ port?: number; targetPort?: number | string }>;
+          };
+        }>;
+      };
+      const hasPort9464 = (p: {
+        port?: number;
+        targetPort?: number | string;
+      }) => Number(p.port) === 9464 || Number(p.targetPort) === 9464;
+      const metricsSvc = services.items?.find((svc) =>
+        svc.spec?.ports?.some(hasPort9464),
       );
-    }
+      const serviceName = metricsSvc?.metadata?.name;
+      if (!serviceName) {
+        throw new Error(
+          `No RHDH metrics service (port 9464) found in namespace ${namespace}. ` +
+            `List services with: kubectl get svc -n ${namespace}`,
+        );
+      }
 
-    const login =
-      process.env.K8S_CLUSTER_TOKEN && process.env.K8S_CLUSTER_URL
-        ? `oc login --token="${process.env.K8S_CLUSTER_TOKEN}" --server="${process.env.K8S_CLUSTER_URL}" --insecure-skip-tls-verify=true && `
-        : "";
-    const cmd = `${login}kubectl config set-context --current --namespace="${namespace}" 2>/dev/null; kubectl port-forward service/${serviceName} 9464:9464 --namespace="${namespace}"`;
-    portForward = spawn("/bin/sh", ["-c", cmd]);
+      const login =
+        process.env.K8S_CLUSTER_TOKEN && process.env.K8S_CLUSTER_URL
+          ? `oc login --token="${process.env.K8S_CLUSTER_TOKEN}" --server="${process.env.K8S_CLUSTER_URL}" --insecure-skip-tls-verify=true && `
+          : "";
+      const cmd = `${login}kubectl config set-context --current --namespace="${namespace}" 2>/dev/null; kubectl port-forward service/${serviceName} 9464:9464 --namespace="${namespace}"`;
+      portForward = spawn("/bin/sh", ["-c", cmd]);
 
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error("Port-forward readiness timeout"));
-      }, 15000);
-      portForward.stdout?.on("data", (data: Buffer) => {
-        if (data.toString().includes("Forwarding from 127.0.0.1:9464")) {
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("Port-forward readiness timeout"));
+        }, 15000);
+        portForward.stdout?.on("data", (data: Buffer) => {
+          if (data.toString().includes("Forwarding from 127.0.0.1:9464")) {
+            clearTimeout(timeout);
+            resolve();
+          }
+        });
+        portForward.stderr?.on("data", (data: Buffer) => {
+          const s = data.toString();
+          if (s.includes("Forwarding from 127.0.0.1:9464")) {
+            clearTimeout(timeout);
+            resolve();
+          } else {
+            console.error("Port-forward stderr:", s);
+          }
+        });
+        portForward.on("error", (err) => {
           clearTimeout(timeout);
-          resolve();
-        }
-      });
-      portForward.stderr?.on("data", (data: Buffer) => {
-        const s = data.toString();
-        if (s.includes("Forwarding from 127.0.0.1:9464")) {
-          clearTimeout(timeout);
-          resolve();
-        } else {
-          console.error("Port-forward stderr:", s);
-        }
-      });
-      portForward.on("error", (err) => {
-        clearTimeout(timeout);
-        reject(err);
+          reject(err);
+        });
       });
     });
-  });
 
-  test.afterEach(async () => {
-    if (portForward?.pid) {
-      try {
-        portForward.kill("SIGKILL");
-      } catch {
-        // ignore
+    test.afterEach(async () => {
+      if (portForward?.pid) {
+        try {
+          portForward.kill("SIGKILL");
+        } catch {
+          // ignore
+        }
       }
-    }
-    await $`pkill -f 'kubectl port-forward.*9464:9464' 2>/dev/null || true`.nothrow();
-  });
+      await $`pkill -f 'kubectl port-forward.*9464:9464' 2>/dev/null || true`.nothrow();
+    });
 
-  test("keycloak metrics with failure counters", async () => {
-    const metricsEndpointURL = "http://localhost:9464/metrics";
-    const metricLines = await fetchMetrics(metricsEndpointURL);
+    test("keycloak metrics with failure counters", async () => {
+      const metricsEndpointURL = "http://localhost:9464/metrics";
+      const metricLines = await fetchMetrics(metricsEndpointURL);
 
-    const catalogMetricPrefix =
-      'backend_keycloak_fetch_task_failure_count_total{taskInstanceId="';
-    const hasCatalogMetric = metricLines.some(
-      (line) =>
-        line.startsWith(catalogMetricPrefix) && /"} \d+$/.test(line.trimEnd()),
-    );
-    const hasKeycloakRelatedMetric = metricLines.some((l) =>
-      /keycloak/i.test(l),
-    );
+      const catalogMetricPrefix =
+        'backend_keycloak_fetch_task_failure_count_total{taskInstanceId="';
+      const hasCatalogMetric = metricLines.some(
+        (line) =>
+          line.startsWith(catalogMetricPrefix) &&
+          /"} \d+$/.test(line.trimEnd()),
+      );
+      const hasKeycloakRelatedMetric = metricLines.some((l) =>
+        /keycloak/i.test(l),
+      );
 
-    expect(metricLines.length).toBeGreaterThan(0);
-    expect(
-      hasCatalogMetric || hasKeycloakRelatedMetric,
-      "Expected /metrics to contain backend_keycloak_fetch_task_failure_count_total or keycloak-related metrics (e.g. RHDH Keycloak instance)",
-    ).toBeTruthy();
-  });
-});
+      expect(metricLines.length).toBeGreaterThan(0);
+      expect(
+        hasCatalogMetric || hasKeycloakRelatedMetric,
+        "Expected /metrics to contain backend_keycloak_fetch_task_failure_count_total or keycloak-related metrics (e.g. RHDH Keycloak instance)",
+      ).toBeTruthy();
+    });
+  },
+);
 
 async function fetchMetrics(metricsEndpointUrl: string): Promise<string[]> {
   const response = await fetch(metricsEndpointUrl, {

--- a/workspaces/keycloak/e2e-tests/tests/specs/catalog-users.spec.ts
+++ b/workspaces/keycloak/e2e-tests/tests/specs/catalog-users.spec.ts
@@ -14,90 +14,79 @@ import {
 } from "@red-hat-developer-hub/e2e-test-utils/keycloak";
 import { CatalogUsersPO } from "../support/page-objects/catalog-users-obj";
 
-test.describe(
-  "Test Keycloak plugin",
-  {
-    annotation: [
+test.describe("Test Keycloak plugin", () => {
+  let keycloakHelper: KeycloakHelper;
+  let keycloakRealm: string;
+
+  test.beforeAll(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "keycloak" },
-    ],
-  },
-  () => {
-    let keycloakHelper: KeycloakHelper;
-    let keycloakRealm: string;
-
-    test.beforeAll(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
-      await rhdh.configure({
-        auth: "keycloak",
-        valueFile: "tests/config/value_file.yaml",
-      });
-      await rhdh.deploy();
-
-      keycloakHelper = new KeycloakHelper();
-      const realm = process.env.KEYCLOAK_REALM;
-      if (!realm) {
-        throw new Error("KEYCLOAK_REALM is required for Keycloak plugin tests");
-      }
-      keycloakRealm = realm;
-      await keycloakHelper.connect({
-        baseUrl: process.env.KEYCLOAK_BASE_URL!,
-        realm: keycloakRealm,
-        clientId: process.env.KEYCLOAK_CLIENT_ID!,
-        clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
-      });
-    });
-
-    test.beforeEach(
-      async ({
-        page,
-        loginHelper,
-      }: {
-        page: Page;
-        loginHelper: LoginHelper;
-      }) => {
-        await loginHelper.loginAsKeycloakUser();
-        await CatalogUsersPO.visitBaseURL(page);
-      },
     );
-
-    test("Users on keycloak should match users on backstage", async ({
-      page,
-      uiHelper,
-    }: {
-      page: Page;
-      uiHelper: UIhelper;
-    }) => {
-      const keycloakUsers = await keycloakHelper.getUsers(keycloakRealm);
-      const backStageUsersLocator = CatalogUsersPO.getListOfUsers(page);
-      await uiHelper.waitForLoad();
-      await backStageUsersLocator.first().waitFor({ state: "visible" });
-      const backStageUsersCount = await backStageUsersLocator.count();
-
-      expect(keycloakUsers.length).toBeGreaterThan(0);
-      expect(backStageUsersCount).toBeGreaterThan(0);
-
-      for (let i = 0; i < backStageUsersCount; i++) {
-        const backStageUser = backStageUsersLocator.nth(i);
-        const backStageUserText = await backStageUser.textContent();
-        const userFound = keycloakUsers.find(
-          (user) => user.username === backStageUserText,
-        );
-        expect(userFound).not.toBeNull();
-
-        // eslint-disable-next-line playwright/no-conditional-in-test
-        if (userFound) {
-          await checkUserDetails(
-            page,
-            userFound,
-            keycloakHelper,
-            keycloakRealm,
-            uiHelper,
-          );
-        }
-      }
+    await rhdh.configure({
+      auth: "keycloak",
+      valueFile: "tests/config/value_file.yaml",
     });
-  },
-);
+    await rhdh.deploy();
+
+    keycloakHelper = new KeycloakHelper();
+    const realm = process.env.KEYCLOAK_REALM;
+    if (!realm) {
+      throw new Error("KEYCLOAK_REALM is required for Keycloak plugin tests");
+    }
+    keycloakRealm = realm;
+    await keycloakHelper.connect({
+      baseUrl: process.env.KEYCLOAK_BASE_URL!,
+      realm: keycloakRealm,
+      clientId: process.env.KEYCLOAK_CLIENT_ID!,
+      clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
+    });
+  });
+
+  test.beforeEach(
+    async ({ page, loginHelper }: { page: Page; loginHelper: LoginHelper }) => {
+      await loginHelper.loginAsKeycloakUser();
+      await CatalogUsersPO.visitBaseURL(page);
+    },
+  );
+
+  test("Users on keycloak should match users on backstage", async ({
+    page,
+    uiHelper,
+  }: {
+    page: Page;
+    uiHelper: UIhelper;
+  }) => {
+    const keycloakUsers = await keycloakHelper.getUsers(keycloakRealm);
+    const backStageUsersLocator = CatalogUsersPO.getListOfUsers(page);
+    await uiHelper.waitForLoad();
+    await backStageUsersLocator.first().waitFor({ state: "visible" });
+    const backStageUsersCount = await backStageUsersLocator.count();
+
+    expect(keycloakUsers.length).toBeGreaterThan(0);
+    expect(backStageUsersCount).toBeGreaterThan(0);
+
+    for (let i = 0; i < backStageUsersCount; i++) {
+      const backStageUser = backStageUsersLocator.nth(i);
+      const backStageUserText = await backStageUser.textContent();
+      const userFound = keycloakUsers.find(
+        (user) => user.username === backStageUserText,
+      );
+      expect(userFound).not.toBeNull();
+
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (userFound) {
+        await checkUserDetails(
+          page,
+          userFound,
+          keycloakHelper,
+          keycloakRealm,
+          uiHelper,
+        );
+      }
+    }
+  });
+});
 
 async function checkUserDetails(
   page: Page,
@@ -125,113 +114,108 @@ async function checkUserDetails(
   await CatalogUsersPO.visitBaseURL(page);
 }
 
-test.describe(
-  "Test Keycloak plugin metrics",
-  {
-    annotation: [
+test.describe("Test Keycloak plugin metrics", () => {
+  let portForward: ChildProcessWithoutNullStreams;
+
+  test.beforeAll(() => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "keycloak" },
-    ],
-  },
-  () => {
-    let portForward: ChildProcessWithoutNullStreams;
+    );
+  });
 
-    test.beforeEach(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
-      const namespace = rhdh.deploymentConfig.namespace;
-      const result = await $({
-        stdio: ["pipe", "pipe", "pipe"],
-      })`kubectl get svc -n ${namespace} -o json`;
-      const servicesJson = result.stdout ?? "";
-      const services = JSON.parse(servicesJson) as {
-        items?: Array<{
-          metadata?: { name?: string };
-          spec?: {
-            ports?: Array<{ port?: number; targetPort?: number | string }>;
-          };
-        }>;
-      };
-      const hasPort9464 = (p: {
-        port?: number;
-        targetPort?: number | string;
-      }) => Number(p.port) === 9464 || Number(p.targetPort) === 9464;
-      const metricsSvc = services.items?.find((svc) =>
-        svc.spec?.ports?.some(hasPort9464),
+  test.beforeEach(async ({ rhdh }: { rhdh: RHDHDeployment }) => {
+    const namespace = rhdh.deploymentConfig.namespace;
+    const result = await $({
+      stdio: ["pipe", "pipe", "pipe"],
+    })`kubectl get svc -n ${namespace} -o json`;
+    const servicesJson = result.stdout ?? "";
+    const services = JSON.parse(servicesJson) as {
+      items?: Array<{
+        metadata?: { name?: string };
+        spec?: {
+          ports?: Array<{ port?: number; targetPort?: number | string }>;
+        };
+      }>;
+    };
+    const hasPort9464 = (p: { port?: number; targetPort?: number | string }) =>
+      Number(p.port) === 9464 || Number(p.targetPort) === 9464;
+    const metricsSvc = services.items?.find((svc) =>
+      svc.spec?.ports?.some(hasPort9464),
+    );
+    const serviceName = metricsSvc?.metadata?.name;
+    if (!serviceName) {
+      throw new Error(
+        `No RHDH metrics service (port 9464) found in namespace ${namespace}. ` +
+          `List services with: kubectl get svc -n ${namespace}`,
       );
-      const serviceName = metricsSvc?.metadata?.name;
-      if (!serviceName) {
-        throw new Error(
-          `No RHDH metrics service (port 9464) found in namespace ${namespace}. ` +
-            `List services with: kubectl get svc -n ${namespace}`,
-        );
-      }
+    }
 
-      const login =
-        process.env.K8S_CLUSTER_TOKEN && process.env.K8S_CLUSTER_URL
-          ? `oc login --token="${process.env.K8S_CLUSTER_TOKEN}" --server="${process.env.K8S_CLUSTER_URL}" --insecure-skip-tls-verify=true && `
-          : "";
-      const cmd = `${login}kubectl config set-context --current --namespace="${namespace}" 2>/dev/null; kubectl port-forward service/${serviceName} 9464:9464 --namespace="${namespace}"`;
-      portForward = spawn("/bin/sh", ["-c", cmd]);
+    const login =
+      process.env.K8S_CLUSTER_TOKEN && process.env.K8S_CLUSTER_URL
+        ? `oc login --token="${process.env.K8S_CLUSTER_TOKEN}" --server="${process.env.K8S_CLUSTER_URL}" --insecure-skip-tls-verify=true && `
+        : "";
+    const cmd = `${login}kubectl config set-context --current --namespace="${namespace}" 2>/dev/null; kubectl port-forward service/${serviceName} 9464:9464 --namespace="${namespace}"`;
+    portForward = spawn("/bin/sh", ["-c", cmd]);
 
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error("Port-forward readiness timeout"));
-        }, 15000);
-        portForward.stdout?.on("data", (data: Buffer) => {
-          if (data.toString().includes("Forwarding from 127.0.0.1:9464")) {
-            clearTimeout(timeout);
-            resolve();
-          }
-        });
-        portForward.stderr?.on("data", (data: Buffer) => {
-          const s = data.toString();
-          if (s.includes("Forwarding from 127.0.0.1:9464")) {
-            clearTimeout(timeout);
-            resolve();
-          } else {
-            console.error("Port-forward stderr:", s);
-          }
-        });
-        portForward.on("error", (err) => {
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("Port-forward readiness timeout"));
+      }, 15000);
+      portForward.stdout?.on("data", (data: Buffer) => {
+        if (data.toString().includes("Forwarding from 127.0.0.1:9464")) {
           clearTimeout(timeout);
-          reject(err);
-        });
+          resolve();
+        }
+      });
+      portForward.stderr?.on("data", (data: Buffer) => {
+        const s = data.toString();
+        if (s.includes("Forwarding from 127.0.0.1:9464")) {
+          clearTimeout(timeout);
+          resolve();
+        } else {
+          console.error("Port-forward stderr:", s);
+        }
+      });
+      portForward.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
       });
     });
+  });
 
-    test.afterEach(async () => {
-      if (portForward?.pid) {
-        try {
-          portForward.kill("SIGKILL");
-        } catch {
-          // ignore
-        }
+  test.afterEach(async () => {
+    if (portForward?.pid) {
+      try {
+        portForward.kill("SIGKILL");
+      } catch {
+        // ignore
       }
-      await $`pkill -f 'kubectl port-forward.*9464:9464' 2>/dev/null || true`.nothrow();
-    });
+    }
+    await $`pkill -f 'kubectl port-forward.*9464:9464' 2>/dev/null || true`.nothrow();
+  });
 
-    test("keycloak metrics with failure counters", async () => {
-      const metricsEndpointURL = "http://localhost:9464/metrics";
-      const metricLines = await fetchMetrics(metricsEndpointURL);
+  test("keycloak metrics with failure counters", async () => {
+    const metricsEndpointURL = "http://localhost:9464/metrics";
+    const metricLines = await fetchMetrics(metricsEndpointURL);
 
-      const catalogMetricPrefix =
-        'backend_keycloak_fetch_task_failure_count_total{taskInstanceId="';
-      const hasCatalogMetric = metricLines.some(
-        (line) =>
-          line.startsWith(catalogMetricPrefix) &&
-          /"} \d+$/.test(line.trimEnd()),
-      );
-      const hasKeycloakRelatedMetric = metricLines.some((l) =>
-        /keycloak/i.test(l),
-      );
+    const catalogMetricPrefix =
+      'backend_keycloak_fetch_task_failure_count_total{taskInstanceId="';
+    const hasCatalogMetric = metricLines.some(
+      (line) =>
+        line.startsWith(catalogMetricPrefix) && /"} \d+$/.test(line.trimEnd()),
+    );
+    const hasKeycloakRelatedMetric = metricLines.some((l) =>
+      /keycloak/i.test(l),
+    );
 
-      expect(metricLines.length).toBeGreaterThan(0);
-      expect(
-        hasCatalogMetric || hasKeycloakRelatedMetric,
-        "Expected /metrics to contain backend_keycloak_fetch_task_failure_count_total or keycloak-related metrics (e.g. RHDH Keycloak instance)",
-      ).toBeTruthy();
-    });
-  },
-);
+    expect(metricLines.length).toBeGreaterThan(0);
+    expect(
+      hasCatalogMetric || hasKeycloakRelatedMetric,
+      "Expected /metrics to contain backend_keycloak_fetch_task_failure_count_total or keycloak-related metrics (e.g. RHDH Keycloak instance)",
+    ).toBeTruthy();
+  });
+});
 
 async function fetchMetrics(metricsEndpointUrl: string): Promise<string[]> {
   const response = await fetch(metricsEndpointUrl, {

--- a/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
+++ b/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
@@ -2,103 +2,98 @@ import { test, expect } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { ImageRegistry } from "../utils/image-registry";
 import { QuayClient } from "../utils/quay-client";
 
-test.describe(
-  "Test Quay.io plugin",
-  {
-    annotation: [
+test.describe("Test Quay.io plugin", () => {
+  const quayRepository = "rhdh-community/rhdh";
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "quay" },
-    ],
-  },
-  () => {
-    const quayRepository = "rhdh-community/rhdh";
+    );
+    await rhdh.configure({ auth: "guest" });
+    await rhdh.deploy();
+  });
 
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({ auth: "guest" });
-      await rhdh.deploy();
+  test.beforeEach(async ({ loginHelper }) => {
+    await loginHelper.loginAsGuest();
+  });
+
+  test.describe("Image Registry tab", () => {
+    test.beforeEach(async ({ uiHelper }) => {
+      await uiHelper.openCatalogSidebar("Component");
+      await uiHelper.searchInputPlaceholder("Developer Hub");
+      await uiHelper.clickLink("Red Hat Developer Hub");
+      await uiHelper.clickTab("Image Registry");
     });
 
-    test.beforeEach(async ({ loginHelper }) => {
-      await loginHelper.loginAsGuest();
+    test("Check if Image Registry is present", async ({ page, uiHelper }) => {
+      await uiHelper.verifyHeading(quayRepository);
+
+      const allGridColumnsText = ImageRegistry.getAllGridColumnsText();
+
+      // Verify Headers
+      for (const column of allGridColumnsText) {
+        const columnLocator = page
+          .getByRole("columnheader")
+          .filter({ hasText: column });
+        await expect(columnLocator).toBeVisible();
+      }
+
+      await page.getByTestId("quay-repo-table").waitFor({ state: "visible" });
+      // Verify cells with the adjusted selector
+      const allCellsIdentifier = ImageRegistry.getAllCellsIdentifier();
+      await uiHelper.verifyCellsInTable(allCellsIdentifier);
     });
 
-    test.describe("Image Registry tab", () => {
-      test.beforeEach(async ({ uiHelper }) => {
-        await uiHelper.openCatalogSidebar("Component");
-        await uiHelper.searchInputPlaceholder("Developer Hub");
-        await uiHelper.clickLink("Red Hat Developer Hub");
-        await uiHelper.clickTab("Image Registry");
+    test("Check Security Scan details", async ({ page }) => {
+      const cell = await ImageRegistry.getScanCell(page);
+      await expect(cell).toBeVisible();
+    });
+  });
+
+  test.describe("Quay Actions", () => {
+    let repository: string;
+    const quayClient = new QuayClient();
+
+    test.beforeEach(async ({ uiHelper }) => {
+      await uiHelper.clickLink({
+        ariaLabel: "Self-service",
       });
-
-      test("Check if Image Registry is present", async ({ page, uiHelper }) => {
-        await uiHelper.verifyHeading(quayRepository);
-
-        const allGridColumnsText = ImageRegistry.getAllGridColumnsText();
-
-        // Verify Headers
-        for (const column of allGridColumnsText) {
-          const columnLocator = page
-            .getByRole("columnheader")
-            .filter({ hasText: column });
-          await expect(columnLocator).toBeVisible();
-        }
-
-        await page.getByTestId("quay-repo-table").waitFor({ state: "visible" });
-        // Verify cells with the adjusted selector
-        const allCellsIdentifier = ImageRegistry.getAllCellsIdentifier();
-        await uiHelper.verifyCellsInTable(allCellsIdentifier);
-      });
-
-      test("Check Security Scan details", async ({ page }) => {
-        const cell = await ImageRegistry.getScanCell(page);
-        await expect(cell).toBeVisible();
-      });
+      await uiHelper.verifyHeading("Self-service");
     });
 
-    test.describe("Quay Actions", () => {
-      let repository: string;
-      const quayClient = new QuayClient();
-
-      test.beforeEach(async ({ uiHelper }) => {
-        await uiHelper.clickLink({
-          ariaLabel: "Self-service",
-        });
-        await uiHelper.verifyHeading("Self-service");
-      });
-
-      test.afterEach(async () => {
-        await quayClient.deleteRepository(
-          process.env.VAULT_QUAY_NAMESPACE!,
-          repository,
-        );
-      });
-
-      test("Creates Quay repository", async ({ page, uiHelper }) => {
-        repository = `quay-actions-create-${Date.now()}`;
-        const description =
-          "This is just a test repository to test the 'quay:create-repository' template action";
-        await uiHelper.clickBtnInCard("Create a Quay repository", "Choose");
-        await uiHelper.waitForTitle("Create a Quay repository", 2);
-
-        await uiHelper.fillTextInputByLabel("Repository name", repository);
-        await uiHelper.fillTextInputByLabel(
-          "Token",
-          process.env.VAULT_QUAY_TOKEN!,
-        );
-        await uiHelper.fillTextInputByLabel(
-          "namespace",
-          process.env.VAULT_QUAY_NAMESPACE!,
-        );
-        await page.getByRole("button", { name: "Visibility​" }).click();
-        await page.getByRole("option", { name: "public" }).click();
-        await uiHelper.fillTextInputByLabel("Description", description);
-        await uiHelper.clickButton("Review");
-        await uiHelper.clickButton("Create");
-        await expect(
-          page.getByRole("link", { name: "Quay repository link" }),
-        ).toBeVisible();
-        await uiHelper.clickLink("Quay repository link");
-      });
+    test.afterEach(async () => {
+      await quayClient.deleteRepository(
+        process.env.VAULT_QUAY_NAMESPACE!,
+        repository,
+      );
     });
-  },
-);
+
+    test("Creates Quay repository", async ({ page, uiHelper }) => {
+      repository = `quay-actions-create-${Date.now()}`;
+      const description =
+        "This is just a test repository to test the 'quay:create-repository' template action";
+      await uiHelper.clickBtnInCard("Create a Quay repository", "Choose");
+      await uiHelper.waitForTitle("Create a Quay repository", 2);
+
+      await uiHelper.fillTextInputByLabel("Repository name", repository);
+      await uiHelper.fillTextInputByLabel(
+        "Token",
+        process.env.VAULT_QUAY_TOKEN!,
+      );
+      await uiHelper.fillTextInputByLabel(
+        "namespace",
+        process.env.VAULT_QUAY_NAMESPACE!,
+      );
+      await page.getByRole("button", { name: "Visibility​" }).click();
+      await page.getByRole("option", { name: "public" }).click();
+      await uiHelper.fillTextInputByLabel("Description", description);
+      await uiHelper.clickButton("Review");
+      await uiHelper.clickButton("Create");
+      await expect(
+        page.getByRole("link", { name: "Quay repository link" }),
+      ).toBeVisible();
+      await uiHelper.clickLink("Quay repository link");
+    });
+  });
+});

--- a/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
+++ b/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
@@ -11,93 +11,94 @@ test.describe(
     ],
   },
   () => {
-  const quayRepository = "rhdh-community/rhdh";
+    const quayRepository = "rhdh-community/rhdh";
 
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({ auth: "guest" });
-    await rhdh.deploy();
-  });
-
-  test.beforeEach(async ({ loginHelper }) => {
-    await loginHelper.loginAsGuest();
-  });
-
-  test.describe("Image Registry tab", () => {
-    test.beforeEach(async ({ uiHelper }) => {
-      await uiHelper.openCatalogSidebar("Component");
-      await uiHelper.searchInputPlaceholder("Developer Hub");
-      await uiHelper.clickLink("Red Hat Developer Hub");
-      await uiHelper.clickTab("Image Registry");
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({ auth: "guest" });
+      await rhdh.deploy();
     });
 
-    test("Check if Image Registry is present", async ({ page, uiHelper }) => {
-      await uiHelper.verifyHeading(quayRepository);
-
-      const allGridColumnsText = ImageRegistry.getAllGridColumnsText();
-
-      // Verify Headers
-      for (const column of allGridColumnsText) {
-        const columnLocator = page
-          .getByRole("columnheader")
-          .filter({ hasText: column });
-        await expect(columnLocator).toBeVisible();
-      }
-
-      await page.getByTestId("quay-repo-table").waitFor({ state: "visible" });
-      // Verify cells with the adjusted selector
-      const allCellsIdentifier = ImageRegistry.getAllCellsIdentifier();
-      await uiHelper.verifyCellsInTable(allCellsIdentifier);
+    test.beforeEach(async ({ loginHelper }) => {
+      await loginHelper.loginAsGuest();
     });
 
-    test("Check Security Scan details", async ({ page }) => {
-      const cell = await ImageRegistry.getScanCell(page);
-      await expect(cell).toBeVisible();
-    });
-  });
-
-  test.describe("Quay Actions", () => {
-    let repository: string;
-    const quayClient = new QuayClient();
-
-    test.beforeEach(async ({ uiHelper }) => {
-      await uiHelper.clickLink({
-        ariaLabel: "Self-service",
+    test.describe("Image Registry tab", () => {
+      test.beforeEach(async ({ uiHelper }) => {
+        await uiHelper.openCatalogSidebar("Component");
+        await uiHelper.searchInputPlaceholder("Developer Hub");
+        await uiHelper.clickLink("Red Hat Developer Hub");
+        await uiHelper.clickTab("Image Registry");
       });
-      await uiHelper.verifyHeading("Self-service");
+
+      test("Check if Image Registry is present", async ({ page, uiHelper }) => {
+        await uiHelper.verifyHeading(quayRepository);
+
+        const allGridColumnsText = ImageRegistry.getAllGridColumnsText();
+
+        // Verify Headers
+        for (const column of allGridColumnsText) {
+          const columnLocator = page
+            .getByRole("columnheader")
+            .filter({ hasText: column });
+          await expect(columnLocator).toBeVisible();
+        }
+
+        await page.getByTestId("quay-repo-table").waitFor({ state: "visible" });
+        // Verify cells with the adjusted selector
+        const allCellsIdentifier = ImageRegistry.getAllCellsIdentifier();
+        await uiHelper.verifyCellsInTable(allCellsIdentifier);
+      });
+
+      test("Check Security Scan details", async ({ page }) => {
+        const cell = await ImageRegistry.getScanCell(page);
+        await expect(cell).toBeVisible();
+      });
     });
 
-    test.afterEach(async () => {
-      await quayClient.deleteRepository(
-        process.env.VAULT_QUAY_NAMESPACE!,
-        repository,
-      );
-    });
+    test.describe("Quay Actions", () => {
+      let repository: string;
+      const quayClient = new QuayClient();
 
-    test("Creates Quay repository", async ({ page, uiHelper }) => {
-      repository = `quay-actions-create-${Date.now()}`;
-      const description =
-        "This is just a test repository to test the 'quay:create-repository' template action";
-      await uiHelper.clickBtnInCard("Create a Quay repository", "Choose");
-      await uiHelper.waitForTitle("Create a Quay repository", 2);
+      test.beforeEach(async ({ uiHelper }) => {
+        await uiHelper.clickLink({
+          ariaLabel: "Self-service",
+        });
+        await uiHelper.verifyHeading("Self-service");
+      });
 
-      await uiHelper.fillTextInputByLabel("Repository name", repository);
-      await uiHelper.fillTextInputByLabel(
-        "Token",
-        process.env.VAULT_QUAY_TOKEN!,
-      );
-      await uiHelper.fillTextInputByLabel(
-        "namespace",
-        process.env.VAULT_QUAY_NAMESPACE!,
-      );
-      await page.getByRole("button", { name: "Visibility​" }).click();
-      await page.getByRole("option", { name: "public" }).click();
-      await uiHelper.fillTextInputByLabel("Description", description);
-      await uiHelper.clickButton("Review");
-      await uiHelper.clickButton("Create");
-      await expect(
-        page.getByRole("link", { name: "Quay repository link" }),
-      ).toBeVisible();
-      await uiHelper.clickLink("Quay repository link");
+      test.afterEach(async () => {
+        await quayClient.deleteRepository(
+          process.env.VAULT_QUAY_NAMESPACE!,
+          repository,
+        );
+      });
+
+      test("Creates Quay repository", async ({ page, uiHelper }) => {
+        repository = `quay-actions-create-${Date.now()}`;
+        const description =
+          "This is just a test repository to test the 'quay:create-repository' template action";
+        await uiHelper.clickBtnInCard("Create a Quay repository", "Choose");
+        await uiHelper.waitForTitle("Create a Quay repository", 2);
+
+        await uiHelper.fillTextInputByLabel("Repository name", repository);
+        await uiHelper.fillTextInputByLabel(
+          "Token",
+          process.env.VAULT_QUAY_TOKEN!,
+        );
+        await uiHelper.fillTextInputByLabel(
+          "namespace",
+          process.env.VAULT_QUAY_NAMESPACE!,
+        );
+        await page.getByRole("button", { name: "Visibility​" }).click();
+        await page.getByRole("option", { name: "public" }).click();
+        await uiHelper.fillTextInputByLabel("Description", description);
+        await uiHelper.clickButton("Review");
+        await uiHelper.clickButton("Create");
+        await expect(
+          page.getByRole("link", { name: "Quay repository link" }),
+        ).toBeVisible();
+        await uiHelper.clickLink("Quay repository link");
+      });
     });
-  });
-});
+  },
+);

--- a/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
+++ b/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
@@ -2,7 +2,15 @@ import { test, expect } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { ImageRegistry } from "../utils/image-registry";
 import { QuayClient } from "../utils/quay-client";
 
-test.describe("Test Quay.io plugin", () => {
+test.describe(
+  "Test Quay.io plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "quay" },
+    ],
+  },
+  () => {
   const quayRepository = "rhdh-community/rhdh";
 
   test.beforeAll(async ({ rhdh }) => {

--- a/workspaces/quickstart/e2e-tests/tests/specs/quick-start.spec.ts
+++ b/workspaces/quickstart/e2e-tests/tests/specs/quick-start.spec.ts
@@ -9,79 +9,80 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({ auth: "keycloak" });
-    await rhdh.deploy();
-  });
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({ auth: "keycloak" });
+      await rhdh.deploy();
+    });
 
-  test("Access Quick start as Guest or Admin", async ({
-    loginHelper,
-    page,
-    uiHelper,
-  }) => {
-    await loginHelper.loginAsGuest();
-    await uiHelper.verifyText("Let's get you started with Developer Hub");
-    await uiHelper.verifyText("We'll guide you through a few quick steps");
-    await uiHelper.verifyText("Not started");
+    test("Access Quick start as Guest or Admin", async ({
+      loginHelper,
+      page,
+      uiHelper,
+    }) => {
+      await loginHelper.loginAsGuest();
+      await uiHelper.verifyText("Let's get you started with Developer Hub");
+      await uiHelper.verifyText("We'll guide you through a few quick steps");
+      await uiHelper.verifyText("Not started");
 
-    await uiHelper.clickButtonByText("Set up authentication");
-    await uiHelper.verifyTextVisible("Set up secure login credentials");
-    await uiHelper.verifyButtonURL(
-      "Learn more",
-      "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/",
-      { exact: false },
-    );
+      await uiHelper.clickButtonByText("Set up authentication");
+      await uiHelper.verifyTextVisible("Set up secure login credentials");
+      await uiHelper.verifyButtonURL(
+        "Learn more",
+        "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/",
+        { exact: false },
+      );
 
-    await uiHelper.clickButtonByText("Configure RBAC");
-    await uiHelper.verifyTextVisible("Assign roles and permissions");
-    await uiHelper.verifyButtonURL("Manage access", "/rbac");
+      await uiHelper.clickButtonByText("Configure RBAC");
+      await uiHelper.verifyTextVisible("Assign roles and permissions");
+      await uiHelper.verifyButtonURL("Manage access", "/rbac");
 
-    await uiHelper.clickButtonByText("Configure Git");
-    await uiHelper.verifyTextVisible("Connect your Git providers");
-    await uiHelper.verifyButtonURL(
-      "Learn more",
-      "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/",
-      { exact: false },
-    );
+      await uiHelper.clickButtonByText("Configure Git");
+      await uiHelper.verifyTextVisible("Connect your Git providers");
+      await uiHelper.verifyButtonURL(
+        "Learn more",
+        "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/",
+        { exact: false },
+      );
 
-    await uiHelper.clickButtonByText("Manage plugins");
-    await uiHelper.verifyTextVisible("Browse and install extensions");
-    await uiHelper.verifyButtonURL("Explore plugins", "/extensions");
-    await uiHelper.clickButtonByText("Explore plugins");
-    await uiHelper.verifyText("Catalog");
-    await uiHelper.verifyText(/Plugins \((\d+)\)/);
-    await uiHelper.verifyText("25% progress");
+      await uiHelper.clickButtonByText("Manage plugins");
+      await uiHelper.verifyTextVisible("Browse and install extensions");
+      await uiHelper.verifyButtonURL("Explore plugins", "/extensions");
+      await uiHelper.clickButtonByText("Explore plugins");
+      await uiHelper.verifyText("Catalog");
+      await uiHelper.verifyText(/Plugins \((\d+)\)/);
+      await uiHelper.verifyText("25% progress");
 
-    await uiHelper.clickButton("Hide");
-    await expect(page.getByRole("button", { name: "Hide" })).toBeHidden();
-  });
+      await uiHelper.clickButton("Hide");
+      await expect(page.getByRole("button", { name: "Hide" })).toBeHidden();
+    });
 
-  test("Access Quick start as User", async ({ loginHelper, uiHelper }) => {
-    await loginHelper.loginAsKeycloakUser();
-    await uiHelper.verifyText("Let's get you started with Developer Hub");
-    await uiHelper.verifyText("We'll guide you through a few quick steps");
+    test("Access Quick start as User", async ({ loginHelper, uiHelper }) => {
+      await loginHelper.loginAsKeycloakUser();
+      await uiHelper.verifyText("Let's get you started with Developer Hub");
+      await uiHelper.verifyText("We'll guide you through a few quick steps");
 
-    await uiHelper.clickButtonByText("Import application");
-    await uiHelper.verifyTextVisible("Import your existing code");
-    await uiHelper.verifyButtonURL("Import", "/bulk-import");
+      await uiHelper.clickButtonByText("Import application");
+      await uiHelper.verifyTextVisible("Import your existing code");
+      await uiHelper.verifyButtonURL("Import", "/bulk-import");
 
-    await uiHelper.clickButtonByText("Learn about the Catalog");
-    await uiHelper.verifyTextVisible("Discover all software components");
-    await uiHelper.verifyButtonURL("View Catalog", "/catalog");
-    await uiHelper.clickButtonByText("View Catalog");
-    await uiHelper.verifyHeading(/All components \((\d+)\)/);
+      await uiHelper.clickButtonByText("Learn about the Catalog");
+      await uiHelper.verifyTextVisible("Discover all software components");
+      await uiHelper.verifyButtonURL("View Catalog", "/catalog");
+      await uiHelper.clickButtonByText("View Catalog");
+      await uiHelper.verifyHeading(/All components \((\d+)\)/);
 
-    await uiHelper.clickButtonByText("Explore Self-service templates");
-    await uiHelper.verifyTextVisible("Use our self-service templates");
-    await uiHelper.verifyButtonURL("Explore templates", "/create");
-    await uiHelper.clickButtonByText("Explore templates");
-    await uiHelper.verifyHeading("Self-service");
+      await uiHelper.clickButtonByText("Explore Self-service templates");
+      await uiHelper.verifyTextVisible("Use our self-service templates");
+      await uiHelper.verifyButtonURL("Explore templates", "/create");
+      await uiHelper.clickButtonByText("Explore templates");
+      await uiHelper.verifyHeading("Self-service");
 
-    await uiHelper.clickButtonByText("Find all Learning Paths");
-    await uiHelper.verifyTextVisible("Integrate tailored e-learning");
-    await uiHelper.verifyButtonURL("View Learning Paths", "/learning-paths");
-    await uiHelper.clickButtonByText("View Learning Paths");
-    await uiHelper.verifyHeading("Learning Paths");
-    await uiHelper.verifyText("75% progress");
-  });
-});
+      await uiHelper.clickButtonByText("Find all Learning Paths");
+      await uiHelper.verifyTextVisible("Integrate tailored e-learning");
+      await uiHelper.verifyButtonURL("View Learning Paths", "/learning-paths");
+      await uiHelper.clickButtonByText("View Learning Paths");
+      await uiHelper.verifyHeading("Learning Paths");
+      await uiHelper.verifyText("75% progress");
+    });
+  },
+);

--- a/workspaces/quickstart/e2e-tests/tests/specs/quick-start.spec.ts
+++ b/workspaces/quickstart/e2e-tests/tests/specs/quick-start.spec.ts
@@ -1,6 +1,14 @@
 import { test, expect } from "@red-hat-developer-hub/e2e-test-utils/test";
 
-test.describe("Test Quick Start plugin", () => {
+test.describe(
+  "Test Quick Start plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "quickstart" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({ auth: "keycloak" });
     await rhdh.deploy();

--- a/workspaces/quickstart/e2e-tests/tests/specs/quick-start.spec.ts
+++ b/workspaces/quickstart/e2e-tests/tests/specs/quick-start.spec.ts
@@ -1,88 +1,83 @@
 import { test, expect } from "@red-hat-developer-hub/e2e-test-utils/test";
 
-test.describe(
-  "Test Quick Start plugin",
-  {
-    annotation: [
+test.describe("Test Quick Start plugin", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "quickstart" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({ auth: "keycloak" });
-      await rhdh.deploy();
-    });
+    );
+    await rhdh.configure({ auth: "keycloak" });
+    await rhdh.deploy();
+  });
 
-    test("Access Quick start as Guest or Admin", async ({
-      loginHelper,
-      page,
-      uiHelper,
-    }) => {
-      await loginHelper.loginAsGuest();
-      await uiHelper.verifyText("Let's get you started with Developer Hub");
-      await uiHelper.verifyText("We'll guide you through a few quick steps");
-      await uiHelper.verifyText("Not started");
+  test("Access Quick start as Guest or Admin", async ({
+    loginHelper,
+    page,
+    uiHelper,
+  }) => {
+    await loginHelper.loginAsGuest();
+    await uiHelper.verifyText("Let's get you started with Developer Hub");
+    await uiHelper.verifyText("We'll guide you through a few quick steps");
+    await uiHelper.verifyText("Not started");
 
-      await uiHelper.clickButtonByText("Set up authentication");
-      await uiHelper.verifyTextVisible("Set up secure login credentials");
-      await uiHelper.verifyButtonURL(
-        "Learn more",
-        "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/",
-        { exact: false },
-      );
+    await uiHelper.clickButtonByText("Set up authentication");
+    await uiHelper.verifyTextVisible("Set up secure login credentials");
+    await uiHelper.verifyButtonURL(
+      "Learn more",
+      "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/",
+      { exact: false },
+    );
 
-      await uiHelper.clickButtonByText("Configure RBAC");
-      await uiHelper.verifyTextVisible("Assign roles and permissions");
-      await uiHelper.verifyButtonURL("Manage access", "/rbac");
+    await uiHelper.clickButtonByText("Configure RBAC");
+    await uiHelper.verifyTextVisible("Assign roles and permissions");
+    await uiHelper.verifyButtonURL("Manage access", "/rbac");
 
-      await uiHelper.clickButtonByText("Configure Git");
-      await uiHelper.verifyTextVisible("Connect your Git providers");
-      await uiHelper.verifyButtonURL(
-        "Learn more",
-        "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/",
-        { exact: false },
-      );
+    await uiHelper.clickButtonByText("Configure Git");
+    await uiHelper.verifyTextVisible("Connect your Git providers");
+    await uiHelper.verifyButtonURL(
+      "Learn more",
+      "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/",
+      { exact: false },
+    );
 
-      await uiHelper.clickButtonByText("Manage plugins");
-      await uiHelper.verifyTextVisible("Browse and install extensions");
-      await uiHelper.verifyButtonURL("Explore plugins", "/extensions");
-      await uiHelper.clickButtonByText("Explore plugins");
-      await uiHelper.verifyText("Catalog");
-      await uiHelper.verifyText(/Plugins \((\d+)\)/);
-      await uiHelper.verifyText("25% progress");
+    await uiHelper.clickButtonByText("Manage plugins");
+    await uiHelper.verifyTextVisible("Browse and install extensions");
+    await uiHelper.verifyButtonURL("Explore plugins", "/extensions");
+    await uiHelper.clickButtonByText("Explore plugins");
+    await uiHelper.verifyText("Catalog");
+    await uiHelper.verifyText(/Plugins \((\d+)\)/);
+    await uiHelper.verifyText("25% progress");
 
-      await uiHelper.clickButton("Hide");
-      await expect(page.getByRole("button", { name: "Hide" })).toBeHidden();
-    });
+    await uiHelper.clickButton("Hide");
+    await expect(page.getByRole("button", { name: "Hide" })).toBeHidden();
+  });
 
-    test("Access Quick start as User", async ({ loginHelper, uiHelper }) => {
-      await loginHelper.loginAsKeycloakUser();
-      await uiHelper.verifyText("Let's get you started with Developer Hub");
-      await uiHelper.verifyText("We'll guide you through a few quick steps");
+  test("Access Quick start as User", async ({ loginHelper, uiHelper }) => {
+    await loginHelper.loginAsKeycloakUser();
+    await uiHelper.verifyText("Let's get you started with Developer Hub");
+    await uiHelper.verifyText("We'll guide you through a few quick steps");
 
-      await uiHelper.clickButtonByText("Import application");
-      await uiHelper.verifyTextVisible("Import your existing code");
-      await uiHelper.verifyButtonURL("Import", "/bulk-import");
+    await uiHelper.clickButtonByText("Import application");
+    await uiHelper.verifyTextVisible("Import your existing code");
+    await uiHelper.verifyButtonURL("Import", "/bulk-import");
 
-      await uiHelper.clickButtonByText("Learn about the Catalog");
-      await uiHelper.verifyTextVisible("Discover all software components");
-      await uiHelper.verifyButtonURL("View Catalog", "/catalog");
-      await uiHelper.clickButtonByText("View Catalog");
-      await uiHelper.verifyHeading(/All components \((\d+)\)/);
+    await uiHelper.clickButtonByText("Learn about the Catalog");
+    await uiHelper.verifyTextVisible("Discover all software components");
+    await uiHelper.verifyButtonURL("View Catalog", "/catalog");
+    await uiHelper.clickButtonByText("View Catalog");
+    await uiHelper.verifyHeading(/All components \((\d+)\)/);
 
-      await uiHelper.clickButtonByText("Explore Self-service templates");
-      await uiHelper.verifyTextVisible("Use our self-service templates");
-      await uiHelper.verifyButtonURL("Explore templates", "/create");
-      await uiHelper.clickButtonByText("Explore templates");
-      await uiHelper.verifyHeading("Self-service");
+    await uiHelper.clickButtonByText("Explore Self-service templates");
+    await uiHelper.verifyTextVisible("Use our self-service templates");
+    await uiHelper.verifyButtonURL("Explore templates", "/create");
+    await uiHelper.clickButtonByText("Explore templates");
+    await uiHelper.verifyHeading("Self-service");
 
-      await uiHelper.clickButtonByText("Find all Learning Paths");
-      await uiHelper.verifyTextVisible("Integrate tailored e-learning");
-      await uiHelper.verifyButtonURL("View Learning Paths", "/learning-paths");
-      await uiHelper.clickButtonByText("View Learning Paths");
-      await uiHelper.verifyHeading("Learning Paths");
-      await uiHelper.verifyText("75% progress");
-    });
-  },
-);
+    await uiHelper.clickButtonByText("Find all Learning Paths");
+    await uiHelper.verifyTextVisible("Integrate tailored e-learning");
+    await uiHelper.verifyButtonURL("View Learning Paths", "/learning-paths");
+    await uiHelper.clickButtonByText("View Learning Paths");
+    await uiHelper.verifyHeading("Learning Paths");
+    await uiHelper.verifyText("75% progress");
+  });
+});

--- a/workspaces/rbac/e2e-tests/tests/specs/rbac-default-permissions.spec.ts
+++ b/workspaces/rbac/e2e-tests/tests/specs/rbac-default-permissions.spec.ts
@@ -20,72 +20,73 @@ test.describe(
     ],
   },
   () => {
-  let rbacPO: RbacPO;
-  let apiToken: string;
+    let rbacPO: RbacPO;
+    let apiToken: string;
 
-  test.beforeAll(async ({ rhdh, browser }) => {
-    await createUsersAndGroups();
+    test.beforeAll(async ({ rhdh, browser }) => {
+      await createUsersAndGroups();
 
-    await rhdh.configure({
-      auth: "keycloak",
-      appConfig:
-        "tests/config/app-config-rhdh-default-permissions-overlay.yaml",
-      valueFile: "tests/config/values.yaml",
-      dynamicPlugins: "tests/config/dynamic-plugins.yaml",
+      await rhdh.configure({
+        auth: "keycloak",
+        appConfig:
+          "tests/config/app-config-rhdh-default-permissions-overlay.yaml",
+        valueFile: "tests/config/values.yaml",
+        dynamicPlugins: "tests/config/dynamic-plugins.yaml",
+      });
+      await rhdh.deploy();
+      await rhdh.waitUntilReady();
+
+      // `beforeAll` does not receive a `page` fixture, so a temporary browser
+      // context is created solely to perform the admin login and extract the
+      // API token used by `afterAll` for programmatic cleanup.
+      const context = await browser.newContext({
+        baseURL: process.env.RHDH_BASE_URL,
+      });
+
+      const page = await context.newPage();
+      const loginHelper = new LoginHelper(page);
+      // todo move to afterAll?
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+      const authApiHelper = new AuthApiHelper(page);
+      apiToken = await authApiHelper.getToken();
+      await context.close();
     });
-    await rhdh.deploy();
-    await rhdh.waitUntilReady();
 
-    // `beforeAll` does not receive a `page` fixture, so a temporary browser
-    // context is created solely to perform the admin login and extract the
-    // API token used by `afterAll` for programmatic cleanup.
-    const context = await browser.newContext({
-      baseURL: process.env.RHDH_BASE_URL,
+    test("User should got default permissions", async ({
+      page,
+      uiHelper,
+      loginHelper,
+    }) => {
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.noAccess);
+
+      rbacPO = new RbacPO(page, uiHelper);
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.waitForLoad();
+      await rbacPO.navigateToCatalogComponent("test-rhdh-qe-2");
     });
 
-    const page = await context.newPage();
-    const loginHelper = new LoginHelper(page);
-    // todo move to afterAll?
-    await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
-    const authApiHelper = new AuthApiHelper(page);
-    apiToken = await authApiHelper.getToken();
-    await context.close();
-  });
+    test("Default role should appear in the RBAC page", async ({
+      page,
+      uiHelper,
+      loginHelper,
+    }) => {
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
 
-  test("User should got default permissions", async ({
-    page,
-    uiHelper,
-    loginHelper,
-  }) => {
-    await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.noAccess);
+      rbacPO = new RbacPO(page, uiHelper);
 
-    rbacPO = new RbacPO(page, uiHelper);
-    await uiHelper.openSidebar("Catalog");
-    await uiHelper.waitForLoad();
-    await rbacPO.navigateToCatalogComponent("test-rhdh-qe-2");
-  });
+      await rbacPO.navigateToRBACPage();
+      await uiHelper.waitForLoad();
+      await rbacPO.filterRolesList(RBAC_ROLES.defaultRole.name);
+      await rbacPO.verifyRoleAndSwitchToOverview(
+        RBAC_ROLES.defaultRole.ref,
+        "Role with default permissions for all users and groups.",
+        ["1 permission"],
+      );
+    });
 
-  test("Default role should appear in the RBAC page", async ({
-    page,
-    uiHelper,
-    loginHelper,
-  }) => {
-    await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
-
-    rbacPO = new RbacPO(page, uiHelper);
-
-    await rbacPO.navigateToRBACPage();
-    await uiHelper.waitForLoad();
-    await rbacPO.filterRolesList(RBAC_ROLES.defaultRole.name);
-    await rbacPO.verifyRoleAndSwitchToOverview(
-      RBAC_ROLES.defaultRole.ref,
-      "Role with default permissions for all users and groups.",
-      ["1 permission"],
-    );
-  });
-
-  // Ensure we clean up in the event that a test fails so that we do not impact other tests
-  test.afterAll(async () => {
-    await cleanupRoles(RBAC_ROLES, apiToken);
-  });
-});
+    // Ensure we clean up in the event that a test fails so that we do not impact other tests
+    test.afterAll(async () => {
+      await cleanupRoles(RBAC_ROLES, apiToken);
+    });
+  },
+);

--- a/workspaces/rbac/e2e-tests/tests/specs/rbac-default-permissions.spec.ts
+++ b/workspaces/rbac/e2e-tests/tests/specs/rbac-default-permissions.spec.ts
@@ -11,7 +11,15 @@ import {
   LoginHelper,
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
 
-test.describe("Check default RBAC permissions", () => {
+test.describe(
+  "Check default RBAC permissions",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "rbac" },
+    ],
+  },
+  () => {
   let rbacPO: RbacPO;
   let apiToken: string;
 

--- a/workspaces/rbac/e2e-tests/tests/specs/rbac-default-permissions.spec.ts
+++ b/workspaces/rbac/e2e-tests/tests/specs/rbac-default-permissions.spec.ts
@@ -11,82 +11,77 @@ import {
   LoginHelper,
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
 
-test.describe(
-  "Check default RBAC permissions",
-  {
-    annotation: [
+test.describe("Check default RBAC permissions", () => {
+  let rbacPO: RbacPO;
+  let apiToken: string;
+
+  test.beforeAll(async ({ rhdh, browser }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "rbac" },
-    ],
-  },
-  () => {
-    let rbacPO: RbacPO;
-    let apiToken: string;
+    );
+    await createUsersAndGroups();
 
-    test.beforeAll(async ({ rhdh, browser }) => {
-      await createUsersAndGroups();
+    await rhdh.configure({
+      auth: "keycloak",
+      appConfig:
+        "tests/config/app-config-rhdh-default-permissions-overlay.yaml",
+      valueFile: "tests/config/values.yaml",
+      dynamicPlugins: "tests/config/dynamic-plugins.yaml",
+    });
+    await rhdh.deploy();
+    await rhdh.waitUntilReady();
 
-      await rhdh.configure({
-        auth: "keycloak",
-        appConfig:
-          "tests/config/app-config-rhdh-default-permissions-overlay.yaml",
-        valueFile: "tests/config/values.yaml",
-        dynamicPlugins: "tests/config/dynamic-plugins.yaml",
-      });
-      await rhdh.deploy();
-      await rhdh.waitUntilReady();
-
-      // `beforeAll` does not receive a `page` fixture, so a temporary browser
-      // context is created solely to perform the admin login and extract the
-      // API token used by `afterAll` for programmatic cleanup.
-      const context = await browser.newContext({
-        baseURL: process.env.RHDH_BASE_URL,
-      });
-
-      const page = await context.newPage();
-      const loginHelper = new LoginHelper(page);
-      // todo move to afterAll?
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
-      const authApiHelper = new AuthApiHelper(page);
-      apiToken = await authApiHelper.getToken();
-      await context.close();
+    // `beforeAll` does not receive a `page` fixture, so a temporary browser
+    // context is created solely to perform the admin login and extract the
+    // API token used by `afterAll` for programmatic cleanup.
+    const context = await browser.newContext({
+      baseURL: process.env.RHDH_BASE_URL,
     });
 
-    test("User should got default permissions", async ({
-      page,
-      uiHelper,
-      loginHelper,
-    }) => {
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.noAccess);
+    const page = await context.newPage();
+    const loginHelper = new LoginHelper(page);
+    // todo move to afterAll?
+    await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+    const authApiHelper = new AuthApiHelper(page);
+    apiToken = await authApiHelper.getToken();
+    await context.close();
+  });
 
-      rbacPO = new RbacPO(page, uiHelper);
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.waitForLoad();
-      await rbacPO.navigateToCatalogComponent("test-rhdh-qe-2");
-    });
+  test("User should got default permissions", async ({
+    page,
+    uiHelper,
+    loginHelper,
+  }) => {
+    await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.noAccess);
 
-    test("Default role should appear in the RBAC page", async ({
-      page,
-      uiHelper,
-      loginHelper,
-    }) => {
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+    rbacPO = new RbacPO(page, uiHelper);
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.waitForLoad();
+    await rbacPO.navigateToCatalogComponent("test-rhdh-qe-2");
+  });
 
-      rbacPO = new RbacPO(page, uiHelper);
+  test("Default role should appear in the RBAC page", async ({
+    page,
+    uiHelper,
+    loginHelper,
+  }) => {
+    await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
 
-      await rbacPO.navigateToRBACPage();
-      await uiHelper.waitForLoad();
-      await rbacPO.filterRolesList(RBAC_ROLES.defaultRole.name);
-      await rbacPO.verifyRoleAndSwitchToOverview(
-        RBAC_ROLES.defaultRole.ref,
-        "Role with default permissions for all users and groups.",
-        ["1 permission"],
-      );
-    });
+    rbacPO = new RbacPO(page, uiHelper);
 
-    // Ensure we clean up in the event that a test fails so that we do not impact other tests
-    test.afterAll(async () => {
-      await cleanupRoles(RBAC_ROLES, apiToken);
-    });
-  },
-);
+    await rbacPO.navigateToRBACPage();
+    await uiHelper.waitForLoad();
+    await rbacPO.filterRolesList(RBAC_ROLES.defaultRole.name);
+    await rbacPO.verifyRoleAndSwitchToOverview(
+      RBAC_ROLES.defaultRole.ref,
+      "Role with default permissions for all users and groups.",
+      ["1 permission"],
+    );
+  });
+
+  // Ensure we clean up in the event that a test fails so that we do not impact other tests
+  test.afterAll(async () => {
+    await cleanupRoles(RBAC_ROLES, apiToken);
+  });
+});

--- a/workspaces/rbac/e2e-tests/tests/specs/rbac.spec.ts
+++ b/workspaces/rbac/e2e-tests/tests/specs/rbac.spec.ts
@@ -33,620 +33,627 @@ test.describe(
     ],
   },
   () => {
-  let rbacPO: RbacPO;
-  let apiToken: string;
+    let rbacPO: RbacPO;
+    let apiToken: string;
 
-  /**
-   * Shared helper used by both `beforeAll` (to grab the API token) and each
-   * `beforeEach` that needs an admin UI session.  Extracting it avoids
-   * duplicating the login + navigation steps across multiple describe blocks.
-   */
-  async function setupAdminSession({
-    page,
-    uiHelper,
-    loginHelper,
-  }: {
-    page: Page;
-    uiHelper: UIhelper;
-    loginHelper: LoginHelper;
-  }) {
-    rbacPO = new RbacPO(page, uiHelper);
-    await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
-    await rbacPO.navigateToRBACPage();
-  }
-
-  test.beforeAll(async ({ rhdh, browser }) => {
-    const rbacConfigmapPath = WorkspacePaths.resolve(
-      "tests/config/rbac-configmap.yaml",
-    );
-    await createUsersAndGroups();
-    const namespace = rhdh.deploymentConfig.namespace;
-    await $`kubectl apply -f ${rbacConfigmapPath} -n ${namespace}`;
-
-    await rhdh.configure({
-      auth: "keycloak",
-      appConfig: "tests/config/app-config-rhdh.yaml",
-      valueFile: "tests/config/values.yaml",
-    });
-    await rhdh.deploy();
-    await rhdh.waitUntilReady();
-
-    // `beforeAll` does not receive a `page` fixture, so a temporary browser
-    // context is created solely to perform the admin login and extract the
-    // API token used by `afterAll` for programmatic cleanup.
-    const context = await browser.newContext({
-      baseURL: process.env.RHDH_BASE_URL,
-    });
-
-    const page = await context.newPage();
-    const uiHelper = new UIhelper(page);
-    const loginHelper = new LoginHelper(page);
-    await setupAdminSession({ page, uiHelper, loginHelper });
-    const authApiHelper = new AuthApiHelper(page);
-    apiToken = await authApiHelper.getToken();
-    await context.close();
-  });
-
-  test.describe("RBAC plugin: admin user", () => {
-    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-      await setupAdminSession({ page, uiHelper, loginHelper });
-    });
-
-    test("Check Administration side nav has RBAC plugin", async ({
+    /**
+     * Shared helper used by both `beforeAll` (to grab the API token) and each
+     * `beforeEach` that needs an admin UI session.  Extracting it avoids
+     * duplicating the login + navigation steps across multiple describe blocks.
+     */
+    async function setupAdminSession({
       page,
       uiHelper,
-    }) => {
-      await uiHelper.goToPageUrl("/", "Welcome back!");
-      await uiHelper.openSidebarButton("Administration");
-      const rbacLink = page.getByRole("link", { name: "RBAC" });
-      await expect(rbacLink).toBeVisible();
-      await rbacLink.click();
-      await uiHelper.verifyHeading("RBAC");
-      expect(await page.title()).toContain("RBAC");
+      loginHelper,
+    }: {
+      page: Page;
+      uiHelper: UIhelper;
+      loginHelper: LoginHelper;
+    }) {
+      rbacPO = new RbacPO(page, uiHelper);
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+      await rbacPO.navigateToRBACPage();
+    }
 
-      await rbacPO.verifyGeneralRbacViewHeading();
-      const allGridColumnsText = RolesPage.getRolesListColumnsText();
-      const allCellsIdentifier = RolesPage.getRolesListCellsIdentifier();
-
-      await rbacPO.verifyRoleOverviewTables(
-        allGridColumnsText,
-        allCellsIdentifier,
+    test.beforeAll(async ({ rhdh, browser }) => {
+      const rbacConfigmapPath = WorkspacePaths.resolve(
+        "tests/config/rbac-configmap.yaml",
       );
+      await createUsersAndGroups();
+      const namespace = rhdh.deploymentConfig.namespace;
+      await $`kubectl apply -f ${rbacConfigmapPath} -n ${namespace}`;
+
+      await rhdh.configure({
+        auth: "keycloak",
+        appConfig: "tests/config/app-config-rhdh.yaml",
+        valueFile: "tests/config/values.yaml",
+      });
+      await rhdh.deploy();
+      await rhdh.waitUntilReady();
+
+      // `beforeAll` does not receive a `page` fixture, so a temporary browser
+      // context is created solely to perform the admin login and extract the
+      // API token used by `afterAll` for programmatic cleanup.
+      const context = await browser.newContext({
+        baseURL: process.env.RHDH_BASE_URL,
+      });
+
+      const page = await context.newPage();
+      const uiHelper = new UIhelper(page);
+      const loginHelper = new LoginHelper(page);
+      await setupAdminSession({ page, uiHelper, loginHelper });
+      const authApiHelper = new AuthApiHelper(page);
+      apiToken = await authApiHelper.getToken();
+      await context.close();
     });
 
-    test("Export CSV of the user list", async ({ page }) => {
-      await rbacPO.navigateToRBACPage();
-      const exportCsvLink = page.getByRole("link", { name: "Export CSV" });
-      await exportCsvLink.click();
-      const fileContent = await downloadAndReadFile(page, exportCsvLink);
-      await test.info().attach("user-list-file", {
-        body: fileContent,
-        contentType: "text/plain",
+    test.describe("RBAC plugin: admin user", () => {
+      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+        await setupAdminSession({ page, uiHelper, loginHelper });
       });
-      const lines = (fileContent ?? "").trim().split("\n");
 
-      const header = "userEntityRef,displayName,email,lastAuthTime";
-      expect(lines[0], "Header needs to match the expected header").toBe(
-        header,
-      );
+      test("Check Administration side nav has RBAC plugin", async ({
+        page,
+        uiHelper,
+      }) => {
+        await uiHelper.goToPageUrl("/", "Welcome back!");
+        await uiHelper.openSidebarButton("Administration");
+        const rbacLink = page.getByRole("link", { name: "RBAC" });
+        await expect(rbacLink).toBeVisible();
+        await rbacLink.click();
+        await uiHelper.verifyHeading("RBAC");
+        expect(await page.title()).toContain("RBAC");
 
-      // Check that each subsequent line starts with "user:default" or "user:development"
-      const invalidLines = lines
-        .slice(1)
-        .filter(
-          (line) =>
-            !line.startsWith("user:default") &&
-            !line.startsWith("user:development"),
+        await rbacPO.verifyGeneralRbacViewHeading();
+        const allGridColumnsText = RolesPage.getRolesListColumnsText();
+        const allCellsIdentifier = RolesPage.getRolesListCellsIdentifier();
+
+        await rbacPO.verifyRoleOverviewTables(
+          allGridColumnsText,
+          allCellsIdentifier,
+        );
+      });
+
+      test("Export CSV of the user list", async ({ page }) => {
+        await rbacPO.navigateToRBACPage();
+        const exportCsvLink = page.getByRole("link", { name: "Export CSV" });
+        await exportCsvLink.click();
+        const fileContent = await downloadAndReadFile(page, exportCsvLink);
+        await test.info().attach("user-list-file", {
+          body: fileContent,
+          contentType: "text/plain",
+        });
+        const lines = (fileContent ?? "").trim().split("\n");
+
+        const header = "userEntityRef,displayName,email,lastAuthTime";
+        expect(lines[0], "Header needs to match the expected header").toBe(
+          header,
         );
 
-      await test.step(`Validate user lines: ${invalidLines.length} invalid out of ${lines.length} total`, async () => {
-        expect(invalidLines, "All users should be valid").toHaveLength(0);
+        // Check that each subsequent line starts with "user:default" or "user:development"
+        const invalidLines = lines
+          .slice(1)
+          .filter(
+            (line) =>
+              !line.startsWith("user:default") &&
+              !line.startsWith("user:development"),
+          );
+
+        await test.step(`Validate user lines: ${invalidLines.length} invalid out of ${lines.length} total`, async () => {
+          expect(invalidLines, "All users should be valid").toHaveLength(0);
+        });
       });
-    });
 
-    test("View details of a role (rbac_admin)", async ({ uiHelper }) => {
-      await rbacPO.navigateToRBACPage();
-      await rbacPO.verifyRoleAndSwitchToOverview(RBAC_ROLES.rbacAdmin.ref, "", [
-        "1 user",
-        "5 permissions",
-      ]);
+      test("View details of a role (rbac_admin)", async ({ uiHelper }) => {
+        await rbacPO.navigateToRBACPage();
+        await rbacPO.verifyRoleAndSwitchToOverview(
+          RBAC_ROLES.rbacAdmin.ref,
+          "",
+          ["1 user", "5 permissions"],
+        );
 
-      const usersAndGroupsColumnsText =
-        RolesPage.getUsersAndGroupsListColumnsText();
-      const usersAndGroupsCellsIdentifier =
-        RolesPage.getUsersAndGroupsListCellsIdentifier();
+        const usersAndGroupsColumnsText =
+          RolesPage.getUsersAndGroupsListColumnsText();
+        const usersAndGroupsCellsIdentifier =
+          RolesPage.getUsersAndGroupsListCellsIdentifier();
 
-      await rbacPO.verifyRoleOverviewTables(
-        usersAndGroupsColumnsText,
-        usersAndGroupsCellsIdentifier,
-      );
+        await rbacPO.verifyRoleOverviewTables(
+          usersAndGroupsColumnsText,
+          usersAndGroupsCellsIdentifier,
+        );
 
-      const permissionPoliciesColumnsText =
-        RolesPage.getPermissionPoliciesListColumnsText();
-      const permissionPoliciesCellsIdentifier =
-        RolesPage.getPermissionPoliciesListCellsIdentifier();
+        const permissionPoliciesColumnsText =
+          RolesPage.getPermissionPoliciesListColumnsText();
+        const permissionPoliciesCellsIdentifier =
+          RolesPage.getPermissionPoliciesListCellsIdentifier();
 
-      await rbacPO.verifyRoleOverviewTables(
-        permissionPoliciesColumnsText,
-        permissionPoliciesCellsIdentifier,
-      );
+        await rbacPO.verifyRoleOverviewTables(
+          permissionPoliciesColumnsText,
+          permissionPoliciesCellsIdentifier,
+        );
 
-      await uiHelper.clickLink("RBAC");
-    });
+        await uiHelper.clickLink("RBAC");
+      });
 
-    test("Cancel role creation exists without creating a role", async ({
-      page,
-      uiHelper,
-    }) => {
-      await rbacPO.navigateToRBACPage();
-      await uiHelper.clickButton("Create");
-      await uiHelper.verifyHeading("Create role");
-      await uiHelper.fillTextInputByLabel("name", "sample-role-1");
-      await uiHelper.fillTextInputByLabel(
-        "description",
-        "Test Description data",
-      );
-
-      await uiHelper.clickButton("Next");
-      // Wait for the users and groups step to be visible
-      await expect(
-        page.getByTestId("users-and-groups-text-field"),
-      ).toBeVisible();
-      await uiHelper.fillTextInputByLabel(
-        "Select users and groups",
-        "sample-role-1",
-      );
-      await page
-        .getByTestId("users-and-groups-text-field")
-        .getByLabel("clear search")
-        .click();
-      await expect(
-        page.getByTestId("users-and-groups-text-field").getByRole("combobox"),
-      ).toBeEmpty();
-      await uiHelper.verifyHeading("No users and groups selected");
-      await uiHelper.clickButton("Cancel");
-      await uiHelper.verifyText("Exit role creation?");
-      await uiHelper.clickButton("Discard");
-      await expect(page.getByRole("alert")).toHaveCount(0);
-    });
-
-    test("Edit role users via the inline edit button on the roles list", async ({
-      page,
-    }) => {
-      await rbacPO.navigateToRBACPage();
-      await rbacPO.createRole(
-        RBAC_ROLES.overviewListEdit.name,
-        [displayName("noAccess"), displayName("tara")],
-        [RBAC_GROUPS.backstage.name],
-        [{ permission: "catalog.entity.delete" }],
-      );
-
-      await rbacPO.filterRolesList(RBAC_ROLES.overviewListEdit.name);
-      await ROLES_PAGE_COMPONENTS.getEditRoleButton(
+      test("Cancel role creation exists without creating a role", async ({
         page,
-        RBAC_ROLES.overviewListEdit.ref,
-      ).click();
-      await rbacPO.editRoleMembers(
-        RBAC_ROLES.overviewListEdit.ref,
-        displayName("jonathon"),
-        3,
-        1,
-      );
+        uiHelper,
+      }) => {
+        await rbacPO.navigateToRBACPage();
+        await uiHelper.clickButton("Create");
+        await uiHelper.verifyHeading("Create role");
+        await uiHelper.fillTextInputByLabel("name", "sample-role-1");
+        await uiHelper.fillTextInputByLabel(
+          "description",
+          "Test Description data",
+        );
 
-      await rbacPO.filterRolesList(RBAC_ROLES.overviewListEdit.name);
-
-      // Use semantic selector for table cell
-      const usersAndGroupsLocator = page
-        .getByRole("cell")
-        .filter({ hasText: rbacPO.regexpShortUsersAndGroups(3, 1) });
-      await expect(usersAndGroupsLocator).toBeVisible();
-
-      await rbacPO.deleteRole(RBAC_ROLES.overviewListEdit.ref);
-    });
-
-    test("Edit role members via the updateMembers button on the overview page", async ({
-      page,
-      uiHelper,
-    }) => {
-      await rbacPO.navigateToRBACPage();
-      await rbacPO.createRole(
-        RBAC_ROLES.overviewMembers.name,
-        [displayName("noAccess"), displayName("tara")],
-        [RBAC_GROUPS.backstage.name],
-        [{ permission: "catalog.entity.delete" }],
-      );
-
-      await rbacPO.filterRolesList(RBAC_ROLES.overviewMembers.name);
-
-      await rbacPO.verifyRoleAndSwitchToOverview(
-        RBAC_ROLES.overviewMembers.ref,
-        "",
-        [rbacPO.regexpShortUsersAndGroups(2, 1), "1 permission"],
-      );
-
-      await ROLE_OVERVIEW_COMPONENTS.getUpdateMembersButton(page).click();
-      await rbacPO.editRoleMembers(
-        RBAC_ROLES.overviewMembers.ref,
-        displayName("noAccess"),
-        1,
-        1,
-      );
-
-      await uiHelper.verifyHeading(rbacPO.regexpShortUsersAndGroups(1, 1));
-
-      await rbacPO.deleteRole(RBAC_ROLES.overviewMembers.ref);
-    });
-
-    test("Edit role policies via the updatePolicies button on the overview page", async ({
-      uiHelper,
-    }) => {
-      await rbacPO.navigateToRBACPage();
-      await rbacPO.createRole(
-        RBAC_ROLES.overviewPolicies.name,
-        [displayName("noAccess"), displayName("tara")],
-        [RBAC_GROUPS.backstage.name],
-        [{ permission: "catalog.entity.delete" }],
-      );
-
-      await rbacPO.filterRolesList(RBAC_ROLES.overviewPolicies.name);
-
-      await rbacPO.verifyRoleAndSwitchToOverview(
-        RBAC_ROLES.overviewPolicies.ref,
-        "",
-        [rbacPO.regexpShortUsersAndGroups(2, 1), "1 permission"],
-      );
-
-      await rbacPO.editRolePermissions();
-
-      await uiHelper.verifyText(
-        `Role ${RBAC_ROLES.overviewPolicies.ref} updated successfully`,
-      );
-      await uiHelper.verifyHeading("2 permissions");
-
-      await rbacPO.deleteRole(RBAC_ROLES.overviewPolicies.ref);
-    });
-  });
-
-  test.describe("RBAC Plugin: validate appropriate guest user handling", () => {
-    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-      rbacPO = new RbacPO(page, uiHelper);
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.noAccess);
-    });
-
-    test("Administration side nav does not show RBAC plugin", async ({
-      page,
-      uiHelper,
-    }) => {
-      await uiHelper.openSidebarButton("Administration");
-      // Check specifically for RBAC link in sidebar navigation, not anywhere on the page
-      const rbacNavLink = page
-        .getByRole("navigation", { name: "sidebar nav" })
-        .getByRole("link", { name: "RBAC" });
-      await expect(rbacNavLink).toHaveCount(0);
-    });
-
-    test("No access user should not see list of components in catalog", async ({
-      uiHelper,
-    }) => {
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.waitForLoad();
-      await uiHelper.verifyTableIsEmpty();
-    });
-
-    test("Direct navigation to /rbac is denied", async ({ uiHelper }) => {
-      await rbacPO.go();
-      await uiHelper.waitForLoad();
-      await uiHelper.verifyText(
-        "ERROR 403: Insufficient permissions to access this page",
-      );
-    });
-  });
-
-  test.describe("RBAC plugin: permission policies loaded from files", () => {
-    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-      await setupAdminSession({ page, uiHelper, loginHelper });
-    });
-
-    test("Permission policies defined in a CSV file are loaded (guest role, 1 permission)", async ({
-      uiHelper,
-    }) => {
-      await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
-      await rbacPO.verifyRoleAndSwitchToOverview(
-        RBAC_ROLES.guest.ref,
-        "csv permission policy file",
-        ["1 user", "1 permission"],
-      );
-
-      const permissionPoliciesColumnsText =
-        RolesPage.getPermissionPoliciesListColumnsText();
-      const permissionPoliciesCellsIdentifier =
-        RolesPage.getPermissionPoliciesListCellsIdentifier();
-
-      await rbacPO.verifyRoleOverviewTables(
-        permissionPoliciesColumnsText,
-        permissionPoliciesCellsIdentifier,
-      );
-
-      await uiHelper.verifyRowInTableByUniqueText(displayName("noAccess"), [
-        "user",
-        "-",
-      ]);
-      await uiHelper.verifyRowInTableByUniqueText("catalog.entity.create", [
-        "create",
-        "-",
-      ]);
-    });
-
-    test("CSV file-sourced role (guest role): Update policies is not available", async ({
-      page,
-    }) => {
-      await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
-      await rbacPO.verifyRoleAndSwitchToOverview(
-        RBAC_ROLES.guest.ref,
-        "csv permission policy file",
-        ["1 user", "1 permission"],
-      );
-
-      await rbacPO.editRolePermissions();
-
-      const errorAlert = page
-        .getByRole("alert")
-        .filter({ hasText: /Unable to edit the role/i });
-      expect(errorAlert.count()).toBeTruthy();
-    });
-
-    test("CSV file-sourced role (guest role): Delete is not available", async ({
-      page,
-    }) => {
-      await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
-      await rbacPO.deleteRole(RBAC_ROLES.guest.ref, "All roles (0)", true);
-
-      const errorAlert = page
-        .getByRole("alert")
-        .filter({ hasText: /Unable to delete policy/i });
-      expect(errorAlert.count()).toBeTruthy();
-    });
-
-    test("Config-sourced role (rbac_admin): Update policies is not available", async ({
-      page,
-    }) => {
-      await rbacPO.filterRolesList(RBAC_ROLES.rbacAdmin.name);
-      await rbacPO.verifyRoleAndSwitchToOverview(RBAC_ROLES.rbacAdmin.ref, "", [
-        "1 user",
-        "5 permissions",
-      ]);
-
-      await rbacPO.editRolePermissions();
-
-      const errorAlert = page
-        .getByRole("alert")
-        .filter({ hasText: /Unable to edit the role/i });
-      expect(errorAlert.count()).toBeTruthy();
-    });
-
-    test("Config-sourced role (rbac_admin): Delete is not available", async ({
-      page,
-    }) => {
-      await rbacPO.filterRolesList(RBAC_ROLES.rbacAdmin.name);
-      await rbacPO.deleteRole(RBAC_ROLES.rbacAdmin.ref, "All roles (0)", true);
-
-      const errorAlert = page
-        .getByRole("alert")
-        .filter({ hasText: /Unable to delete policy/i });
-      expect(errorAlert.count()).toBeTruthy();
-    });
-  });
-
-  test.describe("RBAC conditional policies: $currentUser alias", () => {
-    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-      rbacPO = new RbacPO(page, uiHelper);
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.currentUserOwner);
-    });
-
-    test("User can unregister own components but not group-owned components", async ({
-      page,
-      uiHelper,
-    }) => {
-      await rbacPO.navigateToCatalogComponent("test-rhdh-qe-2");
-
-      // Verify component name in the main heading
-      await expect(page.getByRole("heading", { level: 1 })).toContainText(
-        "test-rhdh-qe-2",
-      );
-      await page.getByTestId("menu-button").click();
-      const unregisterUserOwned = page.getByRole("menuitem", {
-        name: "Unregister entity",
+        await uiHelper.clickButton("Next");
+        // Wait for the users and groups step to be visible
+        await expect(
+          page.getByTestId("users-and-groups-text-field"),
+        ).toBeVisible();
+        await uiHelper.fillTextInputByLabel(
+          "Select users and groups",
+          "sample-role-1",
+        );
+        await page
+          .getByTestId("users-and-groups-text-field")
+          .getByLabel("clear search")
+          .click();
+        await expect(
+          page.getByTestId("users-and-groups-text-field").getByRole("combobox"),
+        ).toBeEmpty();
+        await uiHelper.verifyHeading("No users and groups selected");
+        await uiHelper.clickButton("Cancel");
+        await uiHelper.verifyText("Exit role creation?");
+        await uiHelper.clickButton("Discard");
+        await expect(page.getByRole("alert")).toHaveCount(0);
       });
-      await expect(unregisterUserOwned).toBeEnabled();
 
-      await page.getByRole("menuitem", { name: "Unregister entity" }).click();
-      await expect(page.getByRole("dialog")).toContainText(
-        "Are you sure you want to unregister this entity?",
-      );
-      await page.getByRole("button", { name: "Cancel" }).click();
-
-      await uiHelper.openSidebar("Catalog");
-      await page
-        .getByRole("link", { name: "test-rhdh-qe-2-team-owned" })
-        .click();
-      // Verify owner group in the component metadata (scope to article to avoid duplicates)
-      await expect(
-        page
-          .getByRole("article")
-          .getByRole("link", { name: /janus-qe\/rhdh-qe-2-team/ }),
-      ).toBeVisible();
-      await page.getByTestId("menu-button").click();
-      const unregisterGroupOwned = page.getByRole("menuitem", {
-        name: "Unregister entity",
-      });
-      await expect(unregisterGroupOwned).toBeDisabled();
-    });
-  });
-
-  test.describe("RBAC conditional policies: $ownerRefs transitive group ownership", () => {
-    test.beforeEach(({ page, uiHelper }) => {
-      rbacPO = new RbacPO(page, uiHelper);
-    });
-
-    test("User in child group can read components owned by the parent group", async ({
-      loginHelper,
-    }) => {
-      // login as child-group-member: belongs in rhdh-qe-child-team, which is a sub group of rhdh-qe-parent-team
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.childGroupMember);
-
-      // rhdh-qe-parent-team owns mock-site
-      await rbacPO.navigateToCatalogComponent("mock-site");
-      // Verify owner group in the component metadata
-      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhParentTeam.name);
-
-      // rhdh-qe-child-team owns mock-child-site, check that it can see it's own groups' components
-      await rbacPO.navigateToCatalogComponent("mock-child-site");
-      // Verify owner group in the component metadata
-      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhChildTeam.name);
-    });
-
-    test("User in sub-child group can read components owned by grandparent group", async ({
-      loginHelper,
-    }) => {
-      // login as sub-child-group-member: belongs in rhdh-qe-sub-child-team, which is a sub group of rhdh-qe-child-team
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.subChildGroupMember);
-
-      // rhdh-qe-parent-team owns mock-site
-      await rbacPO.navigateToCatalogComponent("mock-site");
-      // Verify owner group in the component metadata
-      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhParentTeam.name);
-
-      // rhdh-qe-child-team owns mock-child-site
-      await rbacPO.navigateToCatalogComponent("mock-child-site");
-      // Verify owner group in the component metadata
-      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhChildTeam.name);
-
-      // rhdh-qe-sub-child-team owns mock-sub-child-site, check that it can see it's own groups' components
-      await rbacPO.navigateToCatalogComponent("mock-sub-child-site");
-      // Verify owner group in the component metadata
-      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhSubChildTeam.name);
-    });
-  });
-
-  test.describe("RBAC conditional policies: IsOwner ownership rule", () => {
-    test.describe.configure({ mode: "serial" });
-
-    test.beforeEach(async ({ page, uiHelper }) => {
-      rbacPO = new RbacPO(page, uiHelper);
-    });
-
-    test("Admin creates rbac-ownership-role with IsOwner rule for conditional-manager", async ({
-      loginHelper,
-    }) => {
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
-
-      await rbacPO.navigateToRBACPage();
-      await rbacPO.createRBACConditionRole(
-        RBAC_ROLES.rbacOwnership.name,
-        [displayName("conditionalManager")],
-        userEntityRef(RBAC_DESCRIPTIVE_USERS.conditionalManager),
-      );
-    });
-
-    test("conditional-manager can access RBAC page, create a role, edit it, and delete it", async ({
-      page,
-      loginHelper,
-    }) => {
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalManager);
-
-      await rbacPO.navigateToRBACPage();
-      await rbacPO.createRole(
-        RBAC_ROLES.rbacConditional.name,
-        [displayName("noAccess"), displayName("tara")],
-        [RBAC_GROUPS.backstage.name],
-        [{ permission: "catalog.entity.delete" }],
-        "catalog",
-        userEntityRef(RBAC_DESCRIPTIVE_USERS.conditionalManager),
-      );
-
-      await ROLES_PAGE_COMPONENTS.getEditRoleButton(
+      test("Edit role users via the inline edit button on the roles list", async ({
         page,
-        RBAC_ROLES.rbacConditional.ref,
-      ).click();
+      }) => {
+        await rbacPO.navigateToRBACPage();
+        await rbacPO.createRole(
+          RBAC_ROLES.overviewListEdit.name,
+          [displayName("noAccess"), displayName("tara")],
+          [RBAC_GROUPS.backstage.name],
+          [{ permission: "catalog.entity.delete" }],
+        );
 
-      await rbacPO.editRoleMembers(
-        RBAC_ROLES.rbacConditional.ref,
-        displayName("jonathon"),
-        3,
-        1,
-      );
+        await rbacPO.filterRolesList(RBAC_ROLES.overviewListEdit.name);
+        await ROLES_PAGE_COMPONENTS.getEditRoleButton(
+          page,
+          RBAC_ROLES.overviewListEdit.ref,
+        ).click();
+        await rbacPO.editRoleMembers(
+          RBAC_ROLES.overviewListEdit.ref,
+          displayName("jonathon"),
+          3,
+          1,
+        );
 
-      await rbacPO.deleteRole(RBAC_ROLES.rbacConditional.ref, "All roles");
+        await rbacPO.filterRolesList(RBAC_ROLES.overviewListEdit.name);
+
+        // Use semantic selector for table cell
+        const usersAndGroupsLocator = page
+          .getByRole("cell")
+          .filter({ hasText: rbacPO.regexpShortUsersAndGroups(3, 1) });
+        await expect(usersAndGroupsLocator).toBeVisible();
+
+        await rbacPO.deleteRole(RBAC_ROLES.overviewListEdit.ref);
+      });
+
+      test("Edit role members via the updateMembers button on the overview page", async ({
+        page,
+        uiHelper,
+      }) => {
+        await rbacPO.navigateToRBACPage();
+        await rbacPO.createRole(
+          RBAC_ROLES.overviewMembers.name,
+          [displayName("noAccess"), displayName("tara")],
+          [RBAC_GROUPS.backstage.name],
+          [{ permission: "catalog.entity.delete" }],
+        );
+
+        await rbacPO.filterRolesList(RBAC_ROLES.overviewMembers.name);
+
+        await rbacPO.verifyRoleAndSwitchToOverview(
+          RBAC_ROLES.overviewMembers.ref,
+          "",
+          [rbacPO.regexpShortUsersAndGroups(2, 1), "1 permission"],
+        );
+
+        await ROLE_OVERVIEW_COMPONENTS.getUpdateMembersButton(page).click();
+        await rbacPO.editRoleMembers(
+          RBAC_ROLES.overviewMembers.ref,
+          displayName("noAccess"),
+          1,
+          1,
+        );
+
+        await uiHelper.verifyHeading(rbacPO.regexpShortUsersAndGroups(1, 1));
+
+        await rbacPO.deleteRole(RBAC_ROLES.overviewMembers.ref);
+      });
+
+      test("Edit role policies via the updatePolicies button on the overview page", async ({
+        uiHelper,
+      }) => {
+        await rbacPO.navigateToRBACPage();
+        await rbacPO.createRole(
+          RBAC_ROLES.overviewPolicies.name,
+          [displayName("noAccess"), displayName("tara")],
+          [RBAC_GROUPS.backstage.name],
+          [{ permission: "catalog.entity.delete" }],
+        );
+
+        await rbacPO.filterRolesList(RBAC_ROLES.overviewPolicies.name);
+
+        await rbacPO.verifyRoleAndSwitchToOverview(
+          RBAC_ROLES.overviewPolicies.ref,
+          "",
+          [rbacPO.regexpShortUsersAndGroups(2, 1), "1 permission"],
+        );
+
+        await rbacPO.editRolePermissions();
+
+        await uiHelper.verifyText(
+          `Role ${RBAC_ROLES.overviewPolicies.ref} updated successfully`,
+        );
+        await uiHelper.verifyHeading("2 permissions");
+
+        await rbacPO.deleteRole(RBAC_ROLES.overviewPolicies.ref);
+      });
     });
 
-    test("Admin revokes access by deleting rbac-conditional-role", async ({
-      loginHelper,
-    }) => {
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+    test.describe("RBAC Plugin: validate appropriate guest user handling", () => {
+      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+        rbacPO = new RbacPO(page, uiHelper);
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.noAccess);
+      });
 
-      await rbacPO.navigateToRBACPage();
+      test("Administration side nav does not show RBAC plugin", async ({
+        page,
+        uiHelper,
+      }) => {
+        await uiHelper.openSidebarButton("Administration");
+        // Check specifically for RBAC link in sidebar navigation, not anywhere on the page
+        const rbacNavLink = page
+          .getByRole("navigation", { name: "sidebar nav" })
+          .getByRole("link", { name: "RBAC" });
+        await expect(rbacNavLink).toHaveCount(0);
+      });
 
-      await rbacPO.deleteRole(RBAC_ROLES.rbacOwnership.ref);
+      test("No access user should not see list of components in catalog", async ({
+        uiHelper,
+      }) => {
+        await uiHelper.openSidebar("Catalog");
+        await uiHelper.waitForLoad();
+        await uiHelper.verifyTableIsEmpty();
+      });
+
+      test("Direct navigation to /rbac is denied", async ({ uiHelper }) => {
+        await rbacPO.go();
+        await uiHelper.waitForLoad();
+        await uiHelper.verifyText(
+          "ERROR 403: Insufficient permissions to access this page",
+        );
+      });
     });
 
-    test("conditional-manager no longer sees RBAC in the sidebar after access is revoked", async ({
-      page,
-      uiHelper,
-      loginHelper,
-    }) => {
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalManager);
+    test.describe("RBAC plugin: permission policies loaded from files", () => {
+      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+        await setupAdminSession({ page, uiHelper, loginHelper });
+      });
 
-      await uiHelper.openSidebarButton("Administration");
-      const dropdownMenuLocator = page.getByText("RBAC");
-      await expect(dropdownMenuLocator).toBeHidden();
+      test("Permission policies defined in a CSV file are loaded (guest role, 1 permission)", async ({
+        uiHelper,
+      }) => {
+        await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
+        await rbacPO.verifyRoleAndSwitchToOverview(
+          RBAC_ROLES.guest.ref,
+          "csv permission policy file",
+          ["1 user", "1 permission"],
+        );
+
+        const permissionPoliciesColumnsText =
+          RolesPage.getPermissionPoliciesListColumnsText();
+        const permissionPoliciesCellsIdentifier =
+          RolesPage.getPermissionPoliciesListCellsIdentifier();
+
+        await rbacPO.verifyRoleOverviewTables(
+          permissionPoliciesColumnsText,
+          permissionPoliciesCellsIdentifier,
+        );
+
+        await uiHelper.verifyRowInTableByUniqueText(displayName("noAccess"), [
+          "user",
+          "-",
+        ]);
+        await uiHelper.verifyRowInTableByUniqueText("catalog.entity.create", [
+          "create",
+          "-",
+        ]);
+      });
+
+      test("CSV file-sourced role (guest role): Update policies is not available", async ({
+        page,
+      }) => {
+        await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
+        await rbacPO.verifyRoleAndSwitchToOverview(
+          RBAC_ROLES.guest.ref,
+          "csv permission policy file",
+          ["1 user", "1 permission"],
+        );
+
+        await rbacPO.editRolePermissions();
+
+        const errorAlert = page
+          .getByRole("alert")
+          .filter({ hasText: /Unable to edit the role/i });
+        expect(errorAlert.count()).toBeTruthy();
+      });
+
+      test("CSV file-sourced role (guest role): Delete is not available", async ({
+        page,
+      }) => {
+        await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
+        await rbacPO.deleteRole(RBAC_ROLES.guest.ref, "All roles (0)", true);
+
+        const errorAlert = page
+          .getByRole("alert")
+          .filter({ hasText: /Unable to delete policy/i });
+        expect(errorAlert.count()).toBeTruthy();
+      });
+
+      test("Config-sourced role (rbac_admin): Update policies is not available", async ({
+        page,
+      }) => {
+        await rbacPO.filterRolesList(RBAC_ROLES.rbacAdmin.name);
+        await rbacPO.verifyRoleAndSwitchToOverview(
+          RBAC_ROLES.rbacAdmin.ref,
+          "",
+          ["1 user", "5 permissions"],
+        );
+
+        await rbacPO.editRolePermissions();
+
+        const errorAlert = page
+          .getByRole("alert")
+          .filter({ hasText: /Unable to edit the role/i });
+        expect(errorAlert.count()).toBeTruthy();
+      });
+
+      test("Config-sourced role (rbac_admin): Delete is not available", async ({
+        page,
+      }) => {
+        await rbacPO.filterRolesList(RBAC_ROLES.rbacAdmin.name);
+        await rbacPO.deleteRole(
+          RBAC_ROLES.rbacAdmin.ref,
+          "All roles (0)",
+          true,
+        );
+
+        const errorAlert = page
+          .getByRole("alert")
+          .filter({ hasText: /Unable to delete policy/i });
+        expect(errorAlert.count()).toBeTruthy();
+      });
     });
-  });
 
-  test.describe("RBAC conditional policies: policyDecisionPrecedence", () => {
-    test.beforeEach(({ page, uiHelper }) => {
-      rbacPO = new RbacPO(page, uiHelper);
+    test.describe("RBAC conditional policies: $currentUser alias", () => {
+      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+        rbacPO = new RbacPO(page, uiHelper);
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.currentUserOwner);
+      });
+
+      test("User can unregister own components but not group-owned components", async ({
+        page,
+        uiHelper,
+      }) => {
+        await rbacPO.navigateToCatalogComponent("test-rhdh-qe-2");
+
+        // Verify component name in the main heading
+        await expect(page.getByRole("heading", { level: 1 })).toContainText(
+          "test-rhdh-qe-2",
+        );
+        await page.getByTestId("menu-button").click();
+        const unregisterUserOwned = page.getByRole("menuitem", {
+          name: "Unregister entity",
+        });
+        await expect(unregisterUserOwned).toBeEnabled();
+
+        await page.getByRole("menuitem", { name: "Unregister entity" }).click();
+        await expect(page.getByRole("dialog")).toContainText(
+          "Are you sure you want to unregister this entity?",
+        );
+        await page.getByRole("button", { name: "Cancel" }).click();
+
+        await uiHelper.openSidebar("Catalog");
+        await page
+          .getByRole("link", { name: "test-rhdh-qe-2-team-owned" })
+          .click();
+        // Verify owner group in the component metadata (scope to article to avoid duplicates)
+        await expect(
+          page
+            .getByRole("article")
+            .getByRole("link", { name: /janus-qe\/rhdh-qe-2-team/ }),
+        ).toBeVisible();
+        await page.getByTestId("menu-button").click();
+        const unregisterGroupOwned = page.getByRole("menuitem", {
+          name: "Unregister entity",
+        });
+        await expect(unregisterGroupOwned).toBeDisabled();
+      });
     });
 
-    test("Conditional allow overrides basic deny (conditional-allow-user)", async ({
-      loginHelper,
-    }) => {
-      // Should allow read: conditional policy takes precedence over static deny read via CSV
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalAllowUser);
-      await rbacPO.navigateToCatalogComponent("mock-component");
+    test.describe("RBAC conditional policies: $ownerRefs transitive group ownership", () => {
+      test.beforeEach(({ page, uiHelper }) => {
+        rbacPO = new RbacPO(page, uiHelper);
+      });
+
+      test("User in child group can read components owned by the parent group", async ({
+        loginHelper,
+      }) => {
+        // login as child-group-member: belongs in rhdh-qe-child-team, which is a sub group of rhdh-qe-parent-team
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.childGroupMember);
+
+        // rhdh-qe-parent-team owns mock-site
+        await rbacPO.navigateToCatalogComponent("mock-site");
+        // Verify owner group in the component metadata
+        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhParentTeam.name);
+
+        // rhdh-qe-child-team owns mock-child-site, check that it can see it's own groups' components
+        await rbacPO.navigateToCatalogComponent("mock-child-site");
+        // Verify owner group in the component metadata
+        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhChildTeam.name);
+      });
+
+      test("User in sub-child group can read components owned by grandparent group", async ({
+        loginHelper,
+      }) => {
+        // login as sub-child-group-member: belongs in rhdh-qe-sub-child-team, which is a sub group of rhdh-qe-child-team
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.subChildGroupMember);
+
+        // rhdh-qe-parent-team owns mock-site
+        await rbacPO.navigateToCatalogComponent("mock-site");
+        // Verify owner group in the component metadata
+        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhParentTeam.name);
+
+        // rhdh-qe-child-team owns mock-child-site
+        await rbacPO.navigateToCatalogComponent("mock-child-site");
+        // Verify owner group in the component metadata
+        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhChildTeam.name);
+
+        // rhdh-qe-sub-child-team owns mock-sub-child-site, check that it can see it's own groups' components
+        await rbacPO.navigateToCatalogComponent("mock-sub-child-site");
+        // Verify owner group in the component metadata
+        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhSubChildTeam.name);
+      });
     });
 
-    test("Conditional deny overrides basic allow (conditional-deny-user)", async ({
-      uiHelper,
-      loginHelper,
-    }) => {
-      // Should deny read: conditional deny policy takes precedence over allow read via basic
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalDenyUser);
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.selectMuiBox("Kind", "Component");
-      await uiHelper.verifyTableIsEmpty();
+    test.describe("RBAC conditional policies: IsOwner ownership rule", () => {
+      test.describe.configure({ mode: "serial" });
+
+      test.beforeEach(async ({ page, uiHelper }) => {
+        rbacPO = new RbacPO(page, uiHelper);
+      });
+
+      test("Admin creates rbac-ownership-role with IsOwner rule for conditional-manager", async ({
+        loginHelper,
+      }) => {
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+
+        await rbacPO.navigateToRBACPage();
+        await rbacPO.createRBACConditionRole(
+          RBAC_ROLES.rbacOwnership.name,
+          [displayName("conditionalManager")],
+          userEntityRef(RBAC_DESCRIPTIVE_USERS.conditionalManager),
+        );
+      });
+
+      test("conditional-manager can access RBAC page, create a role, edit it, and delete it", async ({
+        page,
+        loginHelper,
+      }) => {
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalManager);
+
+        await rbacPO.navigateToRBACPage();
+        await rbacPO.createRole(
+          RBAC_ROLES.rbacConditional.name,
+          [displayName("noAccess"), displayName("tara")],
+          [RBAC_GROUPS.backstage.name],
+          [{ permission: "catalog.entity.delete" }],
+          "catalog",
+          userEntityRef(RBAC_DESCRIPTIVE_USERS.conditionalManager),
+        );
+
+        await ROLES_PAGE_COMPONENTS.getEditRoleButton(
+          page,
+          RBAC_ROLES.rbacConditional.ref,
+        ).click();
+
+        await rbacPO.editRoleMembers(
+          RBAC_ROLES.rbacConditional.ref,
+          displayName("jonathon"),
+          3,
+          1,
+        );
+
+        await rbacPO.deleteRole(RBAC_ROLES.rbacConditional.ref, "All roles");
+      });
+
+      test("Admin revokes access by deleting rbac-conditional-role", async ({
+        loginHelper,
+      }) => {
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+
+        await rbacPO.navigateToRBACPage();
+
+        await rbacPO.deleteRole(RBAC_ROLES.rbacOwnership.ref);
+      });
+
+      test("conditional-manager no longer sees RBAC in the sidebar after access is revoked", async ({
+        page,
+        uiHelper,
+        loginHelper,
+      }) => {
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalManager);
+
+        await uiHelper.openSidebarButton("Administration");
+        const dropdownMenuLocator = page.getByText("RBAC");
+        await expect(dropdownMenuLocator).toBeHidden();
+      });
     });
-  });
 
-  test.describe("RBAC conditional policies: permission policy per resource type", () => {
-    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-      await setupAdminSession({ page, uiHelper, loginHelper });
+    test.describe("RBAC conditional policies: policyDecisionPrecedence", () => {
+      test.beforeEach(({ page, uiHelper }) => {
+        rbacPO = new RbacPO(page, uiHelper);
+      });
+
+      test("Conditional allow overrides basic deny (conditional-allow-user)", async ({
+        loginHelper,
+      }) => {
+        // Should allow read: conditional policy takes precedence over static deny read via CSV
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalAllowUser);
+        await rbacPO.navigateToCatalogComponent("mock-component");
+      });
+
+      test("Conditional deny overrides basic allow (conditional-deny-user)", async ({
+        uiHelper,
+        loginHelper,
+      }) => {
+        // Should deny read: conditional deny policy takes precedence over allow read via basic
+        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalDenyUser);
+        await uiHelper.openSidebar("Catalog");
+        await uiHelper.selectMuiBox("Kind", "Component");
+        await uiHelper.verifyTableIsEmpty();
+      });
     });
 
-    test("Create role with AnyOf conditional rules per resource type and verify only authorized users see appropriate catalog resources", async ({}) => {
-      await rbacPO.createConditionalRole(
-        RBAC_ROLES.conditionalResource.name,
-        [displayName("noAccess"), displayName("rbacAdmin")],
-        [RBAC_GROUPS.backstage.name],
-        "anyOf",
-        "catalog",
-        userEntityRef(RBAC_DESCRIPTIVE_USERS.rbacAdmin),
-      );
+    test.describe("RBAC conditional policies: permission policy per resource type", () => {
+      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+        await setupAdminSession({ page, uiHelper, loginHelper });
+      });
 
-      await rbacPO.deleteRole(RBAC_ROLES.conditionalResource.ref);
+      test("Create role with AnyOf conditional rules per resource type and verify only authorized users see appropriate catalog resources", async ({}) => {
+        await rbacPO.createConditionalRole(
+          RBAC_ROLES.conditionalResource.name,
+          [displayName("noAccess"), displayName("rbacAdmin")],
+          [RBAC_GROUPS.backstage.name],
+          "anyOf",
+          "catalog",
+          userEntityRef(RBAC_DESCRIPTIVE_USERS.rbacAdmin),
+        );
+
+        await rbacPO.deleteRole(RBAC_ROLES.conditionalResource.ref);
+      });
     });
-  });
 
-  test.afterAll(async () => {
-    await cleanupRoles(RBAC_ROLES, apiToken);
-  });
-});
+    test.afterAll(async () => {
+      await cleanupRoles(RBAC_ROLES, apiToken);
+    });
+  },
+);

--- a/workspaces/rbac/e2e-tests/tests/specs/rbac.spec.ts
+++ b/workspaces/rbac/e2e-tests/tests/specs/rbac.spec.ts
@@ -24,7 +24,15 @@ import {
   UIhelper,
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
 
-test.describe("RBAC plugin", () => {
+test.describe(
+  "RBAC plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "rbac" },
+    ],
+  },
+  () => {
   let rbacPO: RbacPO;
   let apiToken: string;
 

--- a/workspaces/rbac/e2e-tests/tests/specs/rbac.spec.ts
+++ b/workspaces/rbac/e2e-tests/tests/specs/rbac.spec.ts
@@ -24,636 +24,625 @@ import {
   UIhelper,
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
 
-test.describe(
-  "RBAC plugin",
-  {
-    annotation: [
+test.describe("RBAC plugin", () => {
+  let rbacPO: RbacPO;
+  let apiToken: string;
+
+  /**
+   * Shared helper used by both `beforeAll` (to grab the API token) and each
+   * `beforeEach` that needs an admin UI session.  Extracting it avoids
+   * duplicating the login + navigation steps across multiple describe blocks.
+   */
+  async function setupAdminSession({
+    page,
+    uiHelper,
+    loginHelper,
+  }: {
+    page: Page;
+    uiHelper: UIhelper;
+    loginHelper: LoginHelper;
+  }) {
+    rbacPO = new RbacPO(page, uiHelper);
+    await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+    await rbacPO.navigateToRBACPage();
+  }
+
+  test.beforeAll(async ({ rhdh, browser }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "rbac" },
-    ],
-  },
-  () => {
-    let rbacPO: RbacPO;
-    let apiToken: string;
+    );
+    const rbacConfigmapPath = WorkspacePaths.resolve(
+      "tests/config/rbac-configmap.yaml",
+    );
+    await createUsersAndGroups();
+    const namespace = rhdh.deploymentConfig.namespace;
+    await $`kubectl apply -f ${rbacConfigmapPath} -n ${namespace}`;
 
-    /**
-     * Shared helper used by both `beforeAll` (to grab the API token) and each
-     * `beforeEach` that needs an admin UI session.  Extracting it avoids
-     * duplicating the login + navigation steps across multiple describe blocks.
-     */
-    async function setupAdminSession({
+    await rhdh.configure({
+      auth: "keycloak",
+      appConfig: "tests/config/app-config-rhdh.yaml",
+      valueFile: "tests/config/values.yaml",
+    });
+    await rhdh.deploy();
+    await rhdh.waitUntilReady();
+
+    // `beforeAll` does not receive a `page` fixture, so a temporary browser
+    // context is created solely to perform the admin login and extract the
+    // API token used by `afterAll` for programmatic cleanup.
+    const context = await browser.newContext({
+      baseURL: process.env.RHDH_BASE_URL,
+    });
+
+    const page = await context.newPage();
+    const uiHelper = new UIhelper(page);
+    const loginHelper = new LoginHelper(page);
+    await setupAdminSession({ page, uiHelper, loginHelper });
+    const authApiHelper = new AuthApiHelper(page);
+    apiToken = await authApiHelper.getToken();
+    await context.close();
+  });
+
+  test.describe("RBAC plugin: admin user", () => {
+    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+      await setupAdminSession({ page, uiHelper, loginHelper });
+    });
+
+    test("Check Administration side nav has RBAC plugin", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.goToPageUrl("/", "Welcome back!");
+      await uiHelper.openSidebarButton("Administration");
+      const rbacLink = page.getByRole("link", { name: "RBAC" });
+      await expect(rbacLink).toBeVisible();
+      await rbacLink.click();
+      await uiHelper.verifyHeading("RBAC");
+      expect(await page.title()).toContain("RBAC");
+
+      await rbacPO.verifyGeneralRbacViewHeading();
+      const allGridColumnsText = RolesPage.getRolesListColumnsText();
+      const allCellsIdentifier = RolesPage.getRolesListCellsIdentifier();
+
+      await rbacPO.verifyRoleOverviewTables(
+        allGridColumnsText,
+        allCellsIdentifier,
+      );
+    });
+
+    test("Export CSV of the user list", async ({ page }) => {
+      await rbacPO.navigateToRBACPage();
+      const exportCsvLink = page.getByRole("link", { name: "Export CSV" });
+      await exportCsvLink.click();
+      const fileContent = await downloadAndReadFile(page, exportCsvLink);
+      await test.info().attach("user-list-file", {
+        body: fileContent,
+        contentType: "text/plain",
+      });
+      const lines = (fileContent ?? "").trim().split("\n");
+
+      const header = "userEntityRef,displayName,email,lastAuthTime";
+      expect(lines[0], "Header needs to match the expected header").toBe(
+        header,
+      );
+
+      // Check that each subsequent line starts with "user:default" or "user:development"
+      const invalidLines = lines
+        .slice(1)
+        .filter(
+          (line) =>
+            !line.startsWith("user:default") &&
+            !line.startsWith("user:development"),
+        );
+
+      await test.step(`Validate user lines: ${invalidLines.length} invalid out of ${lines.length} total`, async () => {
+        expect(invalidLines, "All users should be valid").toHaveLength(0);
+      });
+    });
+
+    test("View details of a role (rbac_admin)", async ({ uiHelper }) => {
+      await rbacPO.navigateToRBACPage();
+      await rbacPO.verifyRoleAndSwitchToOverview(RBAC_ROLES.rbacAdmin.ref, "", [
+        "1 user",
+        "5 permissions",
+      ]);
+
+      const usersAndGroupsColumnsText =
+        RolesPage.getUsersAndGroupsListColumnsText();
+      const usersAndGroupsCellsIdentifier =
+        RolesPage.getUsersAndGroupsListCellsIdentifier();
+
+      await rbacPO.verifyRoleOverviewTables(
+        usersAndGroupsColumnsText,
+        usersAndGroupsCellsIdentifier,
+      );
+
+      const permissionPoliciesColumnsText =
+        RolesPage.getPermissionPoliciesListColumnsText();
+      const permissionPoliciesCellsIdentifier =
+        RolesPage.getPermissionPoliciesListCellsIdentifier();
+
+      await rbacPO.verifyRoleOverviewTables(
+        permissionPoliciesColumnsText,
+        permissionPoliciesCellsIdentifier,
+      );
+
+      await uiHelper.clickLink("RBAC");
+    });
+
+    test("Cancel role creation exists without creating a role", async ({
+      page,
+      uiHelper,
+    }) => {
+      await rbacPO.navigateToRBACPage();
+      await uiHelper.clickButton("Create");
+      await uiHelper.verifyHeading("Create role");
+      await uiHelper.fillTextInputByLabel("name", "sample-role-1");
+      await uiHelper.fillTextInputByLabel(
+        "description",
+        "Test Description data",
+      );
+
+      await uiHelper.clickButton("Next");
+      // Wait for the users and groups step to be visible
+      await expect(
+        page.getByTestId("users-and-groups-text-field"),
+      ).toBeVisible();
+      await uiHelper.fillTextInputByLabel(
+        "Select users and groups",
+        "sample-role-1",
+      );
+      await page
+        .getByTestId("users-and-groups-text-field")
+        .getByLabel("clear search")
+        .click();
+      await expect(
+        page.getByTestId("users-and-groups-text-field").getByRole("combobox"),
+      ).toBeEmpty();
+      await uiHelper.verifyHeading("No users and groups selected");
+      await uiHelper.clickButton("Cancel");
+      await uiHelper.verifyText("Exit role creation?");
+      await uiHelper.clickButton("Discard");
+      await expect(page.getByRole("alert")).toHaveCount(0);
+    });
+
+    test("Edit role users via the inline edit button on the roles list", async ({
+      page,
+    }) => {
+      await rbacPO.navigateToRBACPage();
+      await rbacPO.createRole(
+        RBAC_ROLES.overviewListEdit.name,
+        [displayName("noAccess"), displayName("tara")],
+        [RBAC_GROUPS.backstage.name],
+        [{ permission: "catalog.entity.delete" }],
+      );
+
+      await rbacPO.filterRolesList(RBAC_ROLES.overviewListEdit.name);
+      await ROLES_PAGE_COMPONENTS.getEditRoleButton(
+        page,
+        RBAC_ROLES.overviewListEdit.ref,
+      ).click();
+      await rbacPO.editRoleMembers(
+        RBAC_ROLES.overviewListEdit.ref,
+        displayName("jonathon"),
+        3,
+        1,
+      );
+
+      await rbacPO.filterRolesList(RBAC_ROLES.overviewListEdit.name);
+
+      // Use semantic selector for table cell
+      const usersAndGroupsLocator = page
+        .getByRole("cell")
+        .filter({ hasText: rbacPO.regexpShortUsersAndGroups(3, 1) });
+      await expect(usersAndGroupsLocator).toBeVisible();
+
+      await rbacPO.deleteRole(RBAC_ROLES.overviewListEdit.ref);
+    });
+
+    test("Edit role members via the updateMembers button on the overview page", async ({
+      page,
+      uiHelper,
+    }) => {
+      await rbacPO.navigateToRBACPage();
+      await rbacPO.createRole(
+        RBAC_ROLES.overviewMembers.name,
+        [displayName("noAccess"), displayName("tara")],
+        [RBAC_GROUPS.backstage.name],
+        [{ permission: "catalog.entity.delete" }],
+      );
+
+      await rbacPO.filterRolesList(RBAC_ROLES.overviewMembers.name);
+
+      await rbacPO.verifyRoleAndSwitchToOverview(
+        RBAC_ROLES.overviewMembers.ref,
+        "",
+        [rbacPO.regexpShortUsersAndGroups(2, 1), "1 permission"],
+      );
+
+      await ROLE_OVERVIEW_COMPONENTS.getUpdateMembersButton(page).click();
+      await rbacPO.editRoleMembers(
+        RBAC_ROLES.overviewMembers.ref,
+        displayName("noAccess"),
+        1,
+        1,
+      );
+
+      await uiHelper.verifyHeading(rbacPO.regexpShortUsersAndGroups(1, 1));
+
+      await rbacPO.deleteRole(RBAC_ROLES.overviewMembers.ref);
+    });
+
+    test("Edit role policies via the updatePolicies button on the overview page", async ({
+      uiHelper,
+    }) => {
+      await rbacPO.navigateToRBACPage();
+      await rbacPO.createRole(
+        RBAC_ROLES.overviewPolicies.name,
+        [displayName("noAccess"), displayName("tara")],
+        [RBAC_GROUPS.backstage.name],
+        [{ permission: "catalog.entity.delete" }],
+      );
+
+      await rbacPO.filterRolesList(RBAC_ROLES.overviewPolicies.name);
+
+      await rbacPO.verifyRoleAndSwitchToOverview(
+        RBAC_ROLES.overviewPolicies.ref,
+        "",
+        [rbacPO.regexpShortUsersAndGroups(2, 1), "1 permission"],
+      );
+
+      await rbacPO.editRolePermissions();
+
+      await uiHelper.verifyText(
+        `Role ${RBAC_ROLES.overviewPolicies.ref} updated successfully`,
+      );
+      await uiHelper.verifyHeading("2 permissions");
+
+      await rbacPO.deleteRole(RBAC_ROLES.overviewPolicies.ref);
+    });
+  });
+
+  test.describe("RBAC Plugin: validate appropriate guest user handling", () => {
+    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+      rbacPO = new RbacPO(page, uiHelper);
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.noAccess);
+    });
+
+    test("Administration side nav does not show RBAC plugin", async ({
+      page,
+      uiHelper,
+    }) => {
+      await uiHelper.openSidebarButton("Administration");
+      // Check specifically for RBAC link in sidebar navigation, not anywhere on the page
+      const rbacNavLink = page
+        .getByRole("navigation", { name: "sidebar nav" })
+        .getByRole("link", { name: "RBAC" });
+      await expect(rbacNavLink).toHaveCount(0);
+    });
+
+    test("No access user should not see list of components in catalog", async ({
+      uiHelper,
+    }) => {
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.waitForLoad();
+      await uiHelper.verifyTableIsEmpty();
+    });
+
+    test("Direct navigation to /rbac is denied", async ({ uiHelper }) => {
+      await rbacPO.go();
+      await uiHelper.waitForLoad();
+      await uiHelper.verifyText(
+        "ERROR 403: Insufficient permissions to access this page",
+      );
+    });
+  });
+
+  test.describe("RBAC plugin: permission policies loaded from files", () => {
+    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+      await setupAdminSession({ page, uiHelper, loginHelper });
+    });
+
+    test("Permission policies defined in a CSV file are loaded (guest role, 1 permission)", async ({
+      uiHelper,
+    }) => {
+      await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
+      await rbacPO.verifyRoleAndSwitchToOverview(
+        RBAC_ROLES.guest.ref,
+        "csv permission policy file",
+        ["1 user", "1 permission"],
+      );
+
+      const permissionPoliciesColumnsText =
+        RolesPage.getPermissionPoliciesListColumnsText();
+      const permissionPoliciesCellsIdentifier =
+        RolesPage.getPermissionPoliciesListCellsIdentifier();
+
+      await rbacPO.verifyRoleOverviewTables(
+        permissionPoliciesColumnsText,
+        permissionPoliciesCellsIdentifier,
+      );
+
+      await uiHelper.verifyRowInTableByUniqueText(displayName("noAccess"), [
+        "user",
+        "-",
+      ]);
+      await uiHelper.verifyRowInTableByUniqueText("catalog.entity.create", [
+        "create",
+        "-",
+      ]);
+    });
+
+    test("CSV file-sourced role (guest role): Update policies is not available", async ({
+      page,
+    }) => {
+      await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
+      await rbacPO.verifyRoleAndSwitchToOverview(
+        RBAC_ROLES.guest.ref,
+        "csv permission policy file",
+        ["1 user", "1 permission"],
+      );
+
+      await rbacPO.editRolePermissions();
+
+      const errorAlert = page
+        .getByRole("alert")
+        .filter({ hasText: /Unable to edit the role/i });
+      expect(errorAlert.count()).toBeTruthy();
+    });
+
+    test("CSV file-sourced role (guest role): Delete is not available", async ({
+      page,
+    }) => {
+      await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
+      await rbacPO.deleteRole(RBAC_ROLES.guest.ref, "All roles (0)", true);
+
+      const errorAlert = page
+        .getByRole("alert")
+        .filter({ hasText: /Unable to delete policy/i });
+      expect(errorAlert.count()).toBeTruthy();
+    });
+
+    test("Config-sourced role (rbac_admin): Update policies is not available", async ({
+      page,
+    }) => {
+      await rbacPO.filterRolesList(RBAC_ROLES.rbacAdmin.name);
+      await rbacPO.verifyRoleAndSwitchToOverview(RBAC_ROLES.rbacAdmin.ref, "", [
+        "1 user",
+        "5 permissions",
+      ]);
+
+      await rbacPO.editRolePermissions();
+
+      const errorAlert = page
+        .getByRole("alert")
+        .filter({ hasText: /Unable to edit the role/i });
+      expect(errorAlert.count()).toBeTruthy();
+    });
+
+    test("Config-sourced role (rbac_admin): Delete is not available", async ({
+      page,
+    }) => {
+      await rbacPO.filterRolesList(RBAC_ROLES.rbacAdmin.name);
+      await rbacPO.deleteRole(RBAC_ROLES.rbacAdmin.ref, "All roles (0)", true);
+
+      const errorAlert = page
+        .getByRole("alert")
+        .filter({ hasText: /Unable to delete policy/i });
+      expect(errorAlert.count()).toBeTruthy();
+    });
+  });
+
+  test.describe("RBAC conditional policies: $currentUser alias", () => {
+    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
+      rbacPO = new RbacPO(page, uiHelper);
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.currentUserOwner);
+    });
+
+    test("User can unregister own components but not group-owned components", async ({
+      page,
+      uiHelper,
+    }) => {
+      await rbacPO.navigateToCatalogComponent("test-rhdh-qe-2");
+
+      // Verify component name in the main heading
+      await expect(page.getByRole("heading", { level: 1 })).toContainText(
+        "test-rhdh-qe-2",
+      );
+      await page.getByTestId("menu-button").click();
+      const unregisterUserOwned = page.getByRole("menuitem", {
+        name: "Unregister entity",
+      });
+      await expect(unregisterUserOwned).toBeEnabled();
+
+      await page.getByRole("menuitem", { name: "Unregister entity" }).click();
+      await expect(page.getByRole("dialog")).toContainText(
+        "Are you sure you want to unregister this entity?",
+      );
+      await page.getByRole("button", { name: "Cancel" }).click();
+
+      await uiHelper.openSidebar("Catalog");
+      await page
+        .getByRole("link", { name: "test-rhdh-qe-2-team-owned" })
+        .click();
+      // Verify owner group in the component metadata (scope to article to avoid duplicates)
+      await expect(
+        page
+          .getByRole("article")
+          .getByRole("link", { name: /janus-qe\/rhdh-qe-2-team/ }),
+      ).toBeVisible();
+      await page.getByTestId("menu-button").click();
+      const unregisterGroupOwned = page.getByRole("menuitem", {
+        name: "Unregister entity",
+      });
+      await expect(unregisterGroupOwned).toBeDisabled();
+    });
+  });
+
+  test.describe("RBAC conditional policies: $ownerRefs transitive group ownership", () => {
+    test.beforeEach(({ page, uiHelper }) => {
+      rbacPO = new RbacPO(page, uiHelper);
+    });
+
+    test("User in child group can read components owned by the parent group", async ({
+      loginHelper,
+    }) => {
+      // login as child-group-member: belongs in rhdh-qe-child-team, which is a sub group of rhdh-qe-parent-team
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.childGroupMember);
+
+      // rhdh-qe-parent-team owns mock-site
+      await rbacPO.navigateToCatalogComponent("mock-site");
+      // Verify owner group in the component metadata
+      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhParentTeam.name);
+
+      // rhdh-qe-child-team owns mock-child-site, check that it can see it's own groups' components
+      await rbacPO.navigateToCatalogComponent("mock-child-site");
+      // Verify owner group in the component metadata
+      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhChildTeam.name);
+    });
+
+    test("User in sub-child group can read components owned by grandparent group", async ({
+      loginHelper,
+    }) => {
+      // login as sub-child-group-member: belongs in rhdh-qe-sub-child-team, which is a sub group of rhdh-qe-child-team
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.subChildGroupMember);
+
+      // rhdh-qe-parent-team owns mock-site
+      await rbacPO.navigateToCatalogComponent("mock-site");
+      // Verify owner group in the component metadata
+      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhParentTeam.name);
+
+      // rhdh-qe-child-team owns mock-child-site
+      await rbacPO.navigateToCatalogComponent("mock-child-site");
+      // Verify owner group in the component metadata
+      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhChildTeam.name);
+
+      // rhdh-qe-sub-child-team owns mock-sub-child-site, check that it can see it's own groups' components
+      await rbacPO.navigateToCatalogComponent("mock-sub-child-site");
+      // Verify owner group in the component metadata
+      await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhSubChildTeam.name);
+    });
+  });
+
+  test.describe("RBAC conditional policies: IsOwner ownership rule", () => {
+    test.describe.configure({ mode: "serial" });
+
+    test.beforeEach(async ({ page, uiHelper }) => {
+      rbacPO = new RbacPO(page, uiHelper);
+    });
+
+    test("Admin creates rbac-ownership-role with IsOwner rule for conditional-manager", async ({
+      loginHelper,
+    }) => {
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+
+      await rbacPO.navigateToRBACPage();
+      await rbacPO.createRBACConditionRole(
+        RBAC_ROLES.rbacOwnership.name,
+        [displayName("conditionalManager")],
+        userEntityRef(RBAC_DESCRIPTIVE_USERS.conditionalManager),
+      );
+    });
+
+    test("conditional-manager can access RBAC page, create a role, edit it, and delete it", async ({
+      page,
+      loginHelper,
+    }) => {
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalManager);
+
+      await rbacPO.navigateToRBACPage();
+      await rbacPO.createRole(
+        RBAC_ROLES.rbacConditional.name,
+        [displayName("noAccess"), displayName("tara")],
+        [RBAC_GROUPS.backstage.name],
+        [{ permission: "catalog.entity.delete" }],
+        "catalog",
+        userEntityRef(RBAC_DESCRIPTIVE_USERS.conditionalManager),
+      );
+
+      await ROLES_PAGE_COMPONENTS.getEditRoleButton(
+        page,
+        RBAC_ROLES.rbacConditional.ref,
+      ).click();
+
+      await rbacPO.editRoleMembers(
+        RBAC_ROLES.rbacConditional.ref,
+        displayName("jonathon"),
+        3,
+        1,
+      );
+
+      await rbacPO.deleteRole(RBAC_ROLES.rbacConditional.ref, "All roles");
+    });
+
+    test("Admin revokes access by deleting rbac-conditional-role", async ({
+      loginHelper,
+    }) => {
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
+
+      await rbacPO.navigateToRBACPage();
+
+      await rbacPO.deleteRole(RBAC_ROLES.rbacOwnership.ref);
+    });
+
+    test("conditional-manager no longer sees RBAC in the sidebar after access is revoked", async ({
       page,
       uiHelper,
       loginHelper,
-    }: {
-      page: Page;
-      uiHelper: UIhelper;
-      loginHelper: LoginHelper;
-    }) {
+    }) => {
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalManager);
+
+      await uiHelper.openSidebarButton("Administration");
+      const dropdownMenuLocator = page.getByText("RBAC");
+      await expect(dropdownMenuLocator).toBeHidden();
+    });
+  });
+
+  test.describe("RBAC conditional policies: policyDecisionPrecedence", () => {
+    test.beforeEach(({ page, uiHelper }) => {
       rbacPO = new RbacPO(page, uiHelper);
-      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
-      await rbacPO.navigateToRBACPage();
-    }
+    });
 
-    test.beforeAll(async ({ rhdh, browser }) => {
-      const rbacConfigmapPath = WorkspacePaths.resolve(
-        "tests/config/rbac-configmap.yaml",
-      );
-      await createUsersAndGroups();
-      const namespace = rhdh.deploymentConfig.namespace;
-      await $`kubectl apply -f ${rbacConfigmapPath} -n ${namespace}`;
+    test("Conditional allow overrides basic deny (conditional-allow-user)", async ({
+      loginHelper,
+    }) => {
+      // Should allow read: conditional policy takes precedence over static deny read via CSV
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalAllowUser);
+      await rbacPO.navigateToCatalogComponent("mock-component");
+    });
 
-      await rhdh.configure({
-        auth: "keycloak",
-        appConfig: "tests/config/app-config-rhdh.yaml",
-        valueFile: "tests/config/values.yaml",
-      });
-      await rhdh.deploy();
-      await rhdh.waitUntilReady();
+    test("Conditional deny overrides basic allow (conditional-deny-user)", async ({
+      uiHelper,
+      loginHelper,
+    }) => {
+      // Should deny read: conditional deny policy takes precedence over allow read via basic
+      await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalDenyUser);
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.selectMuiBox("Kind", "Component");
+      await uiHelper.verifyTableIsEmpty();
+    });
+  });
 
-      // `beforeAll` does not receive a `page` fixture, so a temporary browser
-      // context is created solely to perform the admin login and extract the
-      // API token used by `afterAll` for programmatic cleanup.
-      const context = await browser.newContext({
-        baseURL: process.env.RHDH_BASE_URL,
-      });
-
-      const page = await context.newPage();
-      const uiHelper = new UIhelper(page);
-      const loginHelper = new LoginHelper(page);
+  test.describe("RBAC conditional policies: permission policy per resource type", () => {
+    test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
       await setupAdminSession({ page, uiHelper, loginHelper });
-      const authApiHelper = new AuthApiHelper(page);
-      apiToken = await authApiHelper.getToken();
-      await context.close();
     });
 
-    test.describe("RBAC plugin: admin user", () => {
-      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-        await setupAdminSession({ page, uiHelper, loginHelper });
-      });
+    test("Create role with AnyOf conditional rules per resource type and verify only authorized users see appropriate catalog resources", async ({}) => {
+      await rbacPO.createConditionalRole(
+        RBAC_ROLES.conditionalResource.name,
+        [displayName("noAccess"), displayName("rbacAdmin")],
+        [RBAC_GROUPS.backstage.name],
+        "anyOf",
+        "catalog",
+        userEntityRef(RBAC_DESCRIPTIVE_USERS.rbacAdmin),
+      );
 
-      test("Check Administration side nav has RBAC plugin", async ({
-        page,
-        uiHelper,
-      }) => {
-        await uiHelper.goToPageUrl("/", "Welcome back!");
-        await uiHelper.openSidebarButton("Administration");
-        const rbacLink = page.getByRole("link", { name: "RBAC" });
-        await expect(rbacLink).toBeVisible();
-        await rbacLink.click();
-        await uiHelper.verifyHeading("RBAC");
-        expect(await page.title()).toContain("RBAC");
-
-        await rbacPO.verifyGeneralRbacViewHeading();
-        const allGridColumnsText = RolesPage.getRolesListColumnsText();
-        const allCellsIdentifier = RolesPage.getRolesListCellsIdentifier();
-
-        await rbacPO.verifyRoleOverviewTables(
-          allGridColumnsText,
-          allCellsIdentifier,
-        );
-      });
-
-      test("Export CSV of the user list", async ({ page }) => {
-        await rbacPO.navigateToRBACPage();
-        const exportCsvLink = page.getByRole("link", { name: "Export CSV" });
-        await exportCsvLink.click();
-        const fileContent = await downloadAndReadFile(page, exportCsvLink);
-        await test.info().attach("user-list-file", {
-          body: fileContent,
-          contentType: "text/plain",
-        });
-        const lines = (fileContent ?? "").trim().split("\n");
-
-        const header = "userEntityRef,displayName,email,lastAuthTime";
-        expect(lines[0], "Header needs to match the expected header").toBe(
-          header,
-        );
-
-        // Check that each subsequent line starts with "user:default" or "user:development"
-        const invalidLines = lines
-          .slice(1)
-          .filter(
-            (line) =>
-              !line.startsWith("user:default") &&
-              !line.startsWith("user:development"),
-          );
-
-        await test.step(`Validate user lines: ${invalidLines.length} invalid out of ${lines.length} total`, async () => {
-          expect(invalidLines, "All users should be valid").toHaveLength(0);
-        });
-      });
-
-      test("View details of a role (rbac_admin)", async ({ uiHelper }) => {
-        await rbacPO.navigateToRBACPage();
-        await rbacPO.verifyRoleAndSwitchToOverview(
-          RBAC_ROLES.rbacAdmin.ref,
-          "",
-          ["1 user", "5 permissions"],
-        );
-
-        const usersAndGroupsColumnsText =
-          RolesPage.getUsersAndGroupsListColumnsText();
-        const usersAndGroupsCellsIdentifier =
-          RolesPage.getUsersAndGroupsListCellsIdentifier();
-
-        await rbacPO.verifyRoleOverviewTables(
-          usersAndGroupsColumnsText,
-          usersAndGroupsCellsIdentifier,
-        );
-
-        const permissionPoliciesColumnsText =
-          RolesPage.getPermissionPoliciesListColumnsText();
-        const permissionPoliciesCellsIdentifier =
-          RolesPage.getPermissionPoliciesListCellsIdentifier();
-
-        await rbacPO.verifyRoleOverviewTables(
-          permissionPoliciesColumnsText,
-          permissionPoliciesCellsIdentifier,
-        );
-
-        await uiHelper.clickLink("RBAC");
-      });
-
-      test("Cancel role creation exists without creating a role", async ({
-        page,
-        uiHelper,
-      }) => {
-        await rbacPO.navigateToRBACPage();
-        await uiHelper.clickButton("Create");
-        await uiHelper.verifyHeading("Create role");
-        await uiHelper.fillTextInputByLabel("name", "sample-role-1");
-        await uiHelper.fillTextInputByLabel(
-          "description",
-          "Test Description data",
-        );
-
-        await uiHelper.clickButton("Next");
-        // Wait for the users and groups step to be visible
-        await expect(
-          page.getByTestId("users-and-groups-text-field"),
-        ).toBeVisible();
-        await uiHelper.fillTextInputByLabel(
-          "Select users and groups",
-          "sample-role-1",
-        );
-        await page
-          .getByTestId("users-and-groups-text-field")
-          .getByLabel("clear search")
-          .click();
-        await expect(
-          page.getByTestId("users-and-groups-text-field").getByRole("combobox"),
-        ).toBeEmpty();
-        await uiHelper.verifyHeading("No users and groups selected");
-        await uiHelper.clickButton("Cancel");
-        await uiHelper.verifyText("Exit role creation?");
-        await uiHelper.clickButton("Discard");
-        await expect(page.getByRole("alert")).toHaveCount(0);
-      });
-
-      test("Edit role users via the inline edit button on the roles list", async ({
-        page,
-      }) => {
-        await rbacPO.navigateToRBACPage();
-        await rbacPO.createRole(
-          RBAC_ROLES.overviewListEdit.name,
-          [displayName("noAccess"), displayName("tara")],
-          [RBAC_GROUPS.backstage.name],
-          [{ permission: "catalog.entity.delete" }],
-        );
-
-        await rbacPO.filterRolesList(RBAC_ROLES.overviewListEdit.name);
-        await ROLES_PAGE_COMPONENTS.getEditRoleButton(
-          page,
-          RBAC_ROLES.overviewListEdit.ref,
-        ).click();
-        await rbacPO.editRoleMembers(
-          RBAC_ROLES.overviewListEdit.ref,
-          displayName("jonathon"),
-          3,
-          1,
-        );
-
-        await rbacPO.filterRolesList(RBAC_ROLES.overviewListEdit.name);
-
-        // Use semantic selector for table cell
-        const usersAndGroupsLocator = page
-          .getByRole("cell")
-          .filter({ hasText: rbacPO.regexpShortUsersAndGroups(3, 1) });
-        await expect(usersAndGroupsLocator).toBeVisible();
-
-        await rbacPO.deleteRole(RBAC_ROLES.overviewListEdit.ref);
-      });
-
-      test("Edit role members via the updateMembers button on the overview page", async ({
-        page,
-        uiHelper,
-      }) => {
-        await rbacPO.navigateToRBACPage();
-        await rbacPO.createRole(
-          RBAC_ROLES.overviewMembers.name,
-          [displayName("noAccess"), displayName("tara")],
-          [RBAC_GROUPS.backstage.name],
-          [{ permission: "catalog.entity.delete" }],
-        );
-
-        await rbacPO.filterRolesList(RBAC_ROLES.overviewMembers.name);
-
-        await rbacPO.verifyRoleAndSwitchToOverview(
-          RBAC_ROLES.overviewMembers.ref,
-          "",
-          [rbacPO.regexpShortUsersAndGroups(2, 1), "1 permission"],
-        );
-
-        await ROLE_OVERVIEW_COMPONENTS.getUpdateMembersButton(page).click();
-        await rbacPO.editRoleMembers(
-          RBAC_ROLES.overviewMembers.ref,
-          displayName("noAccess"),
-          1,
-          1,
-        );
-
-        await uiHelper.verifyHeading(rbacPO.regexpShortUsersAndGroups(1, 1));
-
-        await rbacPO.deleteRole(RBAC_ROLES.overviewMembers.ref);
-      });
-
-      test("Edit role policies via the updatePolicies button on the overview page", async ({
-        uiHelper,
-      }) => {
-        await rbacPO.navigateToRBACPage();
-        await rbacPO.createRole(
-          RBAC_ROLES.overviewPolicies.name,
-          [displayName("noAccess"), displayName("tara")],
-          [RBAC_GROUPS.backstage.name],
-          [{ permission: "catalog.entity.delete" }],
-        );
-
-        await rbacPO.filterRolesList(RBAC_ROLES.overviewPolicies.name);
-
-        await rbacPO.verifyRoleAndSwitchToOverview(
-          RBAC_ROLES.overviewPolicies.ref,
-          "",
-          [rbacPO.regexpShortUsersAndGroups(2, 1), "1 permission"],
-        );
-
-        await rbacPO.editRolePermissions();
-
-        await uiHelper.verifyText(
-          `Role ${RBAC_ROLES.overviewPolicies.ref} updated successfully`,
-        );
-        await uiHelper.verifyHeading("2 permissions");
-
-        await rbacPO.deleteRole(RBAC_ROLES.overviewPolicies.ref);
-      });
+      await rbacPO.deleteRole(RBAC_ROLES.conditionalResource.ref);
     });
+  });
 
-    test.describe("RBAC Plugin: validate appropriate guest user handling", () => {
-      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-        rbacPO = new RbacPO(page, uiHelper);
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.noAccess);
-      });
-
-      test("Administration side nav does not show RBAC plugin", async ({
-        page,
-        uiHelper,
-      }) => {
-        await uiHelper.openSidebarButton("Administration");
-        // Check specifically for RBAC link in sidebar navigation, not anywhere on the page
-        const rbacNavLink = page
-          .getByRole("navigation", { name: "sidebar nav" })
-          .getByRole("link", { name: "RBAC" });
-        await expect(rbacNavLink).toHaveCount(0);
-      });
-
-      test("No access user should not see list of components in catalog", async ({
-        uiHelper,
-      }) => {
-        await uiHelper.openSidebar("Catalog");
-        await uiHelper.waitForLoad();
-        await uiHelper.verifyTableIsEmpty();
-      });
-
-      test("Direct navigation to /rbac is denied", async ({ uiHelper }) => {
-        await rbacPO.go();
-        await uiHelper.waitForLoad();
-        await uiHelper.verifyText(
-          "ERROR 403: Insufficient permissions to access this page",
-        );
-      });
-    });
-
-    test.describe("RBAC plugin: permission policies loaded from files", () => {
-      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-        await setupAdminSession({ page, uiHelper, loginHelper });
-      });
-
-      test("Permission policies defined in a CSV file are loaded (guest role, 1 permission)", async ({
-        uiHelper,
-      }) => {
-        await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
-        await rbacPO.verifyRoleAndSwitchToOverview(
-          RBAC_ROLES.guest.ref,
-          "csv permission policy file",
-          ["1 user", "1 permission"],
-        );
-
-        const permissionPoliciesColumnsText =
-          RolesPage.getPermissionPoliciesListColumnsText();
-        const permissionPoliciesCellsIdentifier =
-          RolesPage.getPermissionPoliciesListCellsIdentifier();
-
-        await rbacPO.verifyRoleOverviewTables(
-          permissionPoliciesColumnsText,
-          permissionPoliciesCellsIdentifier,
-        );
-
-        await uiHelper.verifyRowInTableByUniqueText(displayName("noAccess"), [
-          "user",
-          "-",
-        ]);
-        await uiHelper.verifyRowInTableByUniqueText("catalog.entity.create", [
-          "create",
-          "-",
-        ]);
-      });
-
-      test("CSV file-sourced role (guest role): Update policies is not available", async ({
-        page,
-      }) => {
-        await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
-        await rbacPO.verifyRoleAndSwitchToOverview(
-          RBAC_ROLES.guest.ref,
-          "csv permission policy file",
-          ["1 user", "1 permission"],
-        );
-
-        await rbacPO.editRolePermissions();
-
-        const errorAlert = page
-          .getByRole("alert")
-          .filter({ hasText: /Unable to edit the role/i });
-        expect(errorAlert.count()).toBeTruthy();
-      });
-
-      test("CSV file-sourced role (guest role): Delete is not available", async ({
-        page,
-      }) => {
-        await rbacPO.filterRolesList(RBAC_ROLES.guest.name);
-        await rbacPO.deleteRole(RBAC_ROLES.guest.ref, "All roles (0)", true);
-
-        const errorAlert = page
-          .getByRole("alert")
-          .filter({ hasText: /Unable to delete policy/i });
-        expect(errorAlert.count()).toBeTruthy();
-      });
-
-      test("Config-sourced role (rbac_admin): Update policies is not available", async ({
-        page,
-      }) => {
-        await rbacPO.filterRolesList(RBAC_ROLES.rbacAdmin.name);
-        await rbacPO.verifyRoleAndSwitchToOverview(
-          RBAC_ROLES.rbacAdmin.ref,
-          "",
-          ["1 user", "5 permissions"],
-        );
-
-        await rbacPO.editRolePermissions();
-
-        const errorAlert = page
-          .getByRole("alert")
-          .filter({ hasText: /Unable to edit the role/i });
-        expect(errorAlert.count()).toBeTruthy();
-      });
-
-      test("Config-sourced role (rbac_admin): Delete is not available", async ({
-        page,
-      }) => {
-        await rbacPO.filterRolesList(RBAC_ROLES.rbacAdmin.name);
-        await rbacPO.deleteRole(
-          RBAC_ROLES.rbacAdmin.ref,
-          "All roles (0)",
-          true,
-        );
-
-        const errorAlert = page
-          .getByRole("alert")
-          .filter({ hasText: /Unable to delete policy/i });
-        expect(errorAlert.count()).toBeTruthy();
-      });
-    });
-
-    test.describe("RBAC conditional policies: $currentUser alias", () => {
-      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-        rbacPO = new RbacPO(page, uiHelper);
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.currentUserOwner);
-      });
-
-      test("User can unregister own components but not group-owned components", async ({
-        page,
-        uiHelper,
-      }) => {
-        await rbacPO.navigateToCatalogComponent("test-rhdh-qe-2");
-
-        // Verify component name in the main heading
-        await expect(page.getByRole("heading", { level: 1 })).toContainText(
-          "test-rhdh-qe-2",
-        );
-        await page.getByTestId("menu-button").click();
-        const unregisterUserOwned = page.getByRole("menuitem", {
-          name: "Unregister entity",
-        });
-        await expect(unregisterUserOwned).toBeEnabled();
-
-        await page.getByRole("menuitem", { name: "Unregister entity" }).click();
-        await expect(page.getByRole("dialog")).toContainText(
-          "Are you sure you want to unregister this entity?",
-        );
-        await page.getByRole("button", { name: "Cancel" }).click();
-
-        await uiHelper.openSidebar("Catalog");
-        await page
-          .getByRole("link", { name: "test-rhdh-qe-2-team-owned" })
-          .click();
-        // Verify owner group in the component metadata (scope to article to avoid duplicates)
-        await expect(
-          page
-            .getByRole("article")
-            .getByRole("link", { name: /janus-qe\/rhdh-qe-2-team/ }),
-        ).toBeVisible();
-        await page.getByTestId("menu-button").click();
-        const unregisterGroupOwned = page.getByRole("menuitem", {
-          name: "Unregister entity",
-        });
-        await expect(unregisterGroupOwned).toBeDisabled();
-      });
-    });
-
-    test.describe("RBAC conditional policies: $ownerRefs transitive group ownership", () => {
-      test.beforeEach(({ page, uiHelper }) => {
-        rbacPO = new RbacPO(page, uiHelper);
-      });
-
-      test("User in child group can read components owned by the parent group", async ({
-        loginHelper,
-      }) => {
-        // login as child-group-member: belongs in rhdh-qe-child-team, which is a sub group of rhdh-qe-parent-team
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.childGroupMember);
-
-        // rhdh-qe-parent-team owns mock-site
-        await rbacPO.navigateToCatalogComponent("mock-site");
-        // Verify owner group in the component metadata
-        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhParentTeam.name);
-
-        // rhdh-qe-child-team owns mock-child-site, check that it can see it's own groups' components
-        await rbacPO.navigateToCatalogComponent("mock-child-site");
-        // Verify owner group in the component metadata
-        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhChildTeam.name);
-      });
-
-      test("User in sub-child group can read components owned by grandparent group", async ({
-        loginHelper,
-      }) => {
-        // login as sub-child-group-member: belongs in rhdh-qe-sub-child-team, which is a sub group of rhdh-qe-child-team
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.subChildGroupMember);
-
-        // rhdh-qe-parent-team owns mock-site
-        await rbacPO.navigateToCatalogComponent("mock-site");
-        // Verify owner group in the component metadata
-        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhParentTeam.name);
-
-        // rhdh-qe-child-team owns mock-child-site
-        await rbacPO.navigateToCatalogComponent("mock-child-site");
-        // Verify owner group in the component metadata
-        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhChildTeam.name);
-
-        // rhdh-qe-sub-child-team owns mock-sub-child-site, check that it can see it's own groups' components
-        await rbacPO.navigateToCatalogComponent("mock-sub-child-site");
-        // Verify owner group in the component metadata
-        await rbacPO.verifyComponentOwner(RBAC_GROUPS.rhdhSubChildTeam.name);
-      });
-    });
-
-    test.describe("RBAC conditional policies: IsOwner ownership rule", () => {
-      test.describe.configure({ mode: "serial" });
-
-      test.beforeEach(async ({ page, uiHelper }) => {
-        rbacPO = new RbacPO(page, uiHelper);
-      });
-
-      test("Admin creates rbac-ownership-role with IsOwner rule for conditional-manager", async ({
-        loginHelper,
-      }) => {
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
-
-        await rbacPO.navigateToRBACPage();
-        await rbacPO.createRBACConditionRole(
-          RBAC_ROLES.rbacOwnership.name,
-          [displayName("conditionalManager")],
-          userEntityRef(RBAC_DESCRIPTIVE_USERS.conditionalManager),
-        );
-      });
-
-      test("conditional-manager can access RBAC page, create a role, edit it, and delete it", async ({
-        page,
-        loginHelper,
-      }) => {
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalManager);
-
-        await rbacPO.navigateToRBACPage();
-        await rbacPO.createRole(
-          RBAC_ROLES.rbacConditional.name,
-          [displayName("noAccess"), displayName("tara")],
-          [RBAC_GROUPS.backstage.name],
-          [{ permission: "catalog.entity.delete" }],
-          "catalog",
-          userEntityRef(RBAC_DESCRIPTIVE_USERS.conditionalManager),
-        );
-
-        await ROLES_PAGE_COMPONENTS.getEditRoleButton(
-          page,
-          RBAC_ROLES.rbacConditional.ref,
-        ).click();
-
-        await rbacPO.editRoleMembers(
-          RBAC_ROLES.rbacConditional.ref,
-          displayName("jonathon"),
-          3,
-          1,
-        );
-
-        await rbacPO.deleteRole(RBAC_ROLES.rbacConditional.ref, "All roles");
-      });
-
-      test("Admin revokes access by deleting rbac-conditional-role", async ({
-        loginHelper,
-      }) => {
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.rbacAdmin);
-
-        await rbacPO.navigateToRBACPage();
-
-        await rbacPO.deleteRole(RBAC_ROLES.rbacOwnership.ref);
-      });
-
-      test("conditional-manager no longer sees RBAC in the sidebar after access is revoked", async ({
-        page,
-        uiHelper,
-        loginHelper,
-      }) => {
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalManager);
-
-        await uiHelper.openSidebarButton("Administration");
-        const dropdownMenuLocator = page.getByText("RBAC");
-        await expect(dropdownMenuLocator).toBeHidden();
-      });
-    });
-
-    test.describe("RBAC conditional policies: policyDecisionPrecedence", () => {
-      test.beforeEach(({ page, uiHelper }) => {
-        rbacPO = new RbacPO(page, uiHelper);
-      });
-
-      test("Conditional allow overrides basic deny (conditional-allow-user)", async ({
-        loginHelper,
-      }) => {
-        // Should allow read: conditional policy takes precedence over static deny read via CSV
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalAllowUser);
-        await rbacPO.navigateToCatalogComponent("mock-component");
-      });
-
-      test("Conditional deny overrides basic allow (conditional-deny-user)", async ({
-        uiHelper,
-        loginHelper,
-      }) => {
-        // Should deny read: conditional deny policy takes precedence over allow read via basic
-        await loginAs(loginHelper, RBAC_DESCRIPTIVE_USERS.conditionalDenyUser);
-        await uiHelper.openSidebar("Catalog");
-        await uiHelper.selectMuiBox("Kind", "Component");
-        await uiHelper.verifyTableIsEmpty();
-      });
-    });
-
-    test.describe("RBAC conditional policies: permission policy per resource type", () => {
-      test.beforeEach(async ({ page, uiHelper, loginHelper }) => {
-        await setupAdminSession({ page, uiHelper, loginHelper });
-      });
-
-      test("Create role with AnyOf conditional rules per resource type and verify only authorized users see appropriate catalog resources", async ({}) => {
-        await rbacPO.createConditionalRole(
-          RBAC_ROLES.conditionalResource.name,
-          [displayName("noAccess"), displayName("rbacAdmin")],
-          [RBAC_GROUPS.backstage.name],
-          "anyOf",
-          "catalog",
-          userEntityRef(RBAC_DESCRIPTIVE_USERS.rbacAdmin),
-        );
-
-        await rbacPO.deleteRole(RBAC_ROLES.conditionalResource.ref);
-      });
-    });
-
-    test.afterAll(async () => {
-      await cleanupRoles(RBAC_ROLES, apiToken);
-    });
-  },
-);
+  test.afterAll(async () => {
+    await cleanupRoles(RBAC_ROLES, apiToken);
+  });
+});

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/tests/specs/scaffolder-backend-module-kubernetes.spec.ts
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/tests/specs/scaffolder-backend-module-kubernetes.spec.ts
@@ -6,73 +6,77 @@ test.describe(
   {
     annotation: [
       { type: "component", description: "plugins" },
-      { type: "workspace", description: "scaffolder-backend-module-kubernetes" },
+      {
+        type: "workspace",
+        description: "scaffolder-backend-module-kubernetes",
+      },
     ],
   },
   () => {
-  let kubeClient: KubeClient;
-  let namespace: string;
+    let kubeClient: KubeClient;
+    let namespace: string;
 
-  test.beforeAll(async ({ rhdh }) => {
-    kubeClient = new KubeClient();
+    test.beforeAll(async ({ rhdh }) => {
+      kubeClient = new KubeClient();
 
-    await rhdh.configure({
-      auth: "keycloak",
-      appConfig: "tests/config/app-config-rhdh.yaml",
-      secrets: "tests/config/rhdh-secrets.yaml",
+      await rhdh.configure({
+        auth: "keycloak",
+        appConfig: "tests/config/app-config-rhdh.yaml",
+        secrets: "tests/config/rhdh-secrets.yaml",
+      });
+      await rhdh.deploy();
     });
-    await rhdh.deploy();
-  });
 
-  test.beforeEach(async ({ page, uiHelper, loginHelper }, testInfo) => {
-    await loginHelper.loginAsKeycloakUser();
-    await uiHelper.goToPageUrl("/create");
+    test.beforeEach(async ({ page, uiHelper, loginHelper }, testInfo) => {
+      await loginHelper.loginAsKeycloakUser();
+      await uiHelper.goToPageUrl("/create");
 
-    // Add cool-down period before retries (except on first attempt)
-    if (testInfo.retry > 0) {
-      const coolDownMs = 2000;
-      console.log(
-        `Attempt ${testInfo.retry + 1} failed, waiting ${coolDownMs}ms before retry...`,
-      );
-      await page.waitForTimeout(coolDownMs);
-    }
-  });
+      // Add cool-down period before retries (except on first attempt)
+      if (testInfo.retry > 0) {
+        const coolDownMs = 2000;
+        console.log(
+          `Attempt ${testInfo.retry + 1} failed, waiting ${coolDownMs}ms before retry...`,
+        );
+        await page.waitForTimeout(coolDownMs);
+      }
+    });
 
-  test.afterEach(async () => {
-    await kubeClient.deleteNamespace(namespace);
-  });
+    test.afterEach(async () => {
+      await kubeClient.deleteNamespace(namespace);
+    });
 
-  test("Creates kubernetes namespace", async ({ page, uiHelper }) => {
-    namespace = `test-kubernetes-actions-${Date.now()}`;
-    await uiHelper.verifyHeading("Self-service");
-    await uiHelper.clickBtnInCard("Create a kubernetes namespace", "Choose");
-    await uiHelper.waitForTitle("Create a kubernetes namespace", 2);
+    test("Creates kubernetes namespace", async ({ page, uiHelper }) => {
+      namespace = `test-kubernetes-actions-${Date.now()}`;
+      await uiHelper.verifyHeading("Self-service");
+      await uiHelper.clickBtnInCard("Create a kubernetes namespace", "Choose");
+      await uiHelper.waitForTitle("Create a kubernetes namespace", 2);
 
-    await uiHelper.fillTextInputByLabel("Namespace name", namespace);
-    await uiHelper.checkCheckbox("Skip TLS verification");
-    await expect(page.getByRole("button", { name: "Review" })).toBeEnabled();
-    await uiHelper.clickButton("Review");
-    await expect(
-      page.getByRole("button", { name: "Create", exact: true }),
-    ).toBeVisible();
-    await uiHelper.clickButton("Create");
-    await expect(
-      page.getByRole("button", { name: "Create", exact: true }),
-    ).toBeHidden();
-    // Wait for creation process to complete (progressbar reaches 100%)
-    await expect(
-      page.getByRole("article").getByRole("progressbar").first(),
-    ).toHaveAttribute("aria-valuenow", "100", { timeout: 5000 });
-    await expect(page.getByText("second")).toBeVisible();
-    // Verify no error occurred during creation
-    await expect(page.getByRole("article").getByRole("alert")).toHaveCount(0);
+      await uiHelper.fillTextInputByLabel("Namespace name", namespace);
+      await uiHelper.checkCheckbox("Skip TLS verification");
+      await expect(page.getByRole("button", { name: "Review" })).toBeEnabled();
+      await uiHelper.clickButton("Review");
+      await expect(
+        page.getByRole("button", { name: "Create", exact: true }),
+      ).toBeVisible();
+      await uiHelper.clickButton("Create");
+      await expect(
+        page.getByRole("button", { name: "Create", exact: true }),
+      ).toBeHidden();
+      // Wait for creation process to complete (progressbar reaches 100%)
+      await expect(
+        page.getByRole("article").getByRole("progressbar").first(),
+      ).toHaveAttribute("aria-valuenow", "100", { timeout: 5000 });
+      await expect(page.getByText("second")).toBeVisible();
+      // Verify no error occurred during creation
+      await expect(page.getByRole("article").getByRole("alert")).toHaveCount(0);
 
-    console.log(`Verifying namespace ${namespace} exists in Kubernetes API`);
-    await expect
-      .poll(() => kubeClient.getNamespaceByName({ name: namespace }), {
-        timeout: 5000,
-      })
-      .toBeTruthy();
-    console.log(`Namespace ${namespace} verified successfully`);
-  });
-});
+      console.log(`Verifying namespace ${namespace} exists in Kubernetes API`);
+      await expect
+        .poll(() => kubeClient.getNamespaceByName({ name: namespace }), {
+          timeout: 5000,
+        })
+        .toBeTruthy();
+      console.log(`Namespace ${namespace} verified successfully`);
+    });
+  },
+);

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/tests/specs/scaffolder-backend-module-kubernetes.spec.ts
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/tests/specs/scaffolder-backend-module-kubernetes.spec.ts
@@ -1,7 +1,15 @@
 import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { KubeClient } from "../../support/utils/kube-client";
 
-test.describe("Test Kubernetes Actions plugin", () => {
+test.describe(
+  "Test Kubernetes Actions plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "scaffolder-backend-module-kubernetes" },
+    ],
+  },
+  () => {
   let kubeClient: KubeClient;
   let namespace: string;
 

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/tests/specs/scaffolder-backend-module-kubernetes.spec.ts
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/tests/specs/scaffolder-backend-module-kubernetes.spec.ts
@@ -1,82 +1,74 @@
 import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { KubeClient } from "../../support/utils/kube-client";
 
-test.describe(
-  "Test Kubernetes Actions plugin",
-  {
-    annotation: [
+test.describe("Test Kubernetes Actions plugin", () => {
+  let kubeClient: KubeClient;
+  let namespace: string;
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
-      {
-        type: "workspace",
-        description: "scaffolder-backend-module-kubernetes",
-      },
-    ],
-  },
-  () => {
-    let kubeClient: KubeClient;
-    let namespace: string;
+      { type: "workspace", description: "scaffolder-backend-module-kubernetes" },
+    );
+    kubeClient = new KubeClient();
 
-    test.beforeAll(async ({ rhdh }) => {
-      kubeClient = new KubeClient();
-
-      await rhdh.configure({
-        auth: "keycloak",
-        appConfig: "tests/config/app-config-rhdh.yaml",
-        secrets: "tests/config/rhdh-secrets.yaml",
-      });
-      await rhdh.deploy();
+    await rhdh.configure({
+      auth: "keycloak",
+      appConfig: "tests/config/app-config-rhdh.yaml",
+      secrets: "tests/config/rhdh-secrets.yaml",
     });
+    await rhdh.deploy();
+  });
 
-    test.beforeEach(async ({ page, uiHelper, loginHelper }, testInfo) => {
-      await loginHelper.loginAsKeycloakUser();
-      await uiHelper.goToPageUrl("/create");
+  test.beforeEach(async ({ page, uiHelper, loginHelper }, testInfo) => {
+    await loginHelper.loginAsKeycloakUser();
+    await uiHelper.goToPageUrl("/create");
 
-      // Add cool-down period before retries (except on first attempt)
-      if (testInfo.retry > 0) {
-        const coolDownMs = 2000;
-        console.log(
-          `Attempt ${testInfo.retry + 1} failed, waiting ${coolDownMs}ms before retry...`,
-        );
-        await page.waitForTimeout(coolDownMs);
-      }
-    });
+    // Add cool-down period before retries (except on first attempt)
+    if (testInfo.retry > 0) {
+      const coolDownMs = 2000;
+      console.log(
+        `Attempt ${testInfo.retry + 1} failed, waiting ${coolDownMs}ms before retry...`,
+      );
+      await page.waitForTimeout(coolDownMs);
+    }
+  });
 
-    test.afterEach(async () => {
-      await kubeClient.deleteNamespace(namespace);
-    });
+  test.afterEach(async () => {
+    await kubeClient.deleteNamespace(namespace);
+  });
 
-    test("Creates kubernetes namespace", async ({ page, uiHelper }) => {
-      namespace = `test-kubernetes-actions-${Date.now()}`;
-      await uiHelper.verifyHeading("Self-service");
-      await uiHelper.clickBtnInCard("Create a kubernetes namespace", "Choose");
-      await uiHelper.waitForTitle("Create a kubernetes namespace", 2);
+  test("Creates kubernetes namespace", async ({ page, uiHelper }) => {
+    namespace = `test-kubernetes-actions-${Date.now()}`;
+    await uiHelper.verifyHeading("Self-service");
+    await uiHelper.clickBtnInCard("Create a kubernetes namespace", "Choose");
+    await uiHelper.waitForTitle("Create a kubernetes namespace", 2);
 
-      await uiHelper.fillTextInputByLabel("Namespace name", namespace);
-      await uiHelper.checkCheckbox("Skip TLS verification");
-      await expect(page.getByRole("button", { name: "Review" })).toBeEnabled();
-      await uiHelper.clickButton("Review");
-      await expect(
-        page.getByRole("button", { name: "Create", exact: true }),
-      ).toBeVisible();
-      await uiHelper.clickButton("Create");
-      await expect(
-        page.getByRole("button", { name: "Create", exact: true }),
-      ).toBeHidden();
-      // Wait for creation process to complete (progressbar reaches 100%)
-      await expect(
-        page.getByRole("article").getByRole("progressbar").first(),
-      ).toHaveAttribute("aria-valuenow", "100", { timeout: 5000 });
-      await expect(page.getByText("second")).toBeVisible();
-      // Verify no error occurred during creation
-      await expect(page.getByRole("article").getByRole("alert")).toHaveCount(0);
+    await uiHelper.fillTextInputByLabel("Namespace name", namespace);
+    await uiHelper.checkCheckbox("Skip TLS verification");
+    await expect(page.getByRole("button", { name: "Review" })).toBeEnabled();
+    await uiHelper.clickButton("Review");
+    await expect(
+      page.getByRole("button", { name: "Create", exact: true }),
+    ).toBeVisible();
+    await uiHelper.clickButton("Create");
+    await expect(
+      page.getByRole("button", { name: "Create", exact: true }),
+    ).toBeHidden();
+    // Wait for creation process to complete (progressbar reaches 100%)
+    await expect(
+      page.getByRole("article").getByRole("progressbar").first(),
+    ).toHaveAttribute("aria-valuenow", "100", { timeout: 5000 });
+    await expect(page.getByText("second")).toBeVisible();
+    // Verify no error occurred during creation
+    await expect(page.getByRole("article").getByRole("alert")).toHaveCount(0);
 
-      console.log(`Verifying namespace ${namespace} exists in Kubernetes API`);
-      await expect
-        .poll(() => kubeClient.getNamespaceByName({ name: namespace }), {
-          timeout: 5000,
-        })
-        .toBeTruthy();
-      console.log(`Namespace ${namespace} verified successfully`);
-    });
-  },
-);
+    console.log(`Verifying namespace ${namespace} exists in Kubernetes API`);
+    await expect
+      .poll(() => kubeClient.getNamespaceByName({ name: namespace }), {
+        timeout: 5000,
+      })
+      .toBeTruthy();
+    console.log(`Namespace ${namespace} verified successfully`);
+  });
+});

--- a/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
+++ b/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
@@ -15,7 +15,15 @@ import {
   type ScorecardHelpers,
 } from "../utils/scorecard";
 
-test.describe.serial("Scorecard Plugin Tests", () => {
+test.describe.serial(
+  "Scorecard Plugin Tests",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "scorecard" },
+    ],
+  },
+  () => {
   let context: BrowserContext | undefined;
   let page: Page;
   let catalog: CatalogPage;

--- a/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
+++ b/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
@@ -24,186 +24,187 @@ test.describe.serial(
     ],
   },
   () => {
-  let context: BrowserContext | undefined;
-  let page: Page;
-  let catalog: CatalogPage;
-  let scorecard: ScorecardHelpers;
-  let aggregated: AggregatedScorecardHelpers;
+    let context: BrowserContext | undefined;
+    let page: Page;
+    let catalog: CatalogPage;
+    let scorecard: ScorecardHelpers;
+    let aggregated: AggregatedScorecardHelpers;
 
-  let initialGithubCount: number;
-  let initialJiraCount: number;
+    let initialGithubCount: number;
+    let initialJiraCount: number;
 
-  test.beforeAll(async ({ browser, rhdh }) => {
-    // Allow time for deployment + 2 min stabilization delay + browser setup
-    test.setTimeout(10 * 60 * 1000);
+    test.beforeAll(async ({ browser, rhdh }) => {
+      // Allow time for deployment + 2 min stabilization delay + browser setup
+      test.setTimeout(10 * 60 * 1000);
 
-    await rhdh.configure({
-      auth: "keycloak",
-      version: process.env.RHDH_VERSION ?? "1.10",
-    });
-    await rhdh.deploy();
+      await rhdh.configure({
+        auth: "keycloak",
+        version: process.env.RHDH_VERSION ?? "1.10",
+      });
+      await rhdh.deploy();
 
-    // Wait 2 minutes for deployment to stabilize before running tests
-    await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
+      // Wait 2 minutes for deployment to stabilize before running tests
+      await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
 
-    context = await browser.newContext({
-      baseURL: rhdh.rhdhUrl,
-    });
-    page = await context.newPage();
-    const uiHelper = new UIhelper(page);
-    catalog = new CatalogPage(page);
-    scorecard = scorecardHelpers(page, uiHelper);
-    aggregated = aggregatedScorecardHelpers(page);
-    await new LoginHelper(page).loginAsKeycloakUser();
-    await uiHelper.goToPageUrl("/", "Welcome back!");
-  });
-
-  test.afterAll(async () => {
-    await context?.close();
-  });
-
-  test("Setup aggregated scorecards on homepage", async () => {
-    await scorecard.navigateToHome();
-
-    await scorecard.enterEditModeIfNeeded();
-    await scorecard.openAddWidgetDialog();
-    await scorecard.selectWidget("GitHub open PRs");
-    await scorecard.expectNoProgressBar();
-    await scorecard.enterEditMode();
-    await scorecard.expectNoProgressBar();
-    await scorecard.openAddWidgetDialog();
-    await scorecard.selectWidget("Jira open blocking tickets");
-    await scorecard.saveChanges();
-
-    const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-    await scorecard.expectAggregatedScorecardVisible(githubMetric.title);
-    await scorecard.expectAggregatedScorecardVisible(jiraMetric.title);
-
-    initialGithubCount = await scorecard.getAggregatedScorecardEntityCount(
-      githubMetric.title,
-    );
-    initialJiraCount = await scorecard.getAggregatedScorecardEntityCount(
-      jiraMetric.title,
-    );
-  });
-
-  test("Aggregated scorecard (GitHub): info tooltips, drill-down, table UI", async () => {
-    const [githubMetric] = SCORECARD_METRICS;
-    await aggregated.runAggregatedScorecardDrilldownScenario(
-      () => scorecard.navigateToHome(),
-      githubMetric,
-      "github.open_prs",
-    );
-  });
-
-  test("Aggregated scorecard (Jira): no data found blocks drill-down", async () => {
-    const [, jiraMetric] = SCORECARD_METRICS;
-    await aggregated.runAggregatedScorecardNoDataHomepageScenario(
-      () => scorecard.navigateToHome(),
-      jiraMetric,
-      "jira.open_issues",
-      { skipIfHasDrilldown: true },
-    );
-  });
-
-  test.describe("Entity Scorecards", () => {
-    test("Validate scorecard tabs for GitHub PRs and Jira tickets", async () => {
-      await page.waitForTimeout(6000);
-      await catalog.go();
-      await catalog.goToByName("all-scorecards");
-      await scorecard.openTab();
-
-      for (const metric of SCORECARD_METRICS) {
-        await scorecard.validateScorecardAriaFor(metric);
-      }
+      context = await browser.newContext({
+        baseURL: rhdh.rhdhUrl,
+      });
+      page = await context.newPage();
+      const uiHelper = new UIhelper(page);
+      catalog = new CatalogPage(page);
+      scorecard = scorecardHelpers(page, uiHelper);
+      aggregated = aggregatedScorecardHelpers(page);
+      await new LoginHelper(page).loginAsKeycloakUser();
+      await uiHelper.goToPageUrl("/", "Welcome back!");
     });
 
-    test("Validate empty scorecard state", async () => {
-      await catalog.go();
-      await catalog.goToByName("no-scorecards");
-      await scorecard.openTab();
-      await scorecard.expectEmptyState();
+    test.afterAll(async () => {
+      await context?.close();
     });
 
-    test("Displays error state for unavailable data while rendering metrics", async () => {
-      await catalog.go();
-      await catalog.goToByName("unavailable-metric-service");
-      await scorecard.openTab();
+    test("Setup aggregated scorecards on homepage", async () => {
+      await scorecard.navigateToHome();
+
+      await scorecard.enterEditModeIfNeeded();
+      await scorecard.openAddWidgetDialog();
+      await scorecard.selectWidget("GitHub open PRs");
+      await scorecard.expectNoProgressBar();
+      await scorecard.enterEditMode();
+      await scorecard.expectNoProgressBar();
+      await scorecard.openAddWidgetDialog();
+      await scorecard.selectWidget("Jira open blocking tickets");
+      await scorecard.saveChanges();
 
       const [githubMetric, jiraMetric] = SCORECARD_METRICS;
 
-      await scorecard.expectScorecardVisible(githubMetric.title);
-      await scorecard.expectScorecardVisible(jiraMetric.title);
-      await scorecard.expectErrorHeading("Metric data unavailable");
-      await scorecard.validateScorecardAriaFor(jiraMetric);
+      await scorecard.expectAggregatedScorecardVisible(githubMetric.title);
+      await scorecard.expectAggregatedScorecardVisible(jiraMetric.title);
+
+      initialGithubCount = await scorecard.getAggregatedScorecardEntityCount(
+        githubMetric.title,
+      );
+      initialJiraCount = await scorecard.getAggregatedScorecardEntityCount(
+        jiraMetric.title,
+      );
     });
 
-    test("Validate only GitHub scorecard is displayed", async () => {
-      await catalog.go();
-      await catalog.goToByName("github-scorecard-only");
-      await scorecard.openTab();
-
-      const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-      await scorecard.expectScorecardVisible(githubMetric.title);
-      await scorecard.expectScorecardHidden(jiraMetric.title);
-      await scorecard.validateScorecardAriaFor(githubMetric);
+    test("Aggregated scorecard (GitHub): info tooltips, drill-down, table UI", async () => {
+      const [githubMetric] = SCORECARD_METRICS;
+      await aggregated.runAggregatedScorecardDrilldownScenario(
+        () => scorecard.navigateToHome(),
+        githubMetric,
+        "github.open_prs",
+      );
     });
 
-    test("Validate only Jira scorecard is displayed", async () => {
-      await catalog.go();
-      await catalog.goToByName("jira-scorecard-only");
-      await scorecard.openTab();
-
-      const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-      await scorecard.expectScorecardHidden(githubMetric.title);
-      await scorecard.expectScorecardVisible(jiraMetric.title);
-      await scorecard.validateScorecardAriaFor(jiraMetric);
+    test("Aggregated scorecard (Jira): no data found blocks drill-down", async () => {
+      const [, jiraMetric] = SCORECARD_METRICS;
+      await aggregated.runAggregatedScorecardNoDataHomepageScenario(
+        () => scorecard.navigateToHome(),
+        jiraMetric,
+        "jira.open_issues",
+        { skipIfHasDrilldown: true },
+      );
     });
 
-    test("Display error state for invalid threshold config while rendering metrics", async () => {
-      await catalog.go();
-      await catalog.goToByName("invalid-threshold");
-      await scorecard.openTab();
+    test.describe("Entity Scorecards", () => {
+      test("Validate scorecard tabs for GitHub PRs and Jira tickets", async () => {
+        await page.waitForTimeout(6000);
+        await catalog.go();
+        await catalog.goToByName("all-scorecards");
+        await scorecard.openTab();
 
-      const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+        for (const metric of SCORECARD_METRICS) {
+          await scorecard.validateScorecardAriaFor(metric);
+        }
+      });
 
-      await scorecard.expectScorecardVisible(githubMetric.title);
-      await scorecard.expectScorecardVisible(jiraMetric.title);
-      await scorecard.expectErrorHeading("Invalid thresholds");
-      await scorecard.validateScorecardAriaFor(jiraMetric);
+      test("Validate empty scorecard state", async () => {
+        await catalog.go();
+        await catalog.goToByName("no-scorecards");
+        await scorecard.openTab();
+        await scorecard.expectEmptyState();
+      });
+
+      test("Displays error state for unavailable data while rendering metrics", async () => {
+        await catalog.go();
+        await catalog.goToByName("unavailable-metric-service");
+        await scorecard.openTab();
+
+        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+        await scorecard.expectScorecardVisible(githubMetric.title);
+        await scorecard.expectScorecardVisible(jiraMetric.title);
+        await scorecard.expectErrorHeading("Metric data unavailable");
+        await scorecard.validateScorecardAriaFor(jiraMetric);
+      });
+
+      test("Validate only GitHub scorecard is displayed", async () => {
+        await catalog.go();
+        await catalog.goToByName("github-scorecard-only");
+        await scorecard.openTab();
+
+        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+        await scorecard.expectScorecardVisible(githubMetric.title);
+        await scorecard.expectScorecardHidden(jiraMetric.title);
+        await scorecard.validateScorecardAriaFor(githubMetric);
+      });
+
+      test("Validate only Jira scorecard is displayed", async () => {
+        await catalog.go();
+        await catalog.goToByName("jira-scorecard-only");
+        await scorecard.openTab();
+
+        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+        await scorecard.expectScorecardHidden(githubMetric.title);
+        await scorecard.expectScorecardVisible(jiraMetric.title);
+        await scorecard.validateScorecardAriaFor(jiraMetric);
+      });
+
+      test("Display error state for invalid threshold config while rendering metrics", async () => {
+        await catalog.go();
+        await catalog.goToByName("invalid-threshold");
+        await scorecard.openTab();
+
+        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+        await scorecard.expectScorecardVisible(githubMetric.title);
+        await scorecard.expectScorecardVisible(jiraMetric.title);
+        await scorecard.expectErrorHeading("Invalid thresholds");
+        await scorecard.validateScorecardAriaFor(jiraMetric);
+      });
+
+      // Re-enable once https://issues.redhat.com/browse/RHIDP-12130 is fixed
+      // eslint-disable-next-line playwright/no-skipped-test
+      test.skip("Validate scorecards on imported addon-test entity", async () => {
+        await catalog.go();
+        await catalog.goToByName("addon-test");
+        await scorecard.openTab();
+
+        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+        await scorecard.expectScorecardVisible(githubMetric.title);
+        await scorecard.expectScorecardVisible(jiraMetric.title);
+      });
     });
 
     // Re-enable once https://issues.redhat.com/browse/RHIDP-12130 is fixed
     // eslint-disable-next-line playwright/no-skipped-test
-    test.skip("Validate scorecards on imported addon-test entity", async () => {
-      await catalog.go();
-      await catalog.goToByName("addon-test");
-      await scorecard.openTab();
+    test.skip("Verify aggregated scorecard counts increased after import", async () => {
+      await scorecard.navigateToHome();
 
       const [githubMetric, jiraMetric] = SCORECARD_METRICS;
 
-      await scorecard.expectScorecardVisible(githubMetric.title);
-      await scorecard.expectScorecardVisible(jiraMetric.title);
+      await scorecard.expectAggregatedScorecardEntityCountToBe(
+        githubMetric.title,
+        initialGithubCount + 1,
+      );
+      await scorecard.expectAggregatedScorecardEntityCountToBe(
+        jiraMetric.title,
+        initialJiraCount + 1,
+      );
     });
-  });
-
-  // Re-enable once https://issues.redhat.com/browse/RHIDP-12130 is fixed
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip("Verify aggregated scorecard counts increased after import", async () => {
-    await scorecard.navigateToHome();
-
-    const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-    await scorecard.expectAggregatedScorecardEntityCountToBe(
-      githubMetric.title,
-      initialGithubCount + 1,
-    );
-    await scorecard.expectAggregatedScorecardEntityCountToBe(
-      jiraMetric.title,
-      initialJiraCount + 1,
-    );
-  });
-});
+  },
+);

--- a/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
+++ b/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
@@ -15,196 +15,191 @@ import {
   type ScorecardHelpers,
 } from "../utils/scorecard";
 
-test.describe.serial(
-  "Scorecard Plugin Tests",
-  {
-    annotation: [
+test.describe.serial("Scorecard Plugin Tests", () => {
+  let context: BrowserContext | undefined;
+  let page: Page;
+  let catalog: CatalogPage;
+  let scorecard: ScorecardHelpers;
+  let aggregated: AggregatedScorecardHelpers;
+
+  let initialGithubCount: number;
+  let initialJiraCount: number;
+
+  test.beforeAll(async ({ browser, rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "scorecard" },
-    ],
-  },
-  () => {
-    let context: BrowserContext | undefined;
-    let page: Page;
-    let catalog: CatalogPage;
-    let scorecard: ScorecardHelpers;
-    let aggregated: AggregatedScorecardHelpers;
+    );
+    // Allow time for deployment + 2 min stabilization delay + browser setup
+    test.setTimeout(10 * 60 * 1000);
 
-    let initialGithubCount: number;
-    let initialJiraCount: number;
+    await rhdh.configure({
+      auth: "keycloak",
+      version: process.env.RHDH_VERSION ?? "1.10",
+    });
+    await rhdh.deploy();
 
-    test.beforeAll(async ({ browser, rhdh }) => {
-      // Allow time for deployment + 2 min stabilization delay + browser setup
-      test.setTimeout(10 * 60 * 1000);
+    // Wait 2 minutes for deployment to stabilize before running tests
+    await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
 
-      await rhdh.configure({
-        auth: "keycloak",
-        version: process.env.RHDH_VERSION ?? "1.10",
-      });
-      await rhdh.deploy();
+    context = await browser.newContext({
+      baseURL: rhdh.rhdhUrl,
+    });
+    page = await context.newPage();
+    const uiHelper = new UIhelper(page);
+    catalog = new CatalogPage(page);
+    scorecard = scorecardHelpers(page, uiHelper);
+    aggregated = aggregatedScorecardHelpers(page);
+    await new LoginHelper(page).loginAsKeycloakUser();
+    await uiHelper.goToPageUrl("/", "Welcome back!");
+  });
 
-      // Wait 2 minutes for deployment to stabilize before running tests
-      await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
+  test.afterAll(async () => {
+    await context?.close();
+  });
 
-      context = await browser.newContext({
-        baseURL: rhdh.rhdhUrl,
-      });
-      page = await context.newPage();
-      const uiHelper = new UIhelper(page);
-      catalog = new CatalogPage(page);
-      scorecard = scorecardHelpers(page, uiHelper);
-      aggregated = aggregatedScorecardHelpers(page);
-      await new LoginHelper(page).loginAsKeycloakUser();
-      await uiHelper.goToPageUrl("/", "Welcome back!");
+  test("Setup aggregated scorecards on homepage", async () => {
+    await scorecard.navigateToHome();
+
+    await scorecard.enterEditModeIfNeeded();
+    await scorecard.openAddWidgetDialog();
+    await scorecard.selectWidget("GitHub open PRs");
+    await scorecard.expectNoProgressBar();
+    await scorecard.enterEditMode();
+    await scorecard.expectNoProgressBar();
+    await scorecard.openAddWidgetDialog();
+    await scorecard.selectWidget("Jira open blocking tickets");
+    await scorecard.saveChanges();
+
+    const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+    await scorecard.expectAggregatedScorecardVisible(githubMetric.title);
+    await scorecard.expectAggregatedScorecardVisible(jiraMetric.title);
+
+    initialGithubCount = await scorecard.getAggregatedScorecardEntityCount(
+      githubMetric.title,
+    );
+    initialJiraCount = await scorecard.getAggregatedScorecardEntityCount(
+      jiraMetric.title,
+    );
+  });
+
+  test("Aggregated scorecard (GitHub): info tooltips, drill-down, table UI", async () => {
+    const [githubMetric] = SCORECARD_METRICS;
+    await aggregated.runAggregatedScorecardDrilldownScenario(
+      () => scorecard.navigateToHome(),
+      githubMetric,
+      "github.open_prs",
+    );
+  });
+
+  test("Aggregated scorecard (Jira): no data found blocks drill-down", async () => {
+    const [, jiraMetric] = SCORECARD_METRICS;
+    await aggregated.runAggregatedScorecardNoDataHomepageScenario(
+      () => scorecard.navigateToHome(),
+      jiraMetric,
+      "jira.open_issues",
+      { skipIfHasDrilldown: true },
+    );
+  });
+
+  test.describe("Entity Scorecards", () => {
+    test("Validate scorecard tabs for GitHub PRs and Jira tickets", async () => {
+      await page.waitForTimeout(6000);
+      await catalog.go();
+      await catalog.goToByName("all-scorecards");
+      await scorecard.openTab();
+
+      for (const metric of SCORECARD_METRICS) {
+        await scorecard.validateScorecardAriaFor(metric);
+      }
     });
 
-    test.afterAll(async () => {
-      await context?.close();
+    test("Validate empty scorecard state", async () => {
+      await catalog.go();
+      await catalog.goToByName("no-scorecards");
+      await scorecard.openTab();
+      await scorecard.expectEmptyState();
     });
 
-    test("Setup aggregated scorecards on homepage", async () => {
-      await scorecard.navigateToHome();
-
-      await scorecard.enterEditModeIfNeeded();
-      await scorecard.openAddWidgetDialog();
-      await scorecard.selectWidget("GitHub open PRs");
-      await scorecard.expectNoProgressBar();
-      await scorecard.enterEditMode();
-      await scorecard.expectNoProgressBar();
-      await scorecard.openAddWidgetDialog();
-      await scorecard.selectWidget("Jira open blocking tickets");
-      await scorecard.saveChanges();
+    test("Displays error state for unavailable data while rendering metrics", async () => {
+      await catalog.go();
+      await catalog.goToByName("unavailable-metric-service");
+      await scorecard.openTab();
 
       const [githubMetric, jiraMetric] = SCORECARD_METRICS;
 
-      await scorecard.expectAggregatedScorecardVisible(githubMetric.title);
-      await scorecard.expectAggregatedScorecardVisible(jiraMetric.title);
-
-      initialGithubCount = await scorecard.getAggregatedScorecardEntityCount(
-        githubMetric.title,
-      );
-      initialJiraCount = await scorecard.getAggregatedScorecardEntityCount(
-        jiraMetric.title,
-      );
+      await scorecard.expectScorecardVisible(githubMetric.title);
+      await scorecard.expectScorecardVisible(jiraMetric.title);
+      await scorecard.expectErrorHeading("Metric data unavailable");
+      await scorecard.validateScorecardAriaFor(jiraMetric);
     });
 
-    test("Aggregated scorecard (GitHub): info tooltips, drill-down, table UI", async () => {
-      const [githubMetric] = SCORECARD_METRICS;
-      await aggregated.runAggregatedScorecardDrilldownScenario(
-        () => scorecard.navigateToHome(),
-        githubMetric,
-        "github.open_prs",
-      );
+    test("Validate only GitHub scorecard is displayed", async () => {
+      await catalog.go();
+      await catalog.goToByName("github-scorecard-only");
+      await scorecard.openTab();
+
+      const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+      await scorecard.expectScorecardVisible(githubMetric.title);
+      await scorecard.expectScorecardHidden(jiraMetric.title);
+      await scorecard.validateScorecardAriaFor(githubMetric);
     });
 
-    test("Aggregated scorecard (Jira): no data found blocks drill-down", async () => {
-      const [, jiraMetric] = SCORECARD_METRICS;
-      await aggregated.runAggregatedScorecardNoDataHomepageScenario(
-        () => scorecard.navigateToHome(),
-        jiraMetric,
-        "jira.open_issues",
-        { skipIfHasDrilldown: true },
-      );
+    test("Validate only Jira scorecard is displayed", async () => {
+      await catalog.go();
+      await catalog.goToByName("jira-scorecard-only");
+      await scorecard.openTab();
+
+      const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+      await scorecard.expectScorecardHidden(githubMetric.title);
+      await scorecard.expectScorecardVisible(jiraMetric.title);
+      await scorecard.validateScorecardAriaFor(jiraMetric);
     });
 
-    test.describe("Entity Scorecards", () => {
-      test("Validate scorecard tabs for GitHub PRs and Jira tickets", async () => {
-        await page.waitForTimeout(6000);
-        await catalog.go();
-        await catalog.goToByName("all-scorecards");
-        await scorecard.openTab();
+    test("Display error state for invalid threshold config while rendering metrics", async () => {
+      await catalog.go();
+      await catalog.goToByName("invalid-threshold");
+      await scorecard.openTab();
 
-        for (const metric of SCORECARD_METRICS) {
-          await scorecard.validateScorecardAriaFor(metric);
-        }
-      });
+      const [githubMetric, jiraMetric] = SCORECARD_METRICS;
 
-      test("Validate empty scorecard state", async () => {
-        await catalog.go();
-        await catalog.goToByName("no-scorecards");
-        await scorecard.openTab();
-        await scorecard.expectEmptyState();
-      });
-
-      test("Displays error state for unavailable data while rendering metrics", async () => {
-        await catalog.go();
-        await catalog.goToByName("unavailable-metric-service");
-        await scorecard.openTab();
-
-        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-        await scorecard.expectScorecardVisible(githubMetric.title);
-        await scorecard.expectScorecardVisible(jiraMetric.title);
-        await scorecard.expectErrorHeading("Metric data unavailable");
-        await scorecard.validateScorecardAriaFor(jiraMetric);
-      });
-
-      test("Validate only GitHub scorecard is displayed", async () => {
-        await catalog.go();
-        await catalog.goToByName("github-scorecard-only");
-        await scorecard.openTab();
-
-        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-        await scorecard.expectScorecardVisible(githubMetric.title);
-        await scorecard.expectScorecardHidden(jiraMetric.title);
-        await scorecard.validateScorecardAriaFor(githubMetric);
-      });
-
-      test("Validate only Jira scorecard is displayed", async () => {
-        await catalog.go();
-        await catalog.goToByName("jira-scorecard-only");
-        await scorecard.openTab();
-
-        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-        await scorecard.expectScorecardHidden(githubMetric.title);
-        await scorecard.expectScorecardVisible(jiraMetric.title);
-        await scorecard.validateScorecardAriaFor(jiraMetric);
-      });
-
-      test("Display error state for invalid threshold config while rendering metrics", async () => {
-        await catalog.go();
-        await catalog.goToByName("invalid-threshold");
-        await scorecard.openTab();
-
-        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-        await scorecard.expectScorecardVisible(githubMetric.title);
-        await scorecard.expectScorecardVisible(jiraMetric.title);
-        await scorecard.expectErrorHeading("Invalid thresholds");
-        await scorecard.validateScorecardAriaFor(jiraMetric);
-      });
-
-      // Re-enable once https://issues.redhat.com/browse/RHIDP-12130 is fixed
-      // eslint-disable-next-line playwright/no-skipped-test
-      test.skip("Validate scorecards on imported addon-test entity", async () => {
-        await catalog.go();
-        await catalog.goToByName("addon-test");
-        await scorecard.openTab();
-
-        const [githubMetric, jiraMetric] = SCORECARD_METRICS;
-
-        await scorecard.expectScorecardVisible(githubMetric.title);
-        await scorecard.expectScorecardVisible(jiraMetric.title);
-      });
+      await scorecard.expectScorecardVisible(githubMetric.title);
+      await scorecard.expectScorecardVisible(jiraMetric.title);
+      await scorecard.expectErrorHeading("Invalid thresholds");
+      await scorecard.validateScorecardAriaFor(jiraMetric);
     });
 
     // Re-enable once https://issues.redhat.com/browse/RHIDP-12130 is fixed
     // eslint-disable-next-line playwright/no-skipped-test
-    test.skip("Verify aggregated scorecard counts increased after import", async () => {
-      await scorecard.navigateToHome();
+    test.skip("Validate scorecards on imported addon-test entity", async () => {
+      await catalog.go();
+      await catalog.goToByName("addon-test");
+      await scorecard.openTab();
 
       const [githubMetric, jiraMetric] = SCORECARD_METRICS;
 
-      await scorecard.expectAggregatedScorecardEntityCountToBe(
-        githubMetric.title,
-        initialGithubCount + 1,
-      );
-      await scorecard.expectAggregatedScorecardEntityCountToBe(
-        jiraMetric.title,
-        initialJiraCount + 1,
-      );
+      await scorecard.expectScorecardVisible(githubMetric.title);
+      await scorecard.expectScorecardVisible(jiraMetric.title);
     });
-  },
-);
+  });
+
+  // Re-enable once https://issues.redhat.com/browse/RHIDP-12130 is fixed
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip("Verify aggregated scorecard counts increased after import", async () => {
+    await scorecard.navigateToHome();
+
+    const [githubMetric, jiraMetric] = SCORECARD_METRICS;
+
+    await scorecard.expectAggregatedScorecardEntityCountToBe(
+      githubMetric.title,
+      initialGithubCount + 1,
+    );
+    await scorecard.expectAggregatedScorecardEntityCountToBe(
+      jiraMetric.title,
+      initialJiraCount + 1,
+    );
+  });
+});

--- a/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
+++ b/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
@@ -7,45 +7,40 @@ const setupScript = path.join(
   "deploy-customization-provider.sh",
 );
 
-test.describe(
-  "Test tech-radar plugin",
-  {
-    annotation: [
+test.describe("Test tech-radar plugin", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "tech-radar" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      const project = rhdh.deploymentConfig.namespace;
-      await rhdh.configure({ auth: "keycloak" });
-      await $`bash ${setupScript} ${project}`;
-      process.env.TECH_RADAR_DATA_URL = (
-        await rhdh.k8sClient.getRouteLocation(
-          project,
-          "test-backstage-customization-provider",
-        )
-      ).replace("http://", "");
-      await rhdh.deploy();
-    });
+    );
+    const project = rhdh.deploymentConfig.namespace;
+    await rhdh.configure({ auth: "keycloak" });
+    await $`bash ${setupScript} ${project}`;
+    process.env.TECH_RADAR_DATA_URL = (
+      await rhdh.k8sClient.getRouteLocation(
+        project,
+        "test-backstage-customization-provider",
+      )
+    ).replace("http://", "");
+    await rhdh.deploy();
+  });
 
-    test.beforeEach(async ({ loginHelper }) => {
-      await loginHelper.loginAsKeycloakUser();
-    });
+  test.beforeEach(async ({ loginHelper }) => {
+    await loginHelper.loginAsKeycloakUser();
+  });
 
-    test("Verify tech-radar", async ({ page, uiHelper }) => {
-      await uiHelper.openSidebar("Tech Radar");
-      await uiHelper.verifyHeading("Tech Radar");
-      await uiHelper.verifyHeading("Company Radar");
+  test("Verify tech-radar", async ({ page, uiHelper }) => {
+    await uiHelper.openSidebar("Tech Radar");
+    await uiHelper.verifyHeading("Tech Radar");
+    await uiHelper.verifyHeading("Company Radar");
 
-      await verifyRadarDetails(page, "Languages", "JavaScript");
-      // TODO: This is cluster-dependent and we need tests cluster-agnostic, remove if not needed
-      // await verifyRadarDetails(page, "Storage", "AWS S3");
-      await verifyRadarDetails(page, "Frameworks", "React");
-      await verifyRadarDetails(page, "Infrastructure", "GitHub Actions");
-    });
-  },
-);
+    await verifyRadarDetails(page, "Languages", "JavaScript");
+    // TODO: This is cluster-dependent and we need tests cluster-agnostic, remove if not needed
+    // await verifyRadarDetails(page, "Storage", "AWS S3");
+    await verifyRadarDetails(page, "Frameworks", "React");
+    await verifyRadarDetails(page, "Infrastructure", "GitHub Actions");
+  });
+});
 
 async function verifyRadarDetails(page: Page, section: string, text: string) {
   const sectionLocator = page

--- a/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
+++ b/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
@@ -7,7 +7,15 @@ const setupScript = path.join(
   "deploy-customization-provider.sh",
 );
 
-test.describe("Test tech-radar plugin", () => {
+test.describe(
+  "Test tech-radar plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "tech-radar" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     const project = rhdh.deploymentConfig.namespace;
     await rhdh.configure({ auth: "keycloak" });

--- a/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
+++ b/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
@@ -16,35 +16,36 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    const project = rhdh.deploymentConfig.namespace;
-    await rhdh.configure({ auth: "keycloak" });
-    await $`bash ${setupScript} ${project}`;
-    process.env.TECH_RADAR_DATA_URL = (
-      await rhdh.k8sClient.getRouteLocation(
-        project,
-        "test-backstage-customization-provider",
-      )
-    ).replace("http://", "");
-    await rhdh.deploy();
-  });
+    test.beforeAll(async ({ rhdh }) => {
+      const project = rhdh.deploymentConfig.namespace;
+      await rhdh.configure({ auth: "keycloak" });
+      await $`bash ${setupScript} ${project}`;
+      process.env.TECH_RADAR_DATA_URL = (
+        await rhdh.k8sClient.getRouteLocation(
+          project,
+          "test-backstage-customization-provider",
+        )
+      ).replace("http://", "");
+      await rhdh.deploy();
+    });
 
-  test.beforeEach(async ({ loginHelper }) => {
-    await loginHelper.loginAsKeycloakUser();
-  });
+    test.beforeEach(async ({ loginHelper }) => {
+      await loginHelper.loginAsKeycloakUser();
+    });
 
-  test("Verify tech-radar", async ({ page, uiHelper }) => {
-    await uiHelper.openSidebar("Tech Radar");
-    await uiHelper.verifyHeading("Tech Radar");
-    await uiHelper.verifyHeading("Company Radar");
+    test("Verify tech-radar", async ({ page, uiHelper }) => {
+      await uiHelper.openSidebar("Tech Radar");
+      await uiHelper.verifyHeading("Tech Radar");
+      await uiHelper.verifyHeading("Company Radar");
 
-    await verifyRadarDetails(page, "Languages", "JavaScript");
-    // TODO: This is cluster-dependent and we need tests cluster-agnostic, remove if not needed
-    // await verifyRadarDetails(page, "Storage", "AWS S3");
-    await verifyRadarDetails(page, "Frameworks", "React");
-    await verifyRadarDetails(page, "Infrastructure", "GitHub Actions");
-  });
-});
+      await verifyRadarDetails(page, "Languages", "JavaScript");
+      // TODO: This is cluster-dependent and we need tests cluster-agnostic, remove if not needed
+      // await verifyRadarDetails(page, "Storage", "AWS S3");
+      await verifyRadarDetails(page, "Frameworks", "React");
+      await verifyRadarDetails(page, "Infrastructure", "GitHub Actions");
+    });
+  },
+);
 
 async function verifyRadarDetails(page: Page, section: string, text: string) {
   const sectionLocator = page

--- a/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
+++ b/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
@@ -11,50 +11,51 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({
-      auth: "keycloak",
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({
+        auth: "keycloak",
+      });
+      const namespace = rhdh.deploymentConfig.namespace;
+      // operator-install.sh: Tekton/Pipelines operator + waits, then namespace Active wait, pipeline-tests + RBAC (see operator::grant_default_service_account_cluster_reader_and_tekton).
+      const operatorInstallPath = WorkspacePaths.resolve(
+        "tests/config/operator-install.sh",
+      );
+      await $`bash ${operatorInstallPath} ${namespace}`;
+      await rhdh.deploy();
     });
-    const namespace = rhdh.deploymentConfig.namespace;
-    // operator-install.sh: Tekton/Pipelines operator + waits, then namespace Active wait, pipeline-tests + RBAC (see operator::grant_default_service_account_cluster_reader_and_tekton).
-    const operatorInstallPath = WorkspacePaths.resolve(
-      "tests/config/operator-install.sh",
-    );
-    await $`bash ${operatorInstallPath} ${namespace}`;
-    await rhdh.deploy();
-  });
 
-  test.beforeEach(async ({ loginHelper }) => {
-    await loginHelper.loginAsKeycloakUser();
-  });
+    test.beforeEach(async ({ loginHelper }) => {
+      await loginHelper.loginAsKeycloakUser();
+    });
 
-  test("Check Pipeline Run", async ({ page, uiHelper }) => {
-    const tekton = new TektonSupportHelper(page);
-    await tekton.goToBackstageJanusProjectCITab();
-    await tekton.ensurePipelineRunsTableIsNotEmpty();
-    await uiHelper.verifyHeading("Pipeline Runs");
-    await uiHelper.verifyTableHeadingAndRows(
-      tekton.getAllGridColumnsTextForPipelineRunsTable(),
-    );
-  });
+    test("Check Pipeline Run", async ({ page, uiHelper }) => {
+      const tekton = new TektonSupportHelper(page);
+      await tekton.goToBackstageJanusProjectCITab();
+      await tekton.ensurePipelineRunsTableIsNotEmpty();
+      await uiHelper.verifyHeading("Pipeline Runs");
+      await uiHelper.verifyTableHeadingAndRows(
+        tekton.getAllGridColumnsTextForPipelineRunsTable(),
+      );
+    });
 
-  test("Check search functionality", async ({ page }) => {
-    const tekton = new TektonSupportHelper(page);
-    await tekton.goToBackstageJanusProjectCITab();
-    await tekton.search("hello-world");
-    await tekton.ensurePipelineRunsTableIsNotEmpty();
-  });
+    test("Check search functionality", async ({ page }) => {
+      const tekton = new TektonSupportHelper(page);
+      await tekton.goToBackstageJanusProjectCITab();
+      await tekton.search("hello-world");
+      await tekton.ensurePipelineRunsTableIsNotEmpty();
+    });
 
-  test("Check if modal is opened after click on the pipeline stage", async ({
-    page,
-  }) => {
-    const tekton = new TektonSupportHelper(page);
-    await tekton.goToBackstageJanusProjectCITab();
-    await tekton.clickOnExpandRowFromPipelineRunsTable(
-      "hello-world-pipeline-run",
-    );
-    await tekton.openModalEchoHelloWorld();
-    await tekton.verifyModalOpened();
-    await tekton.checkPipelineStages(["echo-hello-world", "echo-bye"]);
-  });
-});
+    test("Check if modal is opened after click on the pipeline stage", async ({
+      page,
+    }) => {
+      const tekton = new TektonSupportHelper(page);
+      await tekton.goToBackstageJanusProjectCITab();
+      await tekton.clickOnExpandRowFromPipelineRunsTable(
+        "hello-world-pipeline-run",
+      );
+      await tekton.openModalEchoHelloWorld();
+      await tekton.verifyModalOpened();
+      await tekton.checkPipelineStages(["echo-hello-world", "echo-bye"]);
+    });
+  },
+);

--- a/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
+++ b/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
@@ -2,60 +2,55 @@ import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { $, WorkspacePaths } from "@red-hat-developer-hub/e2e-test-utils/utils";
 import { TektonSupportHelper } from "../support/tekton-support-helper";
 
-test.describe(
-  "Test Tekton plugin",
-  {
-    annotation: [
+test.describe("Test Tekton plugin", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "tekton" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({
-        auth: "keycloak",
-      });
-      const namespace = rhdh.deploymentConfig.namespace;
-      // operator-install.sh: Tekton/Pipelines operator + waits, then namespace Active wait, pipeline-tests + RBAC (see operator::grant_default_service_account_cluster_reader_and_tekton).
-      const operatorInstallPath = WorkspacePaths.resolve(
-        "tests/config/operator-install.sh",
-      );
-      await $`bash ${operatorInstallPath} ${namespace}`;
-      await rhdh.deploy();
+    );
+    await rhdh.configure({
+      auth: "keycloak",
     });
+    const namespace = rhdh.deploymentConfig.namespace;
+    // operator-install.sh: Tekton/Pipelines operator + waits, then namespace Active wait, pipeline-tests + RBAC (see operator::grant_default_service_account_cluster_reader_and_tekton).
+    const operatorInstallPath = WorkspacePaths.resolve(
+      "tests/config/operator-install.sh",
+    );
+    await $`bash ${operatorInstallPath} ${namespace}`;
+    await rhdh.deploy();
+  });
 
-    test.beforeEach(async ({ loginHelper }) => {
-      await loginHelper.loginAsKeycloakUser();
-    });
+  test.beforeEach(async ({ loginHelper }) => {
+    await loginHelper.loginAsKeycloakUser();
+  });
 
-    test("Check Pipeline Run", async ({ page, uiHelper }) => {
-      const tekton = new TektonSupportHelper(page);
-      await tekton.goToBackstageJanusProjectCITab();
-      await tekton.ensurePipelineRunsTableIsNotEmpty();
-      await uiHelper.verifyHeading("Pipeline Runs");
-      await uiHelper.verifyTableHeadingAndRows(
-        tekton.getAllGridColumnsTextForPipelineRunsTable(),
-      );
-    });
+  test("Check Pipeline Run", async ({ page, uiHelper }) => {
+    const tekton = new TektonSupportHelper(page);
+    await tekton.goToBackstageJanusProjectCITab();
+    await tekton.ensurePipelineRunsTableIsNotEmpty();
+    await uiHelper.verifyHeading("Pipeline Runs");
+    await uiHelper.verifyTableHeadingAndRows(
+      tekton.getAllGridColumnsTextForPipelineRunsTable(),
+    );
+  });
 
-    test("Check search functionality", async ({ page }) => {
-      const tekton = new TektonSupportHelper(page);
-      await tekton.goToBackstageJanusProjectCITab();
-      await tekton.search("hello-world");
-      await tekton.ensurePipelineRunsTableIsNotEmpty();
-    });
+  test("Check search functionality", async ({ page }) => {
+    const tekton = new TektonSupportHelper(page);
+    await tekton.goToBackstageJanusProjectCITab();
+    await tekton.search("hello-world");
+    await tekton.ensurePipelineRunsTableIsNotEmpty();
+  });
 
-    test("Check if modal is opened after click on the pipeline stage", async ({
-      page,
-    }) => {
-      const tekton = new TektonSupportHelper(page);
-      await tekton.goToBackstageJanusProjectCITab();
-      await tekton.clickOnExpandRowFromPipelineRunsTable(
-        "hello-world-pipeline-run",
-      );
-      await tekton.openModalEchoHelloWorld();
-      await tekton.verifyModalOpened();
-      await tekton.checkPipelineStages(["echo-hello-world", "echo-bye"]);
-    });
-  },
-);
+  test("Check if modal is opened after click on the pipeline stage", async ({
+    page,
+  }) => {
+    const tekton = new TektonSupportHelper(page);
+    await tekton.goToBackstageJanusProjectCITab();
+    await tekton.clickOnExpandRowFromPipelineRunsTable(
+      "hello-world-pipeline-run",
+    );
+    await tekton.openModalEchoHelloWorld();
+    await tekton.verifyModalOpened();
+    await tekton.checkPipelineStages(["echo-hello-world", "echo-bye"]);
+  });
+});

--- a/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
+++ b/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
@@ -2,7 +2,15 @@ import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { $, WorkspacePaths } from "@red-hat-developer-hub/e2e-test-utils/utils";
 import { TektonSupportHelper } from "../support/tekton-support-helper";
 
-test.describe("Test Tekton plugin", () => {
+test.describe(
+  "Test Tekton plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "tekton" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({
       auth: "keycloak",

--- a/workspaces/theme/e2e-tests/tests/specs/theme.spec.ts
+++ b/workspaces/theme/e2e-tests/tests/specs/theme.spec.ts
@@ -3,7 +3,15 @@ import { ThemeConstants } from "../../utils/theme-constants";
 import { ThemeVerifier } from "../../utils/theme-verifier";
 import { CUSTOM_FAVICON, CUSTOM_SIDEBAR_LOGO } from "../../utils/custom-theme";
 
-test.describe("Theme Plugin tests", () => {
+test.describe(
+  "Theme Plugin tests",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "theme" },
+    ],
+  },
+  () => {
   test.beforeAll(async ({ rhdh }) => {
     await rhdh.configure({
       auth: "guest",

--- a/workspaces/theme/e2e-tests/tests/specs/theme.spec.ts
+++ b/workspaces/theme/e2e-tests/tests/specs/theme.spec.ts
@@ -3,81 +3,74 @@ import { ThemeConstants } from "../../utils/theme-constants";
 import { ThemeVerifier } from "../../utils/theme-verifier";
 import { CUSTOM_FAVICON, CUSTOM_SIDEBAR_LOGO } from "../../utils/custom-theme";
 
-test.describe(
-  "Theme Plugin tests",
-  {
-    annotation: [
+test.describe("Theme Plugin tests", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "theme" },
-    ],
-  },
-  () => {
-    test.beforeAll(async ({ rhdh }) => {
-      await rhdh.configure({
-        auth: "guest",
-      });
-      await rhdh.deploy();
+    );
+    await rhdh.configure({
+      auth: "guest",
     });
+    await rhdh.deploy();
+  });
 
-    let themeVerifier: ThemeVerifier;
+  let themeVerifier: ThemeVerifier;
 
-    test.beforeEach(async ({ loginHelper, page, uiHelper }) => {
-      themeVerifier = new ThemeVerifier(page, uiHelper);
-      await loginHelper.loginAsGuest();
-      await uiHelper.verifyHeading("Welcome back!");
-      await uiHelper.waitForLoad();
-      await uiHelper.dismissQuickstartIfVisible();
-    });
+  test.beforeEach(async ({ loginHelper, page, uiHelper }) => {
+    themeVerifier = new ThemeVerifier(page, uiHelper);
+    await loginHelper.loginAsGuest();
+    await uiHelper.verifyHeading("Welcome back!");
+    await uiHelper.waitForLoad();
+    await uiHelper.dismissQuickstartIfVisible();
+  });
 
-    test("Verify theme colors are applied", async () => {
-      const themes = ThemeConstants.getThemes();
+  test("Verify theme colors are applied", async () => {
+    const themes = ThemeConstants.getThemes();
 
-      for (const theme of themes) {
-        await themeVerifier.setTheme(theme.name);
-        await themeVerifier.verifyHeaderGradient(
-          `none, linear-gradient(90deg, ${theme.headerColor1}, ${theme.headerColor2})`,
-        );
-        await themeVerifier.verifyBorderLeftColor(
-          theme.navigationIndicatorColor,
-        );
-        await themeVerifier.verifyPrimaryColors(theme.primaryColor);
-      }
-    });
-
-    test("Verify that the RHDH favicon can be customized", async ({ page }) => {
-      await expect(page.locator("#dynamic-favicon")).toHaveAttribute(
-        "href",
-        CUSTOM_FAVICON.light,
+    for (const theme of themes) {
+      await themeVerifier.setTheme(theme.name);
+      await themeVerifier.verifyHeaderGradient(
+        `none, linear-gradient(90deg, ${theme.headerColor1}, ${theme.headerColor2})`,
       );
-    });
+      await themeVerifier.verifyBorderLeftColor(theme.navigationIndicatorColor);
+      await themeVerifier.verifyPrimaryColors(theme.primaryColor);
+    }
+  });
 
-    test("Verify that RHDH CompanyLogo can be customized", async ({ page }) => {
-      await themeVerifier.setTheme("Light");
+  test("Verify that the RHDH favicon can be customized", async ({ page }) => {
+    await expect(page.locator("#dynamic-favicon")).toHaveAttribute(
+      "href",
+      CUSTOM_FAVICON.light,
+    );
+  });
 
-      await expect(page.getByTestId("home-logo")).toHaveAttribute(
-        "src",
-        CUSTOM_SIDEBAR_LOGO.light,
-      );
+  test("Verify that RHDH CompanyLogo can be customized", async ({ page }) => {
+    await themeVerifier.setTheme("Light");
 
-      await themeVerifier.setTheme("Dark");
-      await expect(page.getByTestId("home-logo")).toHaveAttribute(
-        "src",
-        CUSTOM_SIDEBAR_LOGO.dark,
-      );
-    });
+    await expect(page.getByTestId("home-logo")).toHaveAttribute(
+      "src",
+      CUSTOM_SIDEBAR_LOGO.light,
+    );
 
-    test("Verify logo link", async ({ page }) => {
-      await expect(
-        page.getByTestId("global-header-company-logo").locator("a"),
-      ).toHaveAttribute("href", "/");
-      await page.getByTestId("global-header-company-logo").click();
-      await expect(page).toHaveURL("/");
-    });
+    await themeVerifier.setTheme("Dark");
+    await expect(page.getByTestId("home-logo")).toHaveAttribute(
+      "src",
+      CUSTOM_SIDEBAR_LOGO.dark,
+    );
+  });
 
-    test("Verify that title for Backstage can be customized", async ({
-      page,
-    }) => {
-      await expect(page).toHaveTitle(/Red Hat Developer Hub/);
-    });
-  },
-);
+  test("Verify logo link", async ({ page }) => {
+    await expect(
+      page.getByTestId("global-header-company-logo").locator("a"),
+    ).toHaveAttribute("href", "/");
+    await page.getByTestId("global-header-company-logo").click();
+    await expect(page).toHaveURL("/");
+  });
+
+  test("Verify that title for Backstage can be customized", async ({
+    page,
+  }) => {
+    await expect(page).toHaveTitle(/Red Hat Developer Hub/);
+  });
+});

--- a/workspaces/theme/e2e-tests/tests/specs/theme.spec.ts
+++ b/workspaces/theme/e2e-tests/tests/specs/theme.spec.ts
@@ -12,69 +12,72 @@ test.describe(
     ],
   },
   () => {
-  test.beforeAll(async ({ rhdh }) => {
-    await rhdh.configure({
-      auth: "guest",
+    test.beforeAll(async ({ rhdh }) => {
+      await rhdh.configure({
+        auth: "guest",
+      });
+      await rhdh.deploy();
     });
-    await rhdh.deploy();
-  });
 
-  let themeVerifier: ThemeVerifier;
+    let themeVerifier: ThemeVerifier;
 
-  test.beforeEach(async ({ loginHelper, page, uiHelper }) => {
-    themeVerifier = new ThemeVerifier(page, uiHelper);
-    await loginHelper.loginAsGuest();
-    await uiHelper.verifyHeading("Welcome back!");
-    await uiHelper.waitForLoad();
-    await uiHelper.dismissQuickstartIfVisible();
-  });
+    test.beforeEach(async ({ loginHelper, page, uiHelper }) => {
+      themeVerifier = new ThemeVerifier(page, uiHelper);
+      await loginHelper.loginAsGuest();
+      await uiHelper.verifyHeading("Welcome back!");
+      await uiHelper.waitForLoad();
+      await uiHelper.dismissQuickstartIfVisible();
+    });
 
-  test("Verify theme colors are applied", async () => {
-    const themes = ThemeConstants.getThemes();
+    test("Verify theme colors are applied", async () => {
+      const themes = ThemeConstants.getThemes();
 
-    for (const theme of themes) {
-      await themeVerifier.setTheme(theme.name);
-      await themeVerifier.verifyHeaderGradient(
-        `none, linear-gradient(90deg, ${theme.headerColor1}, ${theme.headerColor2})`,
+      for (const theme of themes) {
+        await themeVerifier.setTheme(theme.name);
+        await themeVerifier.verifyHeaderGradient(
+          `none, linear-gradient(90deg, ${theme.headerColor1}, ${theme.headerColor2})`,
+        );
+        await themeVerifier.verifyBorderLeftColor(
+          theme.navigationIndicatorColor,
+        );
+        await themeVerifier.verifyPrimaryColors(theme.primaryColor);
+      }
+    });
+
+    test("Verify that the RHDH favicon can be customized", async ({ page }) => {
+      await expect(page.locator("#dynamic-favicon")).toHaveAttribute(
+        "href",
+        CUSTOM_FAVICON.light,
       );
-      await themeVerifier.verifyBorderLeftColor(theme.navigationIndicatorColor);
-      await themeVerifier.verifyPrimaryColors(theme.primaryColor);
-    }
-  });
+    });
 
-  test("Verify that the RHDH favicon can be customized", async ({ page }) => {
-    await expect(page.locator("#dynamic-favicon")).toHaveAttribute(
-      "href",
-      CUSTOM_FAVICON.light,
-    );
-  });
+    test("Verify that RHDH CompanyLogo can be customized", async ({ page }) => {
+      await themeVerifier.setTheme("Light");
 
-  test("Verify that RHDH CompanyLogo can be customized", async ({ page }) => {
-    await themeVerifier.setTheme("Light");
+      await expect(page.getByTestId("home-logo")).toHaveAttribute(
+        "src",
+        CUSTOM_SIDEBAR_LOGO.light,
+      );
 
-    await expect(page.getByTestId("home-logo")).toHaveAttribute(
-      "src",
-      CUSTOM_SIDEBAR_LOGO.light,
-    );
+      await themeVerifier.setTheme("Dark");
+      await expect(page.getByTestId("home-logo")).toHaveAttribute(
+        "src",
+        CUSTOM_SIDEBAR_LOGO.dark,
+      );
+    });
 
-    await themeVerifier.setTheme("Dark");
-    await expect(page.getByTestId("home-logo")).toHaveAttribute(
-      "src",
-      CUSTOM_SIDEBAR_LOGO.dark,
-    );
-  });
+    test("Verify logo link", async ({ page }) => {
+      await expect(
+        page.getByTestId("global-header-company-logo").locator("a"),
+      ).toHaveAttribute("href", "/");
+      await page.getByTestId("global-header-company-logo").click();
+      await expect(page).toHaveURL("/");
+    });
 
-  test("Verify logo link", async ({ page }) => {
-    await expect(
-      page.getByTestId("global-header-company-logo").locator("a"),
-    ).toHaveAttribute("href", "/");
-    await page.getByTestId("global-header-company-logo").click();
-    await expect(page).toHaveURL("/");
-  });
-
-  test("Verify that title for Backstage can be customized", async ({
-    page,
-  }) => {
-    await expect(page).toHaveTitle(/Red Hat Developer Hub/);
-  });
-});
+    test("Verify that title for Backstage can be customized", async ({
+      page,
+    }) => {
+      await expect(page).toHaveTitle(/Red Hat Developer Hub/);
+    });
+  },
+);

--- a/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
+++ b/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
@@ -28,7 +28,15 @@ async function getResourceType(page: Page): Promise<"ingress" | "route"> {
   return hasIngresses ? "ingress" : "route";
 }
 
-test.describe("Test Topology plugin", () => {
+test.describe(
+  "Test Topology plugin",
+  {
+    annotation: [
+      { type: "component", description: "plugins" },
+      { type: "workspace", description: "topology" },
+    ],
+  },
+  () => {
   const deploymentLocator = `[data-test-id="topology-test"]`;
 
   test.beforeAll(async ({ rhdh }) => {

--- a/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
+++ b/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
@@ -37,151 +37,154 @@ test.describe(
     ],
   },
   () => {
-  const deploymentLocator = `[data-test-id="topology-test"]`;
+    const deploymentLocator = `[data-test-id="topology-test"]`;
 
-  test.beforeAll(async ({ rhdh }) => {
-    test.setTimeout(800_000);
-    const project = rhdh.deploymentConfig.namespace;
+    test.beforeAll(async ({ rhdh }) => {
+      test.setTimeout(800_000);
+      const project = rhdh.deploymentConfig.namespace;
 
-    await rhdh.configure({ auth: "keycloak" });
+      await rhdh.configure({ auth: "keycloak" });
 
-    const rbacConfigmapPath = WorkspacePaths.resolve(
-      "tests/config/rbac-configmap.yaml",
-    );
-
-    await $`oc apply -f ${rbacConfigmapPath} -n ${project}`;
-    await deployResources(project);
-
-    process.env.K8S_CLUSTER_URL = (
-      await $pipe`oc whoami --show-server`
-    ).stdout.trim();
-    process.env.K8S_CLUSTER_TOKEN = (
-      await $pipe`oc create token default -n ${project}`
-    ).stdout.trim();
-
-    await rhdh.deploy({ timeout: null });
-  });
-
-  test("Verify Topology tab is visible on a component with kubernetes annotations", async ({
-    page,
-    loginHelper,
-    uiHelper,
-  }, testInfo) => {
-    test.setTimeout(150000 + testInfo.retry * 30000);
-    await loginHelper.loginAsKeycloakUser("test1", "test1@123");
-    topology = new Topology(page);
-    await navigateToTopology(uiHelper);
-    await uiHelper.verifyHeading("backstage-janus");
-    await uiHelper.clickButton("Hide");
-    await page.getByRole("button", { name: "Fit to Screen" }).click();
-    await expect(async () => {
-      await page
-        .getByTestId(/(status-error|status-ok)/)
-        .first()
-        .click();
-      await uiHelper.verifyText(
-        /Pipeline (Succeeded|Failed|Cancelled|Running)/,
+      const rbacConfigmapPath = WorkspacePaths.resolve(
+        "tests/config/rbac-configmap.yaml",
       );
-      await uiHelper.verifyText(/\d{1,5} (Succeeded|Failed|Cancelled|Running)/);
-    }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
-    await topology.verifyDeployment("topology-test");
-    await uiHelper.verifyButtonURL("Open URL", "topology-test-route", {
-      locator: deploymentLocator,
-    });
-    await uiHelper.clickTab("Details");
-    await uiHelper.verifyText("Status");
-    await uiHelper.verifyText("Active");
-    await uiHelper.clickTab("Resources");
-    await uiHelper.verifyHeading("Pods");
-    await uiHelper.verifyHeading("Services");
 
-    // Determine resource type and run appropriate test
-    const resourceType = await getResourceType(page);
+      await $`oc apply -f ${rbacConfigmapPath} -n ${project}`;
+      await deployResources(project);
 
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (resourceType === "ingress") {
-      await testIngressResources(page, uiHelper);
-    } else {
-      await testRouteResources(page, uiHelper);
-    }
+      process.env.K8S_CLUSTER_URL = (
+        await $pipe`oc whoami --show-server`
+      ).stdout.trim();
+      process.env.K8S_CLUSTER_TOKEN = (
+        await $pipe`oc create token default -n ${project}`
+      ).stdout.trim();
 
-    await uiHelper.verifyText("Location:");
-    await expect(page.getByTitle("Deployment")).toBeVisible();
-    await uiHelper.verifyText("S");
-    // Verify the topology visualization is rendered
-    await expect(page.getByTitle("Deployment")).toBeVisible();
-    await uiHelper.clickTab("Details");
-    await page.getByLabel("Pod").hover();
-    await page.getByText("Display options").click();
-    await page.getByLabel("Pod count").click();
-    await uiHelper.verifyText("1");
-    await uiHelper.verifyText("Pod");
-
-    // TODO: Re-enable once hover flakiness is resolved
-    // await expect(async () => {
-    //   await topology.hoverOnPodStatusIndicator();
-    //   await uiHelper.verifyTextInTooltip("Running");
-    //   await uiHelper.verifyText("1Running");
-    // }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
-
-    await uiHelper.verifyButtonURL(
-      "Edit source code",
-      "https://github.com/janus-idp/backstage-showcase",
-      { locator: deploymentLocator },
-    );
-    await uiHelper.clickTab("Resources");
-    await uiHelper.verifyText("P");
-    await expect(page.getByTestId("pod-list")).toBeVisible();
-    await expect(page.getByTestId("status-running")).toBeVisible();
-    await uiHelper.verifyText("Running");
-    await uiHelper.verifyHeading("PipelineRuns");
-    await uiHelper.verifyText("PL");
-    await uiHelper.verifyText("PLR");
-    await uiHelper.verifyText(/(Succeeded|Failed|Cancelled|Running)/);
-  });
-
-  test.describe("Test Topology Plugin with RBAC", () => {
-    test("Verify guest user cannot see Topology pods", async ({
-      loginHelper,
-      page,
-      uiHelper,
-    }) => {
-      const topo = new Topology(page);
-
-      await loginHelper.loginAsGuest();
-      await navigateToTopology(uiHelper);
-      await topo.verifyMissingTopologyPermission();
+      await rhdh.deploy({ timeout: null });
     });
 
-    test("Verify limited user can see Topology but cannot view pod logs", async ({
-      loginHelper,
+    test("Verify Topology tab is visible on a component with kubernetes annotations", async ({
       page,
-      uiHelper,
-    }) => {
-      const topo = new Topology(page);
-
-      await loginHelper.loginAsKeycloakUser("test2", "test2@123");
-      await navigateToTopology(uiHelper);
-
-      await topo.verifyDeployment("topology-test");
-      await topo.verifyPodLogs(false);
-    });
-
-    test("Verify admin user can see Topology pods and view pod logs", async ({
       loginHelper,
-      page,
       uiHelper,
-    }) => {
-      const topo = new Topology(page);
-
+    }, testInfo) => {
+      test.setTimeout(150000 + testInfo.retry * 30000);
       await loginHelper.loginAsKeycloakUser("test1", "test1@123");
+      topology = new Topology(page);
       await navigateToTopology(uiHelper);
+      await uiHelper.verifyHeading("backstage-janus");
+      await uiHelper.clickButton("Hide");
+      await page.getByRole("button", { name: "Fit to Screen" }).click();
+      await expect(async () => {
+        await page
+          .getByTestId(/(status-error|status-ok)/)
+          .first()
+          .click();
+        await uiHelper.verifyText(
+          /Pipeline (Succeeded|Failed|Cancelled|Running)/,
+        );
+        await uiHelper.verifyText(
+          /\d{1,5} (Succeeded|Failed|Cancelled|Running)/,
+        );
+      }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
+      await topology.verifyDeployment("topology-test");
+      await uiHelper.verifyButtonURL("Open URL", "topology-test-route", {
+        locator: deploymentLocator,
+      });
+      await uiHelper.clickTab("Details");
+      await uiHelper.verifyText("Status");
+      await uiHelper.verifyText("Active");
+      await uiHelper.clickTab("Resources");
+      await uiHelper.verifyHeading("Pods");
+      await uiHelper.verifyHeading("Services");
 
-      await topo.verifyDeployment("topology-test");
-      await topo.verifyPodLogs(true);
+      // Determine resource type and run appropriate test
+      const resourceType = await getResourceType(page);
+
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      if (resourceType === "ingress") {
+        await testIngressResources(page, uiHelper);
+      } else {
+        await testRouteResources(page, uiHelper);
+      }
+
+      await uiHelper.verifyText("Location:");
+      await expect(page.getByTitle("Deployment")).toBeVisible();
+      await uiHelper.verifyText("S");
+      // Verify the topology visualization is rendered
+      await expect(page.getByTitle("Deployment")).toBeVisible();
+      await uiHelper.clickTab("Details");
+      await page.getByLabel("Pod").hover();
+      await page.getByText("Display options").click();
+      await page.getByLabel("Pod count").click();
+      await uiHelper.verifyText("1");
+      await uiHelper.verifyText("Pod");
+
+      // TODO: Re-enable once hover flakiness is resolved
+      // await expect(async () => {
+      //   await topology.hoverOnPodStatusIndicator();
+      //   await uiHelper.verifyTextInTooltip("Running");
+      //   await uiHelper.verifyText("1Running");
+      // }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
+
+      await uiHelper.verifyButtonURL(
+        "Edit source code",
+        "https://github.com/janus-idp/backstage-showcase",
+        { locator: deploymentLocator },
+      );
+      await uiHelper.clickTab("Resources");
+      await uiHelper.verifyText("P");
+      await expect(page.getByTestId("pod-list")).toBeVisible();
+      await expect(page.getByTestId("status-running")).toBeVisible();
+      await uiHelper.verifyText("Running");
+      await uiHelper.verifyHeading("PipelineRuns");
+      await uiHelper.verifyText("PL");
+      await uiHelper.verifyText("PLR");
+      await uiHelper.verifyText(/(Succeeded|Failed|Cancelled|Running)/);
     });
-  });
-});
+
+    test.describe("Test Topology Plugin with RBAC", () => {
+      test("Verify guest user cannot see Topology pods", async ({
+        loginHelper,
+        page,
+        uiHelper,
+      }) => {
+        const topo = new Topology(page);
+
+        await loginHelper.loginAsGuest();
+        await navigateToTopology(uiHelper);
+        await topo.verifyMissingTopologyPermission();
+      });
+
+      test("Verify limited user can see Topology but cannot view pod logs", async ({
+        loginHelper,
+        page,
+        uiHelper,
+      }) => {
+        const topo = new Topology(page);
+
+        await loginHelper.loginAsKeycloakUser("test2", "test2@123");
+        await navigateToTopology(uiHelper);
+
+        await topo.verifyDeployment("topology-test");
+        await topo.verifyPodLogs(false);
+      });
+
+      test("Verify admin user can see Topology pods and view pod logs", async ({
+        loginHelper,
+        page,
+        uiHelper,
+      }) => {
+        const topo = new Topology(page);
+
+        await loginHelper.loginAsKeycloakUser("test1", "test1@123");
+        await navigateToTopology(uiHelper);
+
+        await topo.verifyDeployment("topology-test");
+        await topo.verifyPodLogs(true);
+      });
+    });
+  },
+);
 
 // Helper functions for resource-specific testing
 async function testIngressResources(page: Page, uiHelper: UIhelper) {

--- a/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
+++ b/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
@@ -28,163 +28,156 @@ async function getResourceType(page: Page): Promise<"ingress" | "route"> {
   return hasIngresses ? "ingress" : "route";
 }
 
-test.describe(
-  "Test Topology plugin",
-  {
-    annotation: [
+test.describe("Test Topology plugin", () => {
+  const deploymentLocator = `[data-test-id="topology-test"]`;
+
+  test.beforeAll(async ({ rhdh }) => {
+    test.info().annotations.push(
       { type: "component", description: "plugins" },
       { type: "workspace", description: "topology" },
-    ],
-  },
-  () => {
-    const deploymentLocator = `[data-test-id="topology-test"]`;
+    );
+    test.setTimeout(800_000);
+    const project = rhdh.deploymentConfig.namespace;
 
-    test.beforeAll(async ({ rhdh }) => {
-      test.setTimeout(800_000);
-      const project = rhdh.deploymentConfig.namespace;
+    await rhdh.configure({ auth: "keycloak" });
 
-      await rhdh.configure({ auth: "keycloak" });
+    const rbacConfigmapPath = WorkspacePaths.resolve(
+      "tests/config/rbac-configmap.yaml",
+    );
 
-      const rbacConfigmapPath = WorkspacePaths.resolve(
-        "tests/config/rbac-configmap.yaml",
+    await $`oc apply -f ${rbacConfigmapPath} -n ${project}`;
+    await deployResources(project);
+
+    process.env.K8S_CLUSTER_URL = (
+      await $pipe`oc whoami --show-server`
+    ).stdout.trim();
+    process.env.K8S_CLUSTER_TOKEN = (
+      await $pipe`oc create token default -n ${project}`
+    ).stdout.trim();
+
+    await rhdh.deploy({ timeout: null });
+  });
+
+  test("Verify Topology tab is visible on a component with kubernetes annotations", async ({
+    page,
+    loginHelper,
+    uiHelper,
+  }, testInfo) => {
+    test.setTimeout(150000 + testInfo.retry * 30000);
+    await loginHelper.loginAsKeycloakUser("test1", "test1@123");
+    topology = new Topology(page);
+    await navigateToTopology(uiHelper);
+    await uiHelper.verifyHeading("backstage-janus");
+    await uiHelper.clickButton("Hide");
+    await page.getByRole("button", { name: "Fit to Screen" }).click();
+    await expect(async () => {
+      await page
+        .getByTestId(/(status-error|status-ok)/)
+        .first()
+        .click();
+      await uiHelper.verifyText(
+        /Pipeline (Succeeded|Failed|Cancelled|Running)/,
       );
-
-      await $`oc apply -f ${rbacConfigmapPath} -n ${project}`;
-      await deployResources(project);
-
-      process.env.K8S_CLUSTER_URL = (
-        await $pipe`oc whoami --show-server`
-      ).stdout.trim();
-      process.env.K8S_CLUSTER_TOKEN = (
-        await $pipe`oc create token default -n ${project}`
-      ).stdout.trim();
-
-      await rhdh.deploy({ timeout: null });
+      await uiHelper.verifyText(/\d{1,5} (Succeeded|Failed|Cancelled|Running)/);
+    }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
+    await topology.verifyDeployment("topology-test");
+    await uiHelper.verifyButtonURL("Open URL", "topology-test-route", {
+      locator: deploymentLocator,
     });
+    await uiHelper.clickTab("Details");
+    await uiHelper.verifyText("Status");
+    await uiHelper.verifyText("Active");
+    await uiHelper.clickTab("Resources");
+    await uiHelper.verifyHeading("Pods");
+    await uiHelper.verifyHeading("Services");
 
-    test("Verify Topology tab is visible on a component with kubernetes annotations", async ({
-      page,
+    // Determine resource type and run appropriate test
+    const resourceType = await getResourceType(page);
+
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (resourceType === "ingress") {
+      await testIngressResources(page, uiHelper);
+    } else {
+      await testRouteResources(page, uiHelper);
+    }
+
+    await uiHelper.verifyText("Location:");
+    await expect(page.getByTitle("Deployment")).toBeVisible();
+    await uiHelper.verifyText("S");
+    // Verify the topology visualization is rendered
+    await expect(page.getByTitle("Deployment")).toBeVisible();
+    await uiHelper.clickTab("Details");
+    await page.getByLabel("Pod").hover();
+    await page.getByText("Display options").click();
+    await page.getByLabel("Pod count").click();
+    await uiHelper.verifyText("1");
+    await uiHelper.verifyText("Pod");
+
+    // TODO: Re-enable once hover flakiness is resolved
+    // await expect(async () => {
+    //   await topology.hoverOnPodStatusIndicator();
+    //   await uiHelper.verifyTextInTooltip("Running");
+    //   await uiHelper.verifyText("1Running");
+    // }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
+
+    await uiHelper.verifyButtonURL(
+      "Edit source code",
+      "https://github.com/janus-idp/backstage-showcase",
+      { locator: deploymentLocator },
+    );
+    await uiHelper.clickTab("Resources");
+    await uiHelper.verifyText("P");
+    await expect(page.getByTestId("pod-list")).toBeVisible();
+    await expect(page.getByTestId("status-running")).toBeVisible();
+    await uiHelper.verifyText("Running");
+    await uiHelper.verifyHeading("PipelineRuns");
+    await uiHelper.verifyText("PL");
+    await uiHelper.verifyText("PLR");
+    await uiHelper.verifyText(/(Succeeded|Failed|Cancelled|Running)/);
+  });
+
+  test.describe("Test Topology Plugin with RBAC", () => {
+    test("Verify guest user cannot see Topology pods", async ({
       loginHelper,
+      page,
       uiHelper,
-    }, testInfo) => {
-      test.setTimeout(150000 + testInfo.retry * 30000);
-      await loginHelper.loginAsKeycloakUser("test1", "test1@123");
-      topology = new Topology(page);
+    }) => {
+      const topo = new Topology(page);
+
+      await loginHelper.loginAsGuest();
       await navigateToTopology(uiHelper);
-      await uiHelper.verifyHeading("backstage-janus");
-      await uiHelper.clickButton("Hide");
-      await page.getByRole("button", { name: "Fit to Screen" }).click();
-      await expect(async () => {
-        await page
-          .getByTestId(/(status-error|status-ok)/)
-          .first()
-          .click();
-        await uiHelper.verifyText(
-          /Pipeline (Succeeded|Failed|Cancelled|Running)/,
-        );
-        await uiHelper.verifyText(
-          /\d{1,5} (Succeeded|Failed|Cancelled|Running)/,
-        );
-      }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
-      await topology.verifyDeployment("topology-test");
-      await uiHelper.verifyButtonURL("Open URL", "topology-test-route", {
-        locator: deploymentLocator,
-      });
-      await uiHelper.clickTab("Details");
-      await uiHelper.verifyText("Status");
-      await uiHelper.verifyText("Active");
-      await uiHelper.clickTab("Resources");
-      await uiHelper.verifyHeading("Pods");
-      await uiHelper.verifyHeading("Services");
-
-      // Determine resource type and run appropriate test
-      const resourceType = await getResourceType(page);
-
-      // eslint-disable-next-line playwright/no-conditional-in-test
-      if (resourceType === "ingress") {
-        await testIngressResources(page, uiHelper);
-      } else {
-        await testRouteResources(page, uiHelper);
-      }
-
-      await uiHelper.verifyText("Location:");
-      await expect(page.getByTitle("Deployment")).toBeVisible();
-      await uiHelper.verifyText("S");
-      // Verify the topology visualization is rendered
-      await expect(page.getByTitle("Deployment")).toBeVisible();
-      await uiHelper.clickTab("Details");
-      await page.getByLabel("Pod").hover();
-      await page.getByText("Display options").click();
-      await page.getByLabel("Pod count").click();
-      await uiHelper.verifyText("1");
-      await uiHelper.verifyText("Pod");
-
-      // TODO: Re-enable once hover flakiness is resolved
-      // await expect(async () => {
-      //   await topology.hoverOnPodStatusIndicator();
-      //   await uiHelper.verifyTextInTooltip("Running");
-      //   await uiHelper.verifyText("1Running");
-      // }).toPass({ intervals: [2_000, 5_000], timeout: 30_000 });
-
-      await uiHelper.verifyButtonURL(
-        "Edit source code",
-        "https://github.com/janus-idp/backstage-showcase",
-        { locator: deploymentLocator },
-      );
-      await uiHelper.clickTab("Resources");
-      await uiHelper.verifyText("P");
-      await expect(page.getByTestId("pod-list")).toBeVisible();
-      await expect(page.getByTestId("status-running")).toBeVisible();
-      await uiHelper.verifyText("Running");
-      await uiHelper.verifyHeading("PipelineRuns");
-      await uiHelper.verifyText("PL");
-      await uiHelper.verifyText("PLR");
-      await uiHelper.verifyText(/(Succeeded|Failed|Cancelled|Running)/);
+      await topo.verifyMissingTopologyPermission();
     });
 
-    test.describe("Test Topology Plugin with RBAC", () => {
-      test("Verify guest user cannot see Topology pods", async ({
-        loginHelper,
-        page,
-        uiHelper,
-      }) => {
-        const topo = new Topology(page);
+    test("Verify limited user can see Topology but cannot view pod logs", async ({
+      loginHelper,
+      page,
+      uiHelper,
+    }) => {
+      const topo = new Topology(page);
 
-        await loginHelper.loginAsGuest();
-        await navigateToTopology(uiHelper);
-        await topo.verifyMissingTopologyPermission();
-      });
+      await loginHelper.loginAsKeycloakUser("test2", "test2@123");
+      await navigateToTopology(uiHelper);
 
-      test("Verify limited user can see Topology but cannot view pod logs", async ({
-        loginHelper,
-        page,
-        uiHelper,
-      }) => {
-        const topo = new Topology(page);
-
-        await loginHelper.loginAsKeycloakUser("test2", "test2@123");
-        await navigateToTopology(uiHelper);
-
-        await topo.verifyDeployment("topology-test");
-        await topo.verifyPodLogs(false);
-      });
-
-      test("Verify admin user can see Topology pods and view pod logs", async ({
-        loginHelper,
-        page,
-        uiHelper,
-      }) => {
-        const topo = new Topology(page);
-
-        await loginHelper.loginAsKeycloakUser("test1", "test1@123");
-        await navigateToTopology(uiHelper);
-
-        await topo.verifyDeployment("topology-test");
-        await topo.verifyPodLogs(true);
-      });
+      await topo.verifyDeployment("topology-test");
+      await topo.verifyPodLogs(false);
     });
-  },
-);
+
+    test("Verify admin user can see Topology pods and view pod logs", async ({
+      loginHelper,
+      page,
+      uiHelper,
+    }) => {
+      const topo = new Topology(page);
+
+      await loginHelper.loginAsKeycloakUser("test1", "test1@123");
+      await navigateToTopology(uiHelper);
+
+      await topo.verifyDeployment("topology-test");
+      await topo.verifyPodLogs(true);
+    });
+  });
+});
 
 // Helper functions for resource-specific testing
 async function testIngressResources(page: Page, uiHelper: UIhelper) {


### PR DESCRIPTION
## Summary

- Add `component` and `workspace` annotations to every `test.beforeAll` block across all 27 E2E spec files (18 workspaces)
- Update the existing annotation in keycloak's `catalog-users.spec.ts` to also include workspace
- Update `CLAUDE.md` to document the annotation convention

Jira: https://redhat.atlassian.net/browse/RHIDP-13047

## Annotation types

| Type | Description | Purpose |
|------|-------------|---------|
| `component` | Always `"plugins"` | Categorizes tests as plugin tests |
| `workspace` | Workspace directory name (e.g., `tech-radar`, `rbac`) | Links tests to their workspace for filtering and reporting |

## Approach chosen: runtime `test.info().annotations.push()` in `beforeAll` (Option B)

Annotations are pushed at the start of each `test.beforeAll`:

```typescript
test.beforeAll(async ({ rhdh }) => {
  test.info().annotations.push(
    { type: "component", description: "plugins" },
    { type: "workspace", description: "my-workspace" },
  );
  // ...
});
```

### Options evaluated

**Option A: Declarative `test.describe` details parameter**
- Uses Playwright's `details.annotation` parameter on `test.describe`
- Clean and declarative, but changes the `test.describe` call signature
- Rejected: prettier reformats the entire `test.describe(...)` block when arguments are added, triggering pre-existing formatting issues across all files and failing CI

**Option B (chosen): Runtime `test.info().annotations.push()` in `beforeAll`**
- Pushes annotations at runtime inside `test.beforeAll`
- Minimal diff — only adds 4 lines per file, no existing lines changed
- Does not trigger prettier reformatting of surrounding code
- Already used in the keycloak workspace (extended to include workspace annotation)

**Option C: Fixture-based injection in e2e-test-utils**
- Would auto-inject annotations from the `rhdh` fixture based on project/workspace name
- Zero spec file changes, fully centralized
- Rejected: requires a separate package release, over-engineering for static metadata

### Why Option B

- Adding the `details` parameter to `test.describe` (Option A) causes prettier to reformat the entire function call, surfacing pre-existing formatting issues across all files and failing CI
- Option B inserts lines inside an existing block — no reformatting triggered
- Already established pattern in the codebase (keycloak)

## Changes

- **27 spec files**: Added `test.info().annotations.push()` as first statement in `test.beforeAll`
- **keycloak/catalog-users.spec.ts**: First describe block gets new annotations push; second describe block's existing push updated to also include `workspace` annotation
- **CLAUDE.md**: Updated "Standard Test Pattern" section with annotation convention and example