### PR TITLE
chore(lightspeed): fix metadata so the default config tree is processed as a tree, not a string (RHDHBUGS-3083)

### DIFF
--- a/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed-backend.yaml
+++ b/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed-backend.yaml
@@ -28,7 +28,7 @@ spec:
     - lightspeed
   appConfigExamples:
     - title: Default configuration
-      content: |
+      content:
         lightspeed: 
           # REQUIRED: Configure LLM servers with OpenAI API compatibility
           servers:

--- a/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
+++ b/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
@@ -28,7 +28,7 @@ spec:
     - lightspeed
   appConfigExamples:
     - title: Default configuration
-      content: |
+      content:
         lightspeed:
           # OPTIONAL: Custom users prompts displayed to users
           # If not provided, the plugin uses built-in default prompts


### PR DESCRIPTION
### What does this PR do?

chore(lightspeed): fix metadata so the default config tree is processed as a tree, not a string

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

[RHDHBUGS-3083](https://redhat.atlassian.net/browse/RHDHBUGS-3083)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.