### PR TITLE
chore(konflux): fix metadata so the default config tree is processed as a tree, not a string (RHDHBUGS-3083)

### DIFF
--- a/workspaces/konflux/metadata/red-hat-developer-hub-backstage-plugin-konflux-backend.yaml
+++ b/workspaces/konflux/metadata/red-hat-developer-hub-backstage-plugin-konflux-backend.yaml
@@ -27,7 +27,7 @@ spec:
     - konflux
   appConfigExamples:
     - title: Default configuration
-      content: |
+      content:
         konflux:
           authProvider: impersonationHeaders
           clusters:

--- a/workspaces/konflux/metadata/red-hat-developer-hub-backstage-plugin-konflux.yaml
+++ b/workspaces/konflux/metadata/red-hat-developer-hub-backstage-plugin-konflux.yaml
@@ -27,7 +27,7 @@ spec:
     - konflux
   appConfigExamples:
     - title: Default configuration
-      content: |
+      content:
         dynamicPlugins:
           frontend:
             red-hat-developer-hub.backstage-plugin-konflux:


### PR DESCRIPTION
### What does this PR do?

chore(konflux): fix metadata so the default config tree is processed as a tree, not a string ([RHDHBUGS-3083](https://redhat.atlassian.net/browse/RHDHBUGS-3083))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.