### PR TITLE
chore(aws): fix metadata so the default config tree is processed as a tree, not a string (RHDHBUGS-3083)

### DIFF
--- a/workspaces/backstage-plugins-for-aws/metadata/aws-amazon-ecs-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-amazon-ecs-plugin-for-backstage-backend.yaml
@@ -28,9 +28,10 @@ spec:
     - backstage-plugins-for-aws
   appConfigExamples:
     - title: AWS Credentials Configuration
-      content: |
+      content:
         # Backend plugin uses AWS SDK credential chain
         # Configure via environment variables:
-        AWS_REGION: us-east-1
-        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+        aws:
+          mainAccount:
+            accessKeyId: ${AWS_ACCESS_KEY_ID}
+            secretAccessKey: ${AWS_SECRET_ACCESS_KEY}

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-amazon-ecs-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-amazon-ecs-plugin-for-backstage-backend.yaml
@@ -33,5 +33,6 @@ spec:
         # Configure via environment variables:
         aws:
           mainAccount:
+            region: ${AWS_REGION}
             accessKeyId: ${AWS_ACCESS_KEY_ID}
             secretAccessKey: ${AWS_SECRET_ACCESS_KEY}

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codebuild-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codebuild-plugin-for-backstage-backend.yaml
@@ -29,7 +29,10 @@ spec:
     - backstage-plugins-for-aws
   appConfigExamples:
     - title: AWS Credentials Configuration
-      content: |
+      content:
         # Backend plugin uses AWS SDK credential chain
         # Configure via environment variables:
-        # AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+        aws:
+          mainAccount:
+            accessKeyId: ${AWS_ACCESS_KEY_ID}
+            secretAccessKey: ${AWS_SECRET_ACCESS_KEY}

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codebuild-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codebuild-plugin-for-backstage-backend.yaml
@@ -34,5 +34,6 @@ spec:
         # Configure via environment variables:
         aws:
           mainAccount:
+            region: ${AWS_REGION}
             accessKeyId: ${AWS_ACCESS_KEY_ID}
             secretAccessKey: ${AWS_SECRET_ACCESS_KEY}

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codepipeline-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codepipeline-plugin-for-backstage-backend.yaml
@@ -29,7 +29,10 @@ spec:
     - backstage-plugins-for-aws
   appConfigExamples:
     - title: AWS Credentials Configuration
-      content: |
+      content:
         # Backend plugin uses AWS SDK credential chain
         # Configure via environment variables:
-        # AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+        aws:
+          mainAccount:
+            accessKeyId: ${AWS_ACCESS_KEY_ID}
+            secretAccessKey: ${AWS_SECRET_ACCESS_KEY}

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codepipeline-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codepipeline-plugin-for-backstage-backend.yaml
@@ -34,5 +34,6 @@ spec:
         # Configure via environment variables:
         aws:
           mainAccount:
+            region: ${AWS_REGION}
             accessKeyId: ${AWS_ACCESS_KEY_ID}
             secretAccessKey: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
### What does this PR do?

chore(aws): fix metadata so the default config tree is processed as a tree, not a string ([RHDHBUGS-3083](https://redhat.atlassian.net/browse/RHDHBUGS-3083))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.