### PR TITLE
chore(lightspeed): update lightspeed metadata config examples

### DIFF
--- a/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed-backend.yaml
+++ b/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed-backend.yaml
@@ -30,18 +30,13 @@ spec:
     - title: Default configuration
       content:
         lightspeed: 
-          # REQUIRED: Configure LLM servers with OpenAI API compatibility
-          servers:
-            - id: ${LIGHTSPEED_SERVER_ID}
-              url: ${LIGHTSPEED_SERVER_URL}
-              token: ${LIGHTSPEED_SERVER_TOKEN}
-
-          # OPTIONAL: Enable/disable question validation (default: true)
-          # When enabled, restricts questions to RHDH-related topics for better security
-          questionValidation: true 
-
           # OPTIONAL: Port for lightspeed service (default: 8080)
-          # servicePort: ${LIGHTSPEED_SERVICE_PORT}
+          servicePort: 8080
+          
+          # OPTIONAL: MCP server name and token for MCP servers defined in LCORE config
+          # mcpServers:
+          #  - name: <mcp server name>
+          #    token: ${MCP_TOKEN}
 
           # OPTIONAL: Override default RHDH system prompt
           # systemPrompt: "You are a helpful assistant focused on Red Hat Developer Hub development."

--- a/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
+++ b/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
@@ -38,14 +38,13 @@ spec:
         dynamicPlugins:
           frontend:
             red-hat-developer-hub.backstage-plugin-lightspeed:
-              appIcons:
-                - name: LightspeedIcon
-                  module: LightspeedPlugin
-                  importName: LightspeedIcon
+              translationResources:
+                - importName: lightspeedTranslations
+                  module: Alpha
+                  ref: lightspeedTranslationRef
               dynamicRoutes:
                 - path: /lightspeed
                   importName: LightspeedPage
-                  module: LightspeedPlugin
               mountPoints:
                 - mountPoint: application/listener
                   importName: LightspeedFAB


### PR DESCRIPTION
Removes unused portions from the config example and sets the default port to 8080 in the example (this is to avoid everything being commented out and possibly breaking parsing)