### PR TITLE
chore(scorecard): update support level to dev-preview

### DIFF
--- a/catalog-entities/extensions/plugins/scorecard.yaml
+++ b/catalog-entities/extensions/plugins/scorecard.yaml
@@ -26,7 +26,7 @@ spec:
   author: Red Hat
   support:
     provider: Red Hat
-    level: tech-preview
+    level: dev-preview
   lifecycle: active
   publisher: Red Hat
 

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-filecheck.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-filecheck.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin-module
     supportedVersions: 1.49.3
   author: Red Hat
-  support: tech-preview
+  support: dev-preview
   lifecycle: active
   partOf:
     - scorecard

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin-module
     supportedVersions: 1.49.3
   author: Red Hat
-  support: tech-preview
+  support: dev-preview
   lifecycle: active
   partOf:
     - scorecard

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin-module
     supportedVersions: 1.49.3
   author: Red Hat
-  support: tech-preview
+  support: dev-preview
   lifecycle: active
   partOf:
     - scorecard

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
@@ -23,7 +23,7 @@ spec:
     role: backend-plugin
     supportedVersions: 1.49.3
   author: Red Hat
-  support: tech-preview
+  support: dev-preview
   lifecycle: active
   appConfigExamples:
     - title: Default configuration

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
@@ -23,7 +23,7 @@ spec:
     role: frontend-plugin
     supportedVersions: 1.49.3
   author: Red Hat
-  support: tech-preview
+  support: dev-preview
   lifecycle: active
   partOf:
     - scorecard


### PR DESCRIPTION
Updates the support level for some of the Scorecard plugins from `tech-preview` to `dev-preview`. We have a follow up feature targeting the move to `tech-preview` support level at [RHDHPLAN-1234](https://redhat.atlassian.net/browse/RHDHPLAN-1234)