### PR TITLE
chore: fix missing metadata updates for the github workspace migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,8 +36,7 @@
 # /workspaces/dynatrace-dql
 /workspaces/env-viewer                                                  @redhat-developer/rhdh-ui @christoph-jerolimov
 /workspaces/extensions                                                 @redhat-developer/rhdh-ui @redhat-developer/rhdh-plugins
-# /workspaces/github-actions
-/workspaces/github-issues                                               @redhat-developer/rhdh-ui @divyanshiGupta
+/workspaces/github                                                      @redhat-developer/rhdh-ui @divyanshiGupta
 /workspaces/github-notifications                                        @redhat-developer/rhdh-ui @christoph-jerolimov
 /workspaces/github-pull-requests-board                                  @redhat-developer/rhdh-ui @christoph-jerolimov @kadel
 # /workspaces/gitlab

--- a/catalog-entities/extensions/plugins/github-actions.yaml
+++ b/catalog-entities/extensions/plugins/github-actions.yaml
@@ -18,7 +18,7 @@ metadata:
     - title: Documentation for Red Hat Developer Hub
       url: https://docs.redhat.com/en/documentation/red_hat_developer_hub
     - title: Source Code
-      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github-actions/plugins/github-actions
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-actions
 spec:
   author: Backstage Community
   support:

--- a/catalog-entities/extensions/plugins/github-issues.yaml
+++ b/catalog-entities/extensions/plugins/github-issues.yaml
@@ -18,7 +18,7 @@ metadata:
     - title: Documentation for Red Hat Developer Hub
       url: https://docs.redhat.com/en/documentation/red_hat_developer_hub
     - title: Source Code
-      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github-issues/plugins/github-issues
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-issues
 spec:
   categories:
     - Code Quality

--- a/rhdh-community-packages.txt
+++ b/rhdh-community-packages.txt
@@ -33,8 +33,8 @@ jenkins/plugins/jenkins
 jenkins/plugins/jenkins-backend
 sonarqube/plugins/sonarqube
 sonarqube/plugins/sonarqube-backend
-github-actions/plugins/github-actions
-github-issues/plugins/github-issues
+github/plugins/github-actions
+github/plugins/github-issues
 backstage/plugins/scaffolder-backend-module-azure
 roadie-backstage-plugins/plugins/frontend/backstage-plugin-github-insights
 roadie-backstage-plugins/plugins/frontend/backstage-plugin-github-pull-requests

--- a/workspaces/github/metadata/backstage-community-plugin-github-actions.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-actions.yaml
@@ -10,9 +10,9 @@ metadata:
     - url: https://github.com/backstage/community-plugins/issues
       title: Bugs
     - title: Source Code
-      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github-actions
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-actions
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/github-actions
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/github
   tags: []
 spec:
   packageName: "@backstage-community/plugin-github-actions"

--- a/workspaces/github/metadata/backstage-community-plugin-github-issues.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-issues.yaml
@@ -10,9 +10,9 @@ metadata:
     - url: https://github.com/backstage/community-plugins/issues
       title: Bugs
     - title: Source Code
-      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github-issues
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-issues
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/github-issues
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/github
   tags: []
 spec:
   packageName: "@backstage-community/plugin-github-issues"


### PR DESCRIPTION
### Description

Adds the metadata updates that were missed in https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2298