### PR TITLE
Add Jest 30 patch for tech-radar

### DIFF
--- a/workspaces/tech-radar/patches/1-jest-30-workspace-devdeps.patch
+++ b/workspaces/tech-radar/patches/1-jest-30-workspace-devdeps.patch
@@ -1,0 +1,3594 @@
+# Jest 30 workspace devDependencies + RadarComponent fake-timers test updates.
+# Mirrors community-plugins@7038bf7 (PR #8574) for ref dda5b313; yarn.lock refreshed after
+# adding root devDependencies. Format omits diff --git/index so override-sources uses patch -p0.
+# See: redhat-developer/rhdh-plugin-export-utils override-sources.sh
+# Remove when source.json advances past a commit that includes this upstream.
+#
+--- package.json
++++ package.json
+@@ -43,6 +43,11 @@
+     "@backstage/e2e-test-utils": "backstage:^",
+     "@backstage/repo-tools": "backstage:^",
+     "@changesets/cli": "^2.27.1",
++    "@jest/environment-jsdom-abstract": "^30",
++    "@types/jest": "^30",
++    "@types/jsdom": "^28.0.0",
++    "jest": "^30",
++    "jsdom": "^27",
+     "knip": "^5.27.4",
+     "node-gyp": "^10.0.0",
+     "prettier": "^2.3.2",
+--- plugins/tech-radar/src/components/RadarComponent.test.tsx
++++ plugins/tech-radar/src/components/RadarComponent.test.tsx
+@@ -14,6 +14,7 @@
+  * limitations under the License.
+  */
+ 
++import { act } from '@testing-library/react';
+ import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+ import { TechRadarLoaderResponse } from '@backstage-community/plugin-tech-radar-common';
+ 
+@@ -32,6 +33,10 @@ describe('RadarComponent', () => {
+     GetBBoxPolyfill.remove();
+   });
+ 
++  afterEach(() => {
++    jest.useRealTimers();
++  });
++
+   class MockClient implements TechRadarApi {
+     constructor(private delay = 0) {}
+     async load(): Promise<TechRadarLoaderResponse> {
+@@ -62,13 +67,15 @@ describe('RadarComponent', () => {
+       </TestApiProvider>,
+     );
+ 
+-    jest.advanceTimersByTime(250);
++    await act(async () => {
++      jest.advanceTimersByTime(250);
++    });
+     await expect(findByTestId('progress')).resolves.toBeInTheDocument();
+ 
+-    jest.advanceTimersByTime(250);
++    await act(async () => {
++      jest.advanceTimersByTime(250);
++    });
+     await expect(findByTestId('tech-radar-svg')).resolves.toBeInTheDocument();
+-
+-    jest.useRealTimers();
+   });
+ 
+   it('should call the errorApi if load fails', async () => {
+--- yarn.lock
++++ yarn.lock
+@@ -5,6 +5,13 @@ __metadata:
+   version: 8
+   cacheKey: 10
+ 
++"@acemir/cssom@npm:^0.9.28":
++  version: 0.9.31
++  resolution: "@acemir/cssom@npm:0.9.31"
++  checksum: 10/5948336f7f122062d714f4bb519937c42c91c84be348e31b35179f6109efc6753a695701c29f2271d8990f6f728168e933038418d97646cc5a1096099c3455b5
++  languageName: node
++  linkType: hard
++
+ "@adobe/css-tools@npm:^4.4.0":
+   version: 4.4.0
+   resolution: "@adobe/css-tools@npm:4.4.0"
+@@ -75,6 +82,39 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@asamuzakjp/css-color@npm:^4.1.1":
++  version: 4.1.2
++  resolution: "@asamuzakjp/css-color@npm:4.1.2"
++  dependencies:
++    "@csstools/css-calc": "npm:^3.0.0"
++    "@csstools/css-color-parser": "npm:^4.0.1"
++    "@csstools/css-parser-algorithms": "npm:^4.0.0"
++    "@csstools/css-tokenizer": "npm:^4.0.0"
++    lru-cache: "npm:^11.2.5"
++  checksum: 10/0938a4598a1d06d4db53b8aff406815f77047419eccb78f484dd26d13bd6cafaff247bc42f5493f2cb585477f461a38fba0db3c7a407ba9f281d27bc0d8f1983
++  languageName: node
++  linkType: hard
++
++"@asamuzakjp/dom-selector@npm:^6.7.6":
++  version: 6.8.1
++  resolution: "@asamuzakjp/dom-selector@npm:6.8.1"
++  dependencies:
++    "@asamuzakjp/nwsapi": "npm:^2.3.9"
++    bidi-js: "npm:^1.0.3"
++    css-tree: "npm:^3.1.0"
++    is-potential-custom-element-name: "npm:^1.0.1"
++    lru-cache: "npm:^11.2.6"
++  checksum: 10/4d1c63bf094aa35c9c60ad8d2faf45ee4f5f8d1520fbb158e2552c456f8264029932ff4464ea18ea760a89b3075b4bf70e43b2086191d256f35eff46fde3eb24
++  languageName: node
++  linkType: hard
++
++"@asamuzakjp/nwsapi@npm:^2.3.9":
++  version: 2.3.9
++  resolution: "@asamuzakjp/nwsapi@npm:2.3.9"
++  checksum: 10/95a6d1c102e1117fe818da087fcc5b914d23e0699855991bae50b891435dd1945ad7d384198f8bcf616207fd85b7ec32e3db6b96e9309d84c6903b8dc4151e34
++  languageName: node
++  linkType: hard
++
+ "@asyncapi/avro-schema-parser@npm:^3.0.24":
+   version: 3.0.24
+   resolution: "@asyncapi/avro-schema-parser@npm:3.0.24"
+@@ -1238,7 +1278,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.16.0, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.24.2, @babel/code-frame@npm:^7.24.7, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.8.3":
++"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.16.0, @babel/code-frame@npm:^7.16.7, @babel/code-frame@npm:^7.24.2, @babel/code-frame@npm:^7.24.7, @babel/code-frame@npm:^7.27.1, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0, @babel/code-frame@npm:^7.8.3":
+   version: 7.29.0
+   resolution: "@babel/code-frame@npm:7.29.0"
+   dependencies:
+@@ -1249,6 +1289,36 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/compat-data@npm:^7.28.6":
++  version: 7.29.3
++  resolution: "@babel/compat-data@npm:7.29.3"
++  checksum: 10/3c29661756a7c1cbc5248a7bdc657c0cb49f350e3157040c20486759f1f50a08a0b385fd7d813df50b96cd6fad5896d30ba6abab7602641bd1410ed346c1812f
++  languageName: node
++  linkType: hard
++
++"@babel/core@npm:^7.23.9, @babel/core@npm:^7.27.4":
++  version: 7.29.0
++  resolution: "@babel/core@npm:7.29.0"
++  dependencies:
++    "@babel/code-frame": "npm:^7.29.0"
++    "@babel/generator": "npm:^7.29.0"
++    "@babel/helper-compilation-targets": "npm:^7.28.6"
++    "@babel/helper-module-transforms": "npm:^7.28.6"
++    "@babel/helpers": "npm:^7.28.6"
++    "@babel/parser": "npm:^7.29.0"
++    "@babel/template": "npm:^7.28.6"
++    "@babel/traverse": "npm:^7.29.0"
++    "@babel/types": "npm:^7.29.0"
++    "@jridgewell/remapping": "npm:^2.3.5"
++    convert-source-map: "npm:^2.0.0"
++    debug: "npm:^4.1.0"
++    gensync: "npm:^1.0.0-beta.2"
++    json5: "npm:^2.2.3"
++    semver: "npm:^6.3.1"
++  checksum: 10/25f4e91688cdfbaf1365831f4f245b436cdaabe63d59389b75752013b8d61819ee4257101b52fc328b0546159fd7d0e74457ed7cf12c365fea54be4fb0a40229
++  languageName: node
++  linkType: hard
++
+ "@babel/generator@npm:^7.25.6":
+   version: 7.25.6
+   resolution: "@babel/generator@npm:7.25.6"
+@@ -1261,6 +1331,39 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/generator@npm:^7.27.5, @babel/generator@npm:^7.29.0":
++  version: 7.29.1
++  resolution: "@babel/generator@npm:7.29.1"
++  dependencies:
++    "@babel/parser": "npm:^7.29.0"
++    "@babel/types": "npm:^7.29.0"
++    "@jridgewell/gen-mapping": "npm:^0.3.12"
++    "@jridgewell/trace-mapping": "npm:^0.3.28"
++    jsesc: "npm:^3.0.2"
++  checksum: 10/61fe4ddd6e817aa312a14963ccdbb5c9a8c57e8b97b98d19a8a99ccab2215fda1a5f52bc8dd8d2e3c064497ddeb3ab8ceb55c76fa0f58f8169c34679d2256fe0
++  languageName: node
++  linkType: hard
++
++"@babel/helper-compilation-targets@npm:^7.28.6":
++  version: 7.28.6
++  resolution: "@babel/helper-compilation-targets@npm:7.28.6"
++  dependencies:
++    "@babel/compat-data": "npm:^7.28.6"
++    "@babel/helper-validator-option": "npm:^7.27.1"
++    browserslist: "npm:^4.24.0"
++    lru-cache: "npm:^5.1.1"
++    semver: "npm:^6.3.1"
++  checksum: 10/f512a5aeee4dfc6ea8807f521d085fdca8d66a7d068a6dd5e5b37da10a6081d648c0bbf66791a081e4e8e6556758da44831b331540965dfbf4f5275f3d0a8788
++  languageName: node
++  linkType: hard
++
++"@babel/helper-globals@npm:^7.28.0":
++  version: 7.28.0
++  resolution: "@babel/helper-globals@npm:7.28.0"
++  checksum: 10/91445f7edfde9b65dcac47f4f858f68dc1661bf73332060ab67ad7cc7b313421099a2bfc4bda30c3db3842cfa1e86fffbb0d7b2c5205a177d91b22c8d7d9cb47
++  languageName: node
++  linkType: hard
++
+ "@babel/helper-module-imports@npm:^7.16.7":
+   version: 7.24.7
+   resolution: "@babel/helper-module-imports@npm:7.24.7"
+@@ -1271,6 +1374,36 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/helper-module-imports@npm:^7.28.6":
++  version: 7.28.6
++  resolution: "@babel/helper-module-imports@npm:7.28.6"
++  dependencies:
++    "@babel/traverse": "npm:^7.28.6"
++    "@babel/types": "npm:^7.28.6"
++  checksum: 10/64b1380d74425566a3c288074d7ce4dea56d775d2d3325a3d4a6df1dca702916c1d268133b6f385de9ba5b822b3c6e2af5d3b11ac88e5453d5698d77264f0ec0
++  languageName: node
++  linkType: hard
++
++"@babel/helper-module-transforms@npm:^7.28.6":
++  version: 7.28.6
++  resolution: "@babel/helper-module-transforms@npm:7.28.6"
++  dependencies:
++    "@babel/helper-module-imports": "npm:^7.28.6"
++    "@babel/helper-validator-identifier": "npm:^7.28.5"
++    "@babel/traverse": "npm:^7.28.6"
++  peerDependencies:
++    "@babel/core": ^7.0.0
++  checksum: 10/2e421c7db743249819ee51e83054952709dc2e197c7d5d415b4bdddc718580195704bfcdf38544b3f674efc2eccd4d29a65d38678fc827ed3934a7690984cd8b
++  languageName: node
++  linkType: hard
++
++"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.28.6, @babel/helper-plugin-utils@npm:^7.8.0":
++  version: 7.28.6
++  resolution: "@babel/helper-plugin-utils@npm:7.28.6"
++  checksum: 10/21c853bbc13dbdddf03309c9a0477270124ad48989e1ad6524b83e83a77524b333f92edd2caae645c5a7ecf264ec6d04a9ebe15aeb54c7f33c037b71ec521e4a
++  languageName: node
++  linkType: hard
++
+ "@babel/helper-string-parser@npm:^7.24.8":
+   version: 7.24.8
+   resolution: "@babel/helper-string-parser@npm:7.24.8"
+@@ -1278,6 +1411,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/helper-string-parser@npm:^7.27.1":
++  version: 7.27.1
++  resolution: "@babel/helper-string-parser@npm:7.27.1"
++  checksum: 10/0ae29cc2005084abdae2966afdb86ed14d41c9c37db02c3693d5022fba9f5d59b011d039380b8e537c34daf117c549f52b452398f576e908fb9db3c7abbb3a00
++  languageName: node
++  linkType: hard
++
+ "@babel/helper-validator-identifier@npm:^7.24.7, @babel/helper-validator-identifier@npm:^7.28.5":
+   version: 7.28.5
+   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
+@@ -1285,6 +1425,23 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/helper-validator-option@npm:^7.27.1":
++  version: 7.27.1
++  resolution: "@babel/helper-validator-option@npm:7.27.1"
++  checksum: 10/db73e6a308092531c629ee5de7f0d04390835b21a263be2644276cb27da2384b64676cab9f22cd8d8dbd854c92b1d7d56fc8517cf0070c35d1c14a8c828b0903
++  languageName: node
++  linkType: hard
++
++"@babel/helpers@npm:^7.28.6":
++  version: 7.29.2
++  resolution: "@babel/helpers@npm:7.29.2"
++  dependencies:
++    "@babel/template": "npm:^7.28.6"
++    "@babel/types": "npm:^7.29.0"
++  checksum: 10/ad77706f3f917bd224e037fd0fbc67c45b240d2a45981321b093f70b7c535bee9bbddb0a19e34c362cb000ae21cdd8638f8a87a5f305a5bd7547e93fdcc524fe
++  languageName: node
++  linkType: hard
++
+ "@babel/highlight@npm:^7.0.0":
+   version: 7.24.7
+   resolution: "@babel/highlight@npm:7.24.7"
+@@ -1297,6 +1454,17 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
++  version: 7.29.3
++  resolution: "@babel/parser@npm:7.29.3"
++  dependencies:
++    "@babel/types": "npm:^7.29.0"
++  bin:
++    parser: ./bin/babel-parser.js
++  checksum: 10/10e8f34e0fdaa495b9db8be71f4eb29b16d8a57e0818c1bb1c4084015b0383803fd77812ed41597760cbf3d9ab3ae9f4af54f39ff5e5d8e081ba43593232f0ca
++  languageName: node
++  linkType: hard
++
+ "@babel/parser@npm:^7.25.0, @babel/parser@npm:^7.25.6":
+   version: 7.25.6
+   resolution: "@babel/parser@npm:7.25.6"
+@@ -1308,6 +1476,193 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/plugin-syntax-async-generators@npm:^7.8.4":
++  version: 7.8.4
++  resolution: "@babel/plugin-syntax-async-generators@npm:7.8.4"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.8.0"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/7ed1c1d9b9e5b64ef028ea5e755c0be2d4e5e4e3d6cf7df757b9a8c4cfa4193d268176d0f1f7fbecdda6fe722885c7fda681f480f3741d8a2d26854736f05367
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-bigint@npm:^7.8.3":
++  version: 7.8.3
++  resolution: "@babel/plugin-syntax-bigint@npm:7.8.3"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.8.0"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/3a10849d83e47aec50f367a9e56a6b22d662ddce643334b087f9828f4c3dd73bdc5909aaeabe123fed78515767f9ca43498a0e621c438d1cd2802d7fae3c9648
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-class-properties@npm:^7.12.13":
++  version: 7.12.13
++  resolution: "@babel/plugin-syntax-class-properties@npm:7.12.13"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.12.13"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/24f34b196d6342f28d4bad303612d7ff566ab0a013ce89e775d98d6f832969462e7235f3e7eaf17678a533d4be0ba45d3ae34ab4e5a9dcbda5d98d49e5efa2fc
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-class-static-block@npm:^7.14.5":
++  version: 7.14.5
++  resolution: "@babel/plugin-syntax-class-static-block@npm:7.14.5"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.14.5"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/3e80814b5b6d4fe17826093918680a351c2d34398a914ce6e55d8083d72a9bdde4fbaf6a2dcea0e23a03de26dc2917ae3efd603d27099e2b98380345703bf948
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-import-attributes@npm:^7.24.7":
++  version: 7.28.6
++  resolution: "@babel/plugin-syntax-import-attributes@npm:7.28.6"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.28.6"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/6c8c6a5988dbb9799d6027360d1a5ba64faabf551f2ef11ba4eade0c62253b5c85d44ddc8eb643c74b9acb2bcaa664a950bd5de9a5d4aef291c4f2a48223bb4b
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-import-meta@npm:^7.10.4":
++  version: 7.10.4
++  resolution: "@babel/plugin-syntax-import-meta@npm:7.10.4"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.10.4"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/166ac1125d10b9c0c430e4156249a13858c0366d38844883d75d27389621ebe651115cb2ceb6dc011534d5055719fa1727b59f39e1ab3ca97820eef3dcab5b9b
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-json-strings@npm:^7.8.3":
++  version: 7.8.3
++  resolution: "@babel/plugin-syntax-json-strings@npm:7.8.3"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.8.0"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/bf5aea1f3188c9a507e16efe030efb996853ca3cadd6512c51db7233cc58f3ac89ff8c6bdfb01d30843b161cfe7d321e1bf28da82f7ab8d7e6bc5464666f354a
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-jsx@npm:^7.27.1":
++  version: 7.28.6
++  resolution: "@babel/plugin-syntax-jsx@npm:7.28.6"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.28.6"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/572e38f5c1bb4b8124300e7e3dd13e82ae84a21f90d3f0786c98cd05e63c78ca1f32d1cfe462dfbaf5e7d5102fa7cd8fd741dfe4f3afc2e01a3b2877dcc8c866
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-logical-assignment-operators@npm:^7.10.4":
++  version: 7.10.4
++  resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.10.4"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/aff33577037e34e515911255cdbb1fd39efee33658aa00b8a5fd3a4b903585112d037cce1cc9e4632f0487dc554486106b79ccd5ea63a2e00df4363f6d4ff886
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-nullish-coalescing-operator@npm:^7.8.3":
++  version: 7.8.3
++  resolution: "@babel/plugin-syntax-nullish-coalescing-operator@npm:7.8.3"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.8.0"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/87aca4918916020d1fedba54c0e232de408df2644a425d153be368313fdde40d96088feed6c4e5ab72aac89be5d07fef2ddf329a15109c5eb65df006bf2580d1
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-numeric-separator@npm:^7.10.4":
++  version: 7.10.4
++  resolution: "@babel/plugin-syntax-numeric-separator@npm:7.10.4"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.10.4"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/01ec5547bd0497f76cc903ff4d6b02abc8c05f301c88d2622b6d834e33a5651aa7c7a3d80d8d57656a4588f7276eba357f6b7e006482f5b564b7a6488de493a1
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-object-rest-spread@npm:^7.8.3":
++  version: 7.8.3
++  resolution: "@babel/plugin-syntax-object-rest-spread@npm:7.8.3"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.8.0"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/fddcf581a57f77e80eb6b981b10658421bc321ba5f0a5b754118c6a92a5448f12a0c336f77b8abf734841e102e5126d69110a306eadb03ca3e1547cab31f5cbf
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-optional-catch-binding@npm:^7.8.3":
++  version: 7.8.3
++  resolution: "@babel/plugin-syntax-optional-catch-binding@npm:7.8.3"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.8.0"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/910d90e72bc90ea1ce698e89c1027fed8845212d5ab588e35ef91f13b93143845f94e2539d831dc8d8ededc14ec02f04f7bd6a8179edd43a326c784e7ed7f0b9
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-optional-chaining@npm:^7.8.3":
++  version: 7.8.3
++  resolution: "@babel/plugin-syntax-optional-chaining@npm:7.8.3"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.8.0"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/eef94d53a1453361553c1f98b68d17782861a04a392840341bc91780838dd4e695209c783631cf0de14c635758beafb6a3a65399846ffa4386bff90639347f30
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-private-property-in-object@npm:^7.14.5":
++  version: 7.14.5
++  resolution: "@babel/plugin-syntax-private-property-in-object@npm:7.14.5"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.14.5"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/b317174783e6e96029b743ccff2a67d63d38756876e7e5d0ba53a322e38d9ca452c13354a57de1ad476b4c066dbae699e0ca157441da611117a47af88985ecda
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-top-level-await@npm:^7.14.5":
++  version: 7.14.5
++  resolution: "@babel/plugin-syntax-top-level-await@npm:7.14.5"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.14.5"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/bbd1a56b095be7820029b209677b194db9b1d26691fe999856462e66b25b281f031f3dfd91b1619e9dcf95bebe336211833b854d0fb8780d618e35667c2d0d7e
++  languageName: node
++  linkType: hard
++
++"@babel/plugin-syntax-typescript@npm:^7.27.1":
++  version: 7.28.6
++  resolution: "@babel/plugin-syntax-typescript@npm:7.28.6"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.28.6"
++  peerDependencies:
++    "@babel/core": ^7.0.0-0
++  checksum: 10/5c55f9c63bd36cf3d7e8db892294c8f85000f9c1526c3a1cc310d47d1e174f5c6f6605e5cc902c4636d885faba7a9f3d5e5edc6b35e4f3b1fd4c2d58d0304fa5
++  languageName: node
++  linkType: hard
++
+ "@babel/runtime-corejs3@npm:^7.20.7, @babel/runtime-corejs3@npm:^7.22.15, @babel/runtime-corejs3@npm:^7.26.10, @babel/runtime-corejs3@npm:^7.27.1":
+   version: 7.28.4
+   resolution: "@babel/runtime-corejs3@npm:7.28.4"
+@@ -1335,6 +1690,17 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/template@npm:^7.28.6":
++  version: 7.28.6
++  resolution: "@babel/template@npm:7.28.6"
++  dependencies:
++    "@babel/code-frame": "npm:^7.28.6"
++    "@babel/parser": "npm:^7.28.6"
++    "@babel/types": "npm:^7.28.6"
++  checksum: 10/0ad6e32bf1e7e31bf6b52c20d15391f541ddd645cbd488a77fe537a15b280ee91acd3a777062c52e03eedbc2e1f41548791f6a3697c02476ec5daf49faa38533
++  languageName: node
++  linkType: hard
++
+ "@babel/traverse@npm:^7.24.7":
+   version: 7.25.6
+   resolution: "@babel/traverse@npm:7.25.6"
+@@ -1350,6 +1716,31 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0":
++  version: 7.29.0
++  resolution: "@babel/traverse@npm:7.29.0"
++  dependencies:
++    "@babel/code-frame": "npm:^7.29.0"
++    "@babel/generator": "npm:^7.29.0"
++    "@babel/helper-globals": "npm:^7.28.0"
++    "@babel/parser": "npm:^7.29.0"
++    "@babel/template": "npm:^7.28.6"
++    "@babel/types": "npm:^7.29.0"
++    debug: "npm:^4.3.1"
++  checksum: 10/3a0d0438f1ba9fed4fbe1706ea598a865f9af655a16ca9517ab57bda526e224569ca1b980b473fb68feea5e08deafbbf2cf9febb941f92f2d2533310c3fc4abc
++  languageName: node
++  linkType: hard
++
++"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0":
++  version: 7.29.0
++  resolution: "@babel/types@npm:7.29.0"
++  dependencies:
++    "@babel/helper-string-parser": "npm:^7.27.1"
++    "@babel/helper-validator-identifier": "npm:^7.28.5"
++  checksum: 10/bfc2b211210f3894dcd7e6a33b2d1c32c93495dc1e36b547376aa33441abe551ab4bc1640d4154ee2acd8e46d3bbc925c7224caae02fcaf0e6a771e97fccc661
++  languageName: node
++  linkType: hard
++
+ "@babel/types@npm:^7.24.7, @babel/types@npm:^7.25.0, @babel/types@npm:^7.25.6":
+   version: 7.25.6
+   resolution: "@babel/types@npm:7.25.6"
+@@ -3863,6 +4254,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@bcoe/v8-coverage@npm:^0.2.3":
++  version: 0.2.3
++  resolution: "@bcoe/v8-coverage@npm:0.2.3"
++  checksum: 10/1a1f0e356a3bb30b5f1ced6f79c413e6ebacf130421f15fac5fcd8be5ddf98aedb4404d7f5624e3285b700e041f9ef938321f3ca4d359d5b716f96afa120d88d
++  languageName: node
++  linkType: hard
++
+ "@bundled-es-modules/cookie@npm:^2.0.0":
+   version: 2.0.0
+   resolution: "@bundled-es-modules/cookie@npm:2.0.0"
+@@ -4247,6 +4645,64 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@csstools/color-helpers@npm:^6.0.2":
++  version: 6.0.2
++  resolution: "@csstools/color-helpers@npm:6.0.2"
++  checksum: 10/c47a943e947d76980d0e1071027cb70481ac481968e744a05a7aea7ede9886f10d062b2e3691e03c115d97b053d4140c1ca28e24c1ffe2d21693e126de6522e9
++  languageName: node
++  linkType: hard
++
++"@csstools/css-calc@npm:^3.0.0, @csstools/css-calc@npm:^3.2.0":
++  version: 3.2.0
++  resolution: "@csstools/css-calc@npm:3.2.0"
++  peerDependencies:
++    "@csstools/css-parser-algorithms": ^4.0.0
++    "@csstools/css-tokenizer": ^4.0.0
++  checksum: 10/7eec51a21945a74aa6a407d1e6290d0f4c5d01829a42c01a56ce2055216398540cc3120837b15a0db38601bcb40cf97f1d991fefb3ee9d00d9cec03d67beba4c
++  languageName: node
++  linkType: hard
++
++"@csstools/css-color-parser@npm:^4.0.1":
++  version: 4.1.0
++  resolution: "@csstools/css-color-parser@npm:4.1.0"
++  dependencies:
++    "@csstools/color-helpers": "npm:^6.0.2"
++    "@csstools/css-calc": "npm:^3.2.0"
++  peerDependencies:
++    "@csstools/css-parser-algorithms": ^4.0.0
++    "@csstools/css-tokenizer": ^4.0.0
++  checksum: 10/794508011a95ebac3856e67e0333ca4174604d2dfddc101d991f2ebfd52b3c99cd36a08462675c2a07d057ca3787187fcd7eac98bced2eefdd9040b37853426d
++  languageName: node
++  linkType: hard
++
++"@csstools/css-parser-algorithms@npm:^4.0.0":
++  version: 4.0.0
++  resolution: "@csstools/css-parser-algorithms@npm:4.0.0"
++  peerDependencies:
++    "@csstools/css-tokenizer": ^4.0.0
++  checksum: 10/000f3ba55f440d9fbece50714e88f9d4479e2bde9e0568333492663f2c6034dc31d0b9ef5d66d196c76be58eea145ca6920aa8bdfdcc6361894806c21b5402d0
++  languageName: node
++  linkType: hard
++
++"@csstools/css-syntax-patches-for-csstree@npm:^1.0.21":
++  version: 1.1.3
++  resolution: "@csstools/css-syntax-patches-for-csstree@npm:1.1.3"
++  peerDependencies:
++    css-tree: ^3.2.1
++  peerDependenciesMeta:
++    css-tree:
++      optional: true
++  checksum: 10/1c91dc03b64ca913eed5064ca0e434da1c0be8def6ce20f932d1db10f9b478ac3830c99a033b0edf75954cf9164c7c267b220ed9faffbc3342bf320870c3bb4b
++  languageName: node
++  linkType: hard
++
++"@csstools/css-tokenizer@npm:^4.0.0":
++  version: 4.0.0
++  resolution: "@csstools/css-tokenizer@npm:4.0.0"
++  checksum: 10/074ade1a7fc3410b813c8982cf07a56814a55af509c533c2dc80d5689f34d2ba38219f8fa78fa36ea2adc6c5db506ea3c3a667388dda1b59b1281fdd2a2d1e28
++  languageName: node
++  linkType: hard
++
+ "@dabh/diagnostics@npm:^2.0.2":
+   version: 2.0.3
+   resolution: "@dabh/diagnostics@npm:2.0.3"
+@@ -4306,6 +4762,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@emnapi/core@npm:^1.4.3":
++  version: 1.10.0
++  resolution: "@emnapi/core@npm:1.10.0"
++  dependencies:
++    "@emnapi/wasi-threads": "npm:1.2.1"
++    tslib: "npm:^2.4.0"
++  checksum: 10/d32f386084e64deaf2609aabb8295d1ad5af6144d0f46d2060b76cc53f1f3b486df54bec9b0f33c37d85a3822e1193ebcd4e3deb4a5f0e4cd650aa2ffc631715
++  languageName: node
++  linkType: hard
++
+ "@emnapi/core@npm:^1.4.5":
+   version: 1.4.5
+   resolution: "@emnapi/core@npm:1.4.5"
+@@ -4316,6 +4782,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@emnapi/runtime@npm:^1.4.3":
++  version: 1.10.0
++  resolution: "@emnapi/runtime@npm:1.10.0"
++  dependencies:
++    tslib: "npm:^2.4.0"
++  checksum: 10/d21083d07fa0c2da171c142e78ef986b66b07d45b06accc0bcaf49fcc61bb4dbc10e1c1760813070165b9f49b054376a931045347f21c0f42ff1eb2d2040faac
++  languageName: node
++  linkType: hard
++
+ "@emnapi/runtime@npm:^1.4.5":
+   version: 1.4.5
+   resolution: "@emnapi/runtime@npm:1.4.5"
+@@ -4334,6 +4809,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@emnapi/wasi-threads@npm:1.2.1":
++  version: 1.2.1
++  resolution: "@emnapi/wasi-threads@npm:1.2.1"
++  dependencies:
++    tslib: "npm:^2.4.0"
++  checksum: 10/57cd4292be81c05d26aa886d68a9e4c449ff666e8503fed6463dfc6b64a4e4213f03c152d53296b7cda32840271e38cd33347332070658f01befeb9bf4e59f36
++  languageName: node
++  linkType: hard
++
+ "@emotion/babel-plugin@npm:^11.12.0":
+   version: 11.12.0
+   resolution: "@emotion/babel-plugin@npm:11.12.0"
+@@ -4757,6 +5241,18 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@exodus/bytes@npm:^1.6.0":
++  version: 1.15.0
++  resolution: "@exodus/bytes@npm:1.15.0"
++  peerDependencies:
++    "@noble/hashes": ^1.8.0 || ^2.0.0
++  peerDependenciesMeta:
++    "@noble/hashes":
++      optional: true
++  checksum: 10/d18519341c354356b65b9ac64b8166880972d122feff4038a92c0e2d2c8579794429117a2bc636bca584e7bf2fdad6d27f0874b2647d4a866c125843497ef193
++  languageName: node
++  linkType: hard
++
+ "@fastify/busboy@npm:^2.0.0":
+   version: 2.1.1
+   resolution: "@fastify/busboy@npm:2.1.1"
+@@ -5186,6 +5682,11 @@ __metadata:
+     "@backstage/e2e-test-utils": "backstage:^"
+     "@backstage/repo-tools": "backstage:^"
+     "@changesets/cli": "npm:^2.27.1"
++    "@jest/environment-jsdom-abstract": "npm:^30"
++    "@types/jest": "npm:^30"
++    "@types/jsdom": "npm:^28.0.0"
++    jest: "npm:^30"
++    jsdom: "npm:^27"
+     knip: "npm:^5.27.4"
+     node-gyp: "npm:^10.0.0"
+     prettier: "npm:^2.3.2"
+@@ -5313,40 +5814,331 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"@jest/create-cache-key-function@npm:^30.0.0":
+-  version: 30.2.0
+-  resolution: "@jest/create-cache-key-function@npm:30.2.0"
++"@istanbuljs/load-nyc-config@npm:^1.0.0":
++  version: 1.1.0
++  resolution: "@istanbuljs/load-nyc-config@npm:1.1.0"
+   dependencies:
+-    "@jest/types": "npm:30.2.0"
+-  checksum: 10/7a2dd0efe747c1b2e61825e51ace11e42f278203fae37a3b9462c8d2132394978682ed7094f5ce3d9f5a9e5f2855e6d1d933e5f3ac5165b127c36591f3d98d85
++    camelcase: "npm:^5.3.1"
++    find-up: "npm:^4.1.0"
++    get-package-type: "npm:^0.1.0"
++    js-yaml: "npm:^3.13.1"
++    resolve-from: "npm:^5.0.0"
++  checksum: 10/b000a5acd8d4fe6e34e25c399c8bdbb5d3a202b4e10416e17bfc25e12bab90bb56d33db6089ae30569b52686f4b35ff28ef26e88e21e69821d2b85884bd055b8
+   languageName: node
+   linkType: hard
+ 
+-"@jest/pattern@npm:30.0.1":
+-  version: 30.0.1
+-  resolution: "@jest/pattern@npm:30.0.1"
+-  dependencies:
+-    "@types/node": "npm:*"
+-    jest-regex-util: "npm:30.0.1"
+-  checksum: 10/afd03b4d3eadc9c9970cf924955dee47984a7e767901fe6fa463b17b246f0ddeec07b3e82c09715c54bde3c8abb92074160c0d79967bd23778724f184e7f5b7b
++"@istanbuljs/schema@npm:^0.1.2, @istanbuljs/schema@npm:^0.1.3":
++  version: 0.1.6
++  resolution: "@istanbuljs/schema@npm:0.1.6"
++  checksum: 10/966e1a80b0e52170d4b3b9fa75e1aa5f2cf01138416c828c249dcfc75706a32b13022dc8d06b7aab6ea6a80b63927d3e546ad04f005188fef20b3d2cbbf2b229
+   languageName: node
+   linkType: hard
+ 
+-"@jest/schemas@npm:30.0.5":
+-  version: 30.0.5
+-  resolution: "@jest/schemas@npm:30.0.5"
++"@jest/console@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/console@npm:30.4.1"
+   dependencies:
+-    "@sinclair/typebox": "npm:^0.34.0"
+-  checksum: 10/40df4db55d4aeed09d1c7e19caf23788309cea34490a1c5d584c913494195e698b9967e996afc27226cac6d76e7512fe73ae6b9584480695c60dd18a5459cdba
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    chalk: "npm:^4.1.2"
++    jest-message-util: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    slash: "npm:^3.0.0"
++  checksum: 10/4eb463d29654c20716f5f9cde43e5d958cb3b9234477df57da5b3814c3f1a4a0ab611a8eaf4b5abc146190a012584d7025f445f3560ed62acd843fc95c0a0e65
+   languageName: node
+   linkType: hard
+ 
+-"@jest/schemas@npm:^29.6.3":
+-  version: 29.6.3
+-  resolution: "@jest/schemas@npm:29.6.3"
++"@jest/core@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/core@npm:30.4.1"
+   dependencies:
+-    "@sinclair/typebox": "npm:^0.27.8"
+-  checksum: 10/910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
++    "@jest/console": "npm:30.4.1"
++    "@jest/pattern": "npm:30.4.0"
++    "@jest/reporters": "npm:30.4.1"
++    "@jest/test-result": "npm:30.4.1"
++    "@jest/transform": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    ansi-escapes: "npm:^4.3.2"
++    chalk: "npm:^4.1.2"
++    ci-info: "npm:^4.2.0"
++    exit-x: "npm:^0.2.2"
++    fast-json-stable-stringify: "npm:^2.1.0"
++    graceful-fs: "npm:^4.2.11"
++    jest-changed-files: "npm:30.4.1"
++    jest-config: "npm:30.4.1"
++    jest-haste-map: "npm:30.4.1"
++    jest-message-util: "npm:30.4.1"
++    jest-regex-util: "npm:30.4.0"
++    jest-resolve: "npm:30.4.1"
++    jest-resolve-dependencies: "npm:30.4.1"
++    jest-runner: "npm:30.4.1"
++    jest-runtime: "npm:30.4.1"
++    jest-snapshot: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    jest-validate: "npm:30.4.1"
++    jest-watcher: "npm:30.4.1"
++    pretty-format: "npm:30.4.1"
++    slash: "npm:^3.0.0"
++  peerDependencies:
++    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
++  peerDependenciesMeta:
++    node-notifier:
++      optional: true
++  checksum: 10/812fb0bb2da9251daf5e6c279d27a5808a1d73cc4362df9708706adf285ba6882d4be1ec817994579427f7562e80becf16dace1e7792b797d2cb0996ef12d5e0
++  languageName: node
++  linkType: hard
++
++"@jest/create-cache-key-function@npm:^30.0.0":
++  version: 30.2.0
++  resolution: "@jest/create-cache-key-function@npm:30.2.0"
++  dependencies:
++    "@jest/types": "npm:30.2.0"
++  checksum: 10/7a2dd0efe747c1b2e61825e51ace11e42f278203fae37a3b9462c8d2132394978682ed7094f5ce3d9f5a9e5f2855e6d1d933e5f3ac5165b127c36591f3d98d85
++  languageName: node
++  linkType: hard
++
++"@jest/diff-sequences@npm:30.4.0":
++  version: 30.4.0
++  resolution: "@jest/diff-sequences@npm:30.4.0"
++  checksum: 10/65c27937c10a7157899dad5d176806104286f9d55464f318955a0cee98db8aed6b8f70ad4aee7133468087146422cdd391d49b1e101ec543db3283ee4eb59c06
++  languageName: node
++  linkType: hard
++
++"@jest/environment-jsdom-abstract@npm:^30":
++  version: 30.4.1
++  resolution: "@jest/environment-jsdom-abstract@npm:30.4.1"
++  dependencies:
++    "@jest/environment": "npm:30.4.1"
++    "@jest/fake-timers": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/jsdom": "npm:^21.1.7"
++    "@types/node": "npm:*"
++    jest-mock: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++  peerDependencies:
++    canvas: ^3.0.0
++    jsdom: "*"
++  peerDependenciesMeta:
++    canvas:
++      optional: true
++  checksum: 10/e51537587162d0972df0abd6f0ce0b2cf5245029035e6b61b62da075547a37cd174254c315b456447a6419b22938623036b355c063498b7876f7ea0352404fa6
++  languageName: node
++  linkType: hard
++
++"@jest/environment@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/environment@npm:30.4.1"
++  dependencies:
++    "@jest/fake-timers": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    jest-mock: "npm:30.4.1"
++  checksum: 10/c25946fee29604f5aa24ea059bc3cc7bc4c8cdaf26db1ed6ffa4f28e37f5193cc4e868650c807d89caff4123e44d07b58200d4cb5960ebdb7d66531509d76359
++  languageName: node
++  linkType: hard
++
++"@jest/expect-utils@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/expect-utils@npm:30.4.1"
++  dependencies:
++    "@jest/get-type": "npm:30.1.0"
++  checksum: 10/3f0337ec791d669cacd07594521f2da71b956712dfd0c0007253dd5e886ef640df510af1357878a80ac56f09d3db9fd68e3db66959f0fdb3add5f551dd7e0f35
++  languageName: node
++  linkType: hard
++
++"@jest/expect@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/expect@npm:30.4.1"
++  dependencies:
++    expect: "npm:30.4.1"
++    jest-snapshot: "npm:30.4.1"
++  checksum: 10/40ae0317a3590ced7a7fd21c49e6b1af6b122e6a83822e643af83f02034dfed6485248cae08d6bcf9380039ba3824ac56db18478712c64ddf5f709ee23cf30cd
++  languageName: node
++  linkType: hard
++
++"@jest/fake-timers@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/fake-timers@npm:30.4.1"
++  dependencies:
++    "@jest/types": "npm:30.4.1"
++    "@sinonjs/fake-timers": "npm:^15.4.0"
++    "@types/node": "npm:*"
++    jest-message-util: "npm:30.4.1"
++    jest-mock: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++  checksum: 10/bc7aff23548395d6e7957bc24f699f921a9616f2357ab49616b0468c7b5e94e6ac4cbdd45d306f1a5d7f72e2a055294f52be3666e4c1da7c137874c5b226e1c6
++  languageName: node
++  linkType: hard
++
++"@jest/get-type@npm:30.1.0":
++  version: 30.1.0
++  resolution: "@jest/get-type@npm:30.1.0"
++  checksum: 10/e2a95fbb49ce2d15547db8af5602626caf9b05f62a5e583b4a2de9bd93a2bfe7175f9bbb2b8a5c3909ce261d467b6991d7265bb1d547cb60e7e97f571f361a70
++  languageName: node
++  linkType: hard
++
++"@jest/globals@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/globals@npm:30.4.1"
++  dependencies:
++    "@jest/environment": "npm:30.4.1"
++    "@jest/expect": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    jest-mock: "npm:30.4.1"
++  checksum: 10/5fe04b9c3b97f0061e4464201ee0dd674dd958843eb80542791d1c576c51f12aaa3f3b369e136d5fd3f8c716f9c9bbfbb76491a3cbc3c4efb3cc71063f909132
++  languageName: node
++  linkType: hard
++
++"@jest/pattern@npm:30.0.1":
++  version: 30.0.1
++  resolution: "@jest/pattern@npm:30.0.1"
++  dependencies:
++    "@types/node": "npm:*"
++    jest-regex-util: "npm:30.0.1"
++  checksum: 10/afd03b4d3eadc9c9970cf924955dee47984a7e767901fe6fa463b17b246f0ddeec07b3e82c09715c54bde3c8abb92074160c0d79967bd23778724f184e7f5b7b
++  languageName: node
++  linkType: hard
++
++"@jest/pattern@npm:30.4.0":
++  version: 30.4.0
++  resolution: "@jest/pattern@npm:30.4.0"
++  dependencies:
++    "@types/node": "npm:*"
++    jest-regex-util: "npm:30.4.0"
++  checksum: 10/4fb1db0e586713708d2fcd79059315600978608483ef2d80e04a0a59b20b0d8de0d3f47cad950ff90bfb9ea3cb788709ee3d1eb225734e4dbf1c4b743c93d204
++  languageName: node
++  linkType: hard
++
++"@jest/reporters@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/reporters@npm:30.4.1"
++  dependencies:
++    "@bcoe/v8-coverage": "npm:^0.2.3"
++    "@jest/console": "npm:30.4.1"
++    "@jest/test-result": "npm:30.4.1"
++    "@jest/transform": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@jridgewell/trace-mapping": "npm:^0.3.25"
++    "@types/node": "npm:*"
++    chalk: "npm:^4.1.2"
++    collect-v8-coverage: "npm:^1.0.2"
++    exit-x: "npm:^0.2.2"
++    glob: "npm:^10.5.0"
++    graceful-fs: "npm:^4.2.11"
++    istanbul-lib-coverage: "npm:^3.0.0"
++    istanbul-lib-instrument: "npm:^6.0.0"
++    istanbul-lib-report: "npm:^3.0.0"
++    istanbul-lib-source-maps: "npm:^5.0.0"
++    istanbul-reports: "npm:^3.1.3"
++    jest-message-util: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    jest-worker: "npm:30.4.1"
++    slash: "npm:^3.0.0"
++    string-length: "npm:^4.0.2"
++    v8-to-istanbul: "npm:^9.0.1"
++  peerDependencies:
++    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
++  peerDependenciesMeta:
++    node-notifier:
++      optional: true
++  checksum: 10/e14e3717c9fe49004b6406cc53554f90954345917bb5f077d23e3a2cecde26d90493e1522d95f63b6c14ef06fb63d45b695ac6400d63b96fecc7a80d1ef83f4d
++  languageName: node
++  linkType: hard
++
++"@jest/schemas@npm:30.0.5":
++  version: 30.0.5
++  resolution: "@jest/schemas@npm:30.0.5"
++  dependencies:
++    "@sinclair/typebox": "npm:^0.34.0"
++  checksum: 10/40df4db55d4aeed09d1c7e19caf23788309cea34490a1c5d584c913494195e698b9967e996afc27226cac6d76e7512fe73ae6b9584480695c60dd18a5459cdba
++  languageName: node
++  linkType: hard
++
++"@jest/schemas@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/schemas@npm:30.4.1"
++  dependencies:
++    "@sinclair/typebox": "npm:^0.34.0"
++  checksum: 10/86e62c8fd8fc77535085f1ede3a416430a3740f78b8f88ec7d0ee4516b22daf3326ffc1ade9d5f7839bbde923aaf1b5ac430a42ed4bb1a38edc3de5005a58f51
++  languageName: node
++  linkType: hard
++
++"@jest/schemas@npm:^29.6.3":
++  version: 29.6.3
++  resolution: "@jest/schemas@npm:29.6.3"
++  dependencies:
++    "@sinclair/typebox": "npm:^0.27.8"
++  checksum: 10/910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
++  languageName: node
++  linkType: hard
++
++"@jest/snapshot-utils@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/snapshot-utils@npm:30.4.1"
++  dependencies:
++    "@jest/types": "npm:30.4.1"
++    chalk: "npm:^4.1.2"
++    graceful-fs: "npm:^4.2.11"
++    natural-compare: "npm:^1.4.0"
++  checksum: 10/8f17768702153267388b3043f358027385e591ac4668699bfce3547cb8e08ac146a074913bcddf68c0a4f7155e24a6d582d27f4592f5c3bd5f9fbc3f9182ef78
++  languageName: node
++  linkType: hard
++
++"@jest/source-map@npm:30.0.1":
++  version: 30.0.1
++  resolution: "@jest/source-map@npm:30.0.1"
++  dependencies:
++    "@jridgewell/trace-mapping": "npm:^0.3.25"
++    callsites: "npm:^3.1.0"
++    graceful-fs: "npm:^4.2.11"
++  checksum: 10/161b27cdf8d9d80fd99374d55222b90478864c6990514be6ebee72b7184a034224c9aceed12c476f3a48d48601bf8ed2e0c047a5a81bd907dc192ebe71365ed4
++  languageName: node
++  linkType: hard
++
++"@jest/test-result@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/test-result@npm:30.4.1"
++  dependencies:
++    "@jest/console": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/istanbul-lib-coverage": "npm:^2.0.6"
++    collect-v8-coverage: "npm:^1.0.2"
++  checksum: 10/c420182d72cef64827981230b4c84b2de3f4312067e7baf1e3e13c501dc57f73faa09fed1a5ed1a6e96bc29f6c67ac2c14de5f973945f14853010729678cb44a
++  languageName: node
++  linkType: hard
++
++"@jest/test-sequencer@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/test-sequencer@npm:30.4.1"
++  dependencies:
++    "@jest/test-result": "npm:30.4.1"
++    graceful-fs: "npm:^4.2.11"
++    jest-haste-map: "npm:30.4.1"
++    slash: "npm:^3.0.0"
++  checksum: 10/d911ef0c527c402d41537aa5f9754725a58732c1c6616401454633fd45729da0b2f01b4c50322b1b789a9f2d4edf3a24aecb0b2e4ca4d873c4335894b63bc5b0
++  languageName: node
++  linkType: hard
++
++"@jest/transform@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/transform@npm:30.4.1"
++  dependencies:
++    "@babel/core": "npm:^7.27.4"
++    "@jest/types": "npm:30.4.1"
++    "@jridgewell/trace-mapping": "npm:^0.3.25"
++    babel-plugin-istanbul: "npm:^7.0.1"
++    chalk: "npm:^4.1.2"
++    convert-source-map: "npm:^2.0.0"
++    fast-json-stable-stringify: "npm:^2.1.0"
++    graceful-fs: "npm:^4.2.11"
++    jest-haste-map: "npm:30.4.1"
++    jest-regex-util: "npm:30.4.0"
++    jest-util: "npm:30.4.1"
++    pirates: "npm:^4.0.7"
++    slash: "npm:^3.0.0"
++    write-file-atomic: "npm:^5.0.1"
++  checksum: 10/7b570451f6c26360f1b852c2281dcc4e36fe685dbc159cf5eabf83d49d6aae4569f444d38f3afb5b3b6e0b809eb41b65f3145c0cac5fee3eec9c9b178fb1f0ea
+   languageName: node
+   linkType: hard
+ 
+@@ -5365,6 +6157,21 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@jest/types@npm:30.4.1":
++  version: 30.4.1
++  resolution: "@jest/types@npm:30.4.1"
++  dependencies:
++    "@jest/pattern": "npm:30.4.0"
++    "@jest/schemas": "npm:30.4.1"
++    "@types/istanbul-lib-coverage": "npm:^2.0.6"
++    "@types/istanbul-reports": "npm:^3.0.4"
++    "@types/node": "npm:*"
++    "@types/yargs": "npm:^17.0.33"
++    chalk: "npm:^4.1.2"
++  checksum: 10/cc0999508613487c6d0f55661cd342ebe7cfe579fa9917534b94310204358f03f94524f70f00b4fe3c6dd2ccd0fd44657615a1b9f420ab310d68b43964bff87c
++  languageName: node
++  linkType: hard
++
+ "@jest/types@npm:^29.6.3":
+   version: 29.6.3
+   resolution: "@jest/types@npm:29.6.3"
+@@ -5379,6 +6186,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@jridgewell/gen-mapping@npm:^0.3.12":
++  version: 0.3.13
++  resolution: "@jridgewell/gen-mapping@npm:0.3.13"
++  dependencies:
++    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
++    "@jridgewell/trace-mapping": "npm:^0.3.24"
++  checksum: 10/902f8261dcf450b4af7b93f9656918e02eec80a2169e155000cb2059f90113dd98f3ccf6efc6072cee1dd84cac48cade51da236972d942babc40e4c23da4d62a
++  languageName: node
++  linkType: hard
++
+ "@jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
+   version: 0.3.5
+   resolution: "@jridgewell/gen-mapping@npm:0.3.5"
+@@ -5390,6 +6207,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@jridgewell/remapping@npm:^2.3.5":
++  version: 2.3.5
++  resolution: "@jridgewell/remapping@npm:2.3.5"
++  dependencies:
++    "@jridgewell/gen-mapping": "npm:^0.3.5"
++    "@jridgewell/trace-mapping": "npm:^0.3.24"
++  checksum: 10/c2bb01856e65b506d439455f28aceacf130d6c023d1d4e3b48705e88def3571753e1a887daa04b078b562316c92d26ce36408a60534bceca3f830aec88a339ad
++  languageName: node
++  linkType: hard
++
+ "@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
+   version: 3.1.2
+   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
+@@ -5431,6 +6258,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.23, @jridgewell/trace-mapping@npm:^0.3.28":
++  version: 0.3.31
++  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
++  dependencies:
++    "@jridgewell/resolve-uri": "npm:^3.1.0"
++    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
++  checksum: 10/da0283270e691bdb5543806077548532791608e52386cfbbf3b9e8fb00457859d1bd01d512851161c886eb3a2f3ce6fd9bcf25db8edf3bddedd275bd4a88d606
++  languageName: node
++  linkType: hard
++
+ "@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
+   version: 0.3.25
+   resolution: "@jridgewell/trace-mapping@npm:0.3.25"
+@@ -6444,6 +7281,17 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@napi-rs/wasm-runtime@npm:^0.2.11":
++  version: 0.2.12
++  resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
++  dependencies:
++    "@emnapi/core": "npm:^1.4.3"
++    "@emnapi/runtime": "npm:^1.4.3"
++    "@tybys/wasm-util": "npm:^0.10.0"
++  checksum: 10/5fd518182427980c28bc724adf06c5f32f9a8915763ef560b5f7d73607d30cd15ac86d0cbd2eb80d4cfab23fc80d0876d89ca36a9daadcb864bc00917c94187c
++  languageName: node
++  linkType: hard
++
+ "@napi-rs/wasm-runtime@npm:^1.0.1":
+   version: 1.0.3
+   resolution: "@napi-rs/wasm-runtime@npm:1.0.3"
+@@ -7119,6 +7967,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@pkgr/core@npm:^0.2.9":
++  version: 0.2.9
++  resolution: "@pkgr/core@npm:0.2.9"
++  checksum: 10/bb2fb86977d63f836f8f5b09015d74e6af6488f7a411dcd2bfdca79d76b5a681a9112f41c45bdf88a9069f049718efc6f3900d7f1de66a2ec966068308ae517f
++  languageName: node
++  linkType: hard
++
+ "@playwright/test@npm:^1.32.3":
+   version: 1.47.2
+   resolution: "@playwright/test@npm:1.47.2"
+@@ -10200,6 +11055,24 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@sinonjs/commons@npm:^3.0.1":
++  version: 3.0.1
++  resolution: "@sinonjs/commons@npm:3.0.1"
++  dependencies:
++    type-detect: "npm:4.0.8"
++  checksum: 10/a0af217ba7044426c78df52c23cedede6daf377586f3ac58857c565769358ab1f44ebf95ba04bbe38814fba6e316ca6f02870a009328294fc2c555d0f85a7117
++  languageName: node
++  linkType: hard
++
++"@sinonjs/fake-timers@npm:^15.4.0":
++  version: 15.4.0
++  resolution: "@sinonjs/fake-timers@npm:15.4.0"
++  dependencies:
++    "@sinonjs/commons": "npm:^3.0.1"
++  checksum: 10/3960a9fe065f38a4228c66d184eeb101e8a6af9cbfc8454dd5d45ac397201da72134048d4e808a25993494885b172dd6deecdad9949bbf4c1d3a220ef561f6cc
++  languageName: node
++  linkType: hard
++
+ "@smithy/abort-controller@npm:^3.1.4, @smithy/abort-controller@npm:^3.1.5":
+   version: 3.1.5
+   resolution: "@smithy/abort-controller@npm:3.1.5"
+@@ -12094,6 +12967,47 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@types/babel__core@npm:^7.20.5":
++  version: 7.20.5
++  resolution: "@types/babel__core@npm:7.20.5"
++  dependencies:
++    "@babel/parser": "npm:^7.20.7"
++    "@babel/types": "npm:^7.20.7"
++    "@types/babel__generator": "npm:*"
++    "@types/babel__template": "npm:*"
++    "@types/babel__traverse": "npm:*"
++  checksum: 10/c32838d280b5ab59d62557f9e331d3831f8e547ee10b4f85cb78753d97d521270cebfc73ce501e9fb27fe71884d1ba75e18658692c2f4117543f0fc4e3e118b3
++  languageName: node
++  linkType: hard
++
++"@types/babel__generator@npm:*":
++  version: 7.27.0
++  resolution: "@types/babel__generator@npm:7.27.0"
++  dependencies:
++    "@babel/types": "npm:^7.0.0"
++  checksum: 10/f572e67a9a39397664350a4437d8a7fbd34acc83ff4887a8cf08349e39f8aeb5ad2f70fb78a0a0a23a280affe3a5f4c25f50966abdce292bcf31237af1c27b1a
++  languageName: node
++  linkType: hard
++
++"@types/babel__template@npm:*":
++  version: 7.4.4
++  resolution: "@types/babel__template@npm:7.4.4"
++  dependencies:
++    "@babel/parser": "npm:^7.1.0"
++    "@babel/types": "npm:^7.0.0"
++  checksum: 10/d7a02d2a9b67e822694d8e6a7ddb8f2b71a1d6962dfd266554d2513eefbb205b33ca71a0d163b1caea3981ccf849211f9964d8bd0727124d18ace45aa6c9ae29
++  languageName: node
++  linkType: hard
++
++"@types/babel__traverse@npm:*":
++  version: 7.28.0
++  resolution: "@types/babel__traverse@npm:7.28.0"
++  dependencies:
++    "@babel/types": "npm:^7.28.2"
++  checksum: 10/371c5e1b40399ef17570e630b2943617b84fafde2860a56f0ebc113d8edb1d0534ade0175af89eda1ae35160903c33057ed42457e165d4aa287fedab2c82abcf
++  languageName: node
++  linkType: hard
++
+ "@types/body-parser@npm:*":
+   version: 1.19.5
+   resolution: "@types/body-parser@npm:1.19.5"
+@@ -12375,7 +13289,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.6":
++"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1, @types/istanbul-lib-coverage@npm:^2.0.6":
+   version: 2.0.6
+   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
+   checksum: 10/3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
+@@ -12400,6 +13314,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@types/jest@npm:^30":
++  version: 30.0.0
++  resolution: "@types/jest@npm:30.0.0"
++  dependencies:
++    expect: "npm:^30.0.0"
++    pretty-format: "npm:^30.0.0"
++  checksum: 10/cdeaa924c68b5233d9ff92861a89e7042df2b0f197633729bcf3a31e65bd4e9426e751c5665b5ac2de0b222b33f100a5502da22aefce3d2c62931c715e88f209
++  languageName: node
++  linkType: hard
++
+ "@types/js-cookie@npm:^2.2.6":
+   version: 2.2.7
+   resolution: "@types/js-cookie@npm:2.2.7"
+@@ -12407,6 +13331,29 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@types/jsdom@npm:^21.1.7":
++  version: 21.1.7
++  resolution: "@types/jsdom@npm:21.1.7"
++  dependencies:
++    "@types/node": "npm:*"
++    "@types/tough-cookie": "npm:*"
++    parse5: "npm:^7.0.0"
++  checksum: 10/a5ee54aec813ac928ef783f69828213af4d81325f584e1fe7573a9ae139924c40768d1d5249237e62d51b9a34ed06bde059c86c6b0248d627457ec5e5d532dfa
++  languageName: node
++  linkType: hard
++
++"@types/jsdom@npm:^28.0.0":
++  version: 28.0.1
++  resolution: "@types/jsdom@npm:28.0.1"
++  dependencies:
++    "@types/node": "npm:*"
++    "@types/tough-cookie": "npm:*"
++    parse5: "npm:^7.0.0"
++    undici-types: "npm:^7.21.0"
++  checksum: 10/5761f89fb00567bce87ec81f9c926cff9a400e2989615368093a0eed81da122329710f39e13d8388cdde8f6a24d49cde4a94bd194e6d94c61727aeaae694f6bb
++  languageName: node
++  linkType: hard
++
+ "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.11, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.7, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+   version: 7.0.15
+   resolution: "@types/json-schema@npm:7.0.15"
+@@ -12760,6 +13707,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@types/stack-utils@npm:^2.0.3":
++  version: 2.0.3
++  resolution: "@types/stack-utils@npm:2.0.3"
++  checksum: 10/72576cc1522090fe497337c2b99d9838e320659ac57fa5560fcbdcbafcf5d0216c6b3a0a8a4ee4fdb3b1f5e3420aa4f6223ab57b82fef3578bec3206425c6cf5
++  languageName: node
++  linkType: hard
++
+ "@types/statuses@npm:^2.0.4":
+   version: 2.0.5
+   resolution: "@types/statuses@npm:2.0.5"
+@@ -13119,45 +14073,187 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"@useoptic/json-pointer-helpers@npm:0.55.1":
+-  version: 0.55.1
+-  resolution: "@useoptic/json-pointer-helpers@npm:0.55.1"
+-  dependencies:
+-    jsonpointer: "npm:^5.0.1"
+-    minimatch: "npm:9.0.3"
+-  checksum: 10/874db1e25c4abecf29faf95c51d39d127ac50ee9f1ad9654babb3a0257a7c321e54312bf66214ac188e3f92f7e9c342fd81565356c0472689c120ea40465b15d
++"@ungap/structured-clone@npm:^1.3.0":
++  version: 1.3.1
++  resolution: "@ungap/structured-clone@npm:1.3.1"
++  checksum: 10/64df206f50aef71c176f9059c1b29e1694821419c6728c446ecf39c80a811eeef156668bf51421b676494a12fd0129ccf09a44f0c641f13c27f50d5f0db6de4e
+   languageName: node
+   linkType: hard
+ 
+-"@useoptic/openapi-utilities@npm:^0.55.0":
+-  version: 0.55.1
+-  resolution: "@useoptic/openapi-utilities@npm:0.55.1"
+-  dependencies:
+-    "@useoptic/json-pointer-helpers": "npm:0.55.1"
+-    ajv: "npm:^8.6.0"
+-    ajv-errors: "npm:~3.0.0"
+-    ajv-formats: "npm:~2.1.0"
+-    chalk: "npm:^4.1.2"
+-    fast-deep-equal: "npm:^3.1.3"
+-    is-url: "npm:^1.2.4"
+-    js-yaml: "npm:^4.1.0"
+-    json-stable-stringify: "npm:^1.0.1"
+-    lodash.groupby: "npm:^4.6.0"
+-    lodash.isequal: "npm:^4.5.0"
+-    lodash.omit: "npm:^4.5.0"
+-    node-machine-id: "npm:^1.1.12"
+-    openapi-types: "npm:^12.0.2"
+-    ts-invariant: "npm:^0.9.3"
+-    url-join: "npm:^4.0.1"
+-    yaml-ast-parser: "npm:^0.0.43"
+-  checksum: 10/c8580f4201cf643eef702e1e161bfa8e5655d81e9c3ca776470db0d68af44d4f3b6bcfb44ac52f9b4bf85ced3d1c6a80462c89e8b602872adb0532695202d8cd
++"@unrs/resolver-binding-android-arm-eabi@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-android-arm-eabi@npm:1.11.1"
++  conditions: os=android & cpu=arm
+   languageName: node
+   linkType: hard
+ 
+-"@webassemblyjs/ast@npm:1.14.1, @webassemblyjs/ast@npm:^1.14.1":
+-  version: 1.14.1
+-  resolution: "@webassemblyjs/ast@npm:1.14.1"
+-  dependencies:
++"@unrs/resolver-binding-android-arm64@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-android-arm64@npm:1.11.1"
++  conditions: os=android & cpu=arm64
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-darwin-arm64@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-darwin-arm64@npm:1.11.1"
++  conditions: os=darwin & cpu=arm64
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-darwin-x64@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-darwin-x64@npm:1.11.1"
++  conditions: os=darwin & cpu=x64
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-freebsd-x64@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-freebsd-x64@npm:1.11.1"
++  conditions: os=freebsd & cpu=x64
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.11.1"
++  conditions: os=linux & cpu=arm
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-arm-musleabihf@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-arm-musleabihf@npm:1.11.1"
++  conditions: os=linux & cpu=arm
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-arm64-gnu@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-arm64-gnu@npm:1.11.1"
++  conditions: os=linux & cpu=arm64 & libc=glibc
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-arm64-musl@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-arm64-musl@npm:1.11.1"
++  conditions: os=linux & cpu=arm64 & libc=musl
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-ppc64-gnu@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.11.1"
++  conditions: os=linux & cpu=ppc64 & libc=glibc
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-riscv64-gnu@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-riscv64-gnu@npm:1.11.1"
++  conditions: os=linux & cpu=riscv64 & libc=glibc
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-riscv64-musl@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-riscv64-musl@npm:1.11.1"
++  conditions: os=linux & cpu=riscv64 & libc=musl
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-s390x-gnu@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-s390x-gnu@npm:1.11.1"
++  conditions: os=linux & cpu=s390x & libc=glibc
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-x64-gnu@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-x64-gnu@npm:1.11.1"
++  conditions: os=linux & cpu=x64 & libc=glibc
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-linux-x64-musl@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-linux-x64-musl@npm:1.11.1"
++  conditions: os=linux & cpu=x64 & libc=musl
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-wasm32-wasi@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-wasm32-wasi@npm:1.11.1"
++  dependencies:
++    "@napi-rs/wasm-runtime": "npm:^0.2.11"
++  conditions: cpu=wasm32
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-win32-arm64-msvc@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-win32-arm64-msvc@npm:1.11.1"
++  conditions: os=win32 & cpu=arm64
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-win32-ia32-msvc@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-win32-ia32-msvc@npm:1.11.1"
++  conditions: os=win32 & cpu=ia32
++  languageName: node
++  linkType: hard
++
++"@unrs/resolver-binding-win32-x64-msvc@npm:1.11.1":
++  version: 1.11.1
++  resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.11.1"
++  conditions: os=win32 & cpu=x64
++  languageName: node
++  linkType: hard
++
++"@useoptic/json-pointer-helpers@npm:0.55.1":
++  version: 0.55.1
++  resolution: "@useoptic/json-pointer-helpers@npm:0.55.1"
++  dependencies:
++    jsonpointer: "npm:^5.0.1"
++    minimatch: "npm:9.0.3"
++  checksum: 10/874db1e25c4abecf29faf95c51d39d127ac50ee9f1ad9654babb3a0257a7c321e54312bf66214ac188e3f92f7e9c342fd81565356c0472689c120ea40465b15d
++  languageName: node
++  linkType: hard
++
++"@useoptic/openapi-utilities@npm:^0.55.0":
++  version: 0.55.1
++  resolution: "@useoptic/openapi-utilities@npm:0.55.1"
++  dependencies:
++    "@useoptic/json-pointer-helpers": "npm:0.55.1"
++    ajv: "npm:^8.6.0"
++    ajv-errors: "npm:~3.0.0"
++    ajv-formats: "npm:~2.1.0"
++    chalk: "npm:^4.1.2"
++    fast-deep-equal: "npm:^3.1.3"
++    is-url: "npm:^1.2.4"
++    js-yaml: "npm:^4.1.0"
++    json-stable-stringify: "npm:^1.0.1"
++    lodash.groupby: "npm:^4.6.0"
++    lodash.isequal: "npm:^4.5.0"
++    lodash.omit: "npm:^4.5.0"
++    node-machine-id: "npm:^1.1.12"
++    openapi-types: "npm:^12.0.2"
++    ts-invariant: "npm:^0.9.3"
++    url-join: "npm:^4.0.1"
++    yaml-ast-parser: "npm:^0.0.43"
++  checksum: 10/c8580f4201cf643eef702e1e161bfa8e5655d81e9c3ca776470db0d68af44d4f3b6bcfb44ac52f9b4bf85ced3d1c6a80462c89e8b602872adb0532695202d8cd
++  languageName: node
++  linkType: hard
++
++"@webassemblyjs/ast@npm:1.14.1, @webassemblyjs/ast@npm:^1.14.1":
++  version: 1.14.1
++  resolution: "@webassemblyjs/ast@npm:1.14.1"
++  dependencies:
+     "@webassemblyjs/helper-numbers": "npm:1.13.2"
+     "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
+   checksum: 10/f83e6abe38057f5d87c1fb356513a371a8b43c9b87657f2790741a66b1ef8ecf958d1391bc42f27c5fb33f58ab8286a38ea849fdd21f433cd4df1307424bab45
+@@ -13451,6 +14547,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"agent-base@npm:^7.1.2":
++  version: 7.1.4
++  resolution: "agent-base@npm:7.1.4"
++  checksum: 10/79bef167247789f955aaba113bae74bf64aa1e1acca4b1d6bb444bdf91d82c3e07e9451ef6a6e2e35e8f71a6f97ce33e3d855a5328eb9fad1bc3cc4cfd031ed8
++  languageName: node
++  linkType: hard
++
+ "agentkeepalive@npm:^4.1.4":
+   version: 4.5.0
+   resolution: "agentkeepalive@npm:4.5.0"
+@@ -13658,7 +14761,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"ansi-styles@npm:^5.0.0":
++"ansi-styles@npm:^5.0.0, ansi-styles@npm:^5.2.0":
+   version: 5.2.0
+   resolution: "ansi-styles@npm:5.2.0"
+   checksum: 10/d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
+@@ -13679,7 +14782,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"anymatch@npm:~3.1.2":
++"anymatch@npm:^3.1.3, anymatch@npm:~3.1.2":
+   version: 3.1.3
+   resolution: "anymatch@npm:3.1.3"
+   dependencies:
+@@ -14257,6 +15360,45 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"babel-jest@npm:30.4.1":
++  version: 30.4.1
++  resolution: "babel-jest@npm:30.4.1"
++  dependencies:
++    "@jest/transform": "npm:30.4.1"
++    "@types/babel__core": "npm:^7.20.5"
++    babel-plugin-istanbul: "npm:^7.0.1"
++    babel-preset-jest: "npm:30.4.0"
++    chalk: "npm:^4.1.2"
++    graceful-fs: "npm:^4.2.11"
++    slash: "npm:^3.0.0"
++  peerDependencies:
++    "@babel/core": ^7.11.0 || ^8.0.0-0
++  checksum: 10/f739152bee60b368b27676441c54e235b49bca10329bb6395b54cca5982ced1f7a5a2c504e406e1082aac3dc68ab518771c9de62cf66ffe00993ad071a58fd1b
++  languageName: node
++  linkType: hard
++
++"babel-plugin-istanbul@npm:^7.0.1":
++  version: 7.0.1
++  resolution: "babel-plugin-istanbul@npm:7.0.1"
++  dependencies:
++    "@babel/helper-plugin-utils": "npm:^7.0.0"
++    "@istanbuljs/load-nyc-config": "npm:^1.0.0"
++    "@istanbuljs/schema": "npm:^0.1.3"
++    istanbul-lib-instrument: "npm:^6.0.2"
++    test-exclude: "npm:^6.0.0"
++  checksum: 10/fe9f865f975aaa7a033de9ccb2b63fdcca7817266c5e98d3e02ac7ffd774c695093d215302796cb3770a71ef4574e7a9b298504c3c0c104cf4b48c8eda67b2a6
++  languageName: node
++  linkType: hard
++
++"babel-plugin-jest-hoist@npm:30.4.0":
++  version: 30.4.0
++  resolution: "babel-plugin-jest-hoist@npm:30.4.0"
++  dependencies:
++    "@types/babel__core": "npm:^7.20.5"
++  checksum: 10/112f984b3b4315f7ff15d5d17df7f5aa4b500e562c67c2eafcd9974af4369c17d50feed2f9c95cbcec32faba8ccb04f8b62828aca41a47d5fdedc532b49fbf19
++  languageName: node
++  linkType: hard
++
+ "babel-plugin-macros@npm:^3.1.0":
+   version: 3.1.0
+   resolution: "babel-plugin-macros@npm:3.1.0"
+@@ -14279,6 +15421,43 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"babel-preset-current-node-syntax@npm:^1.2.0":
++  version: 1.2.0
++  resolution: "babel-preset-current-node-syntax@npm:1.2.0"
++  dependencies:
++    "@babel/plugin-syntax-async-generators": "npm:^7.8.4"
++    "@babel/plugin-syntax-bigint": "npm:^7.8.3"
++    "@babel/plugin-syntax-class-properties": "npm:^7.12.13"
++    "@babel/plugin-syntax-class-static-block": "npm:^7.14.5"
++    "@babel/plugin-syntax-import-attributes": "npm:^7.24.7"
++    "@babel/plugin-syntax-import-meta": "npm:^7.10.4"
++    "@babel/plugin-syntax-json-strings": "npm:^7.8.3"
++    "@babel/plugin-syntax-logical-assignment-operators": "npm:^7.10.4"
++    "@babel/plugin-syntax-nullish-coalescing-operator": "npm:^7.8.3"
++    "@babel/plugin-syntax-numeric-separator": "npm:^7.10.4"
++    "@babel/plugin-syntax-object-rest-spread": "npm:^7.8.3"
++    "@babel/plugin-syntax-optional-catch-binding": "npm:^7.8.3"
++    "@babel/plugin-syntax-optional-chaining": "npm:^7.8.3"
++    "@babel/plugin-syntax-private-property-in-object": "npm:^7.14.5"
++    "@babel/plugin-syntax-top-level-await": "npm:^7.14.5"
++  peerDependencies:
++    "@babel/core": ^7.0.0 || ^8.0.0-0
++  checksum: 10/3608fa671cfa46364ea6ec704b8fcdd7514b7b70e6ec09b1199e13ae73ed346c51d5ce2cb6d4d5b295f6a3f2cad1fdeec2308aa9e037002dd7c929194cc838ea
++  languageName: node
++  linkType: hard
++
++"babel-preset-jest@npm:30.4.0":
++  version: 30.4.0
++  resolution: "babel-preset-jest@npm:30.4.0"
++  dependencies:
++    babel-plugin-jest-hoist: "npm:30.4.0"
++    babel-preset-current-node-syntax: "npm:^1.2.0"
++  peerDependencies:
++    "@babel/core": ^7.11.0 || ^8.0.0-beta.1
++  checksum: 10/7fbdcaa1f24b2efbc1b658220df849a375858bd5e208cefcf53b116bca972b28565a0715521cc20bec41adbd20ff73b9dbbdea3634bd71f50062f0ce694a7159
++  languageName: node
++  linkType: hard
++
+ "babel-runtime@npm:^6.26.0":
+   version: 6.26.0
+   resolution: "babel-runtime@npm:6.26.0"
+@@ -14441,6 +15620,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"baseline-browser-mapping@npm:^2.10.12":
++  version: 2.10.28
++  resolution: "baseline-browser-mapping@npm:2.10.28"
++  bin:
++    baseline-browser-mapping: dist/cli.cjs
++  checksum: 10/27a18f770acc03dd73f1eb0b65ed58ab847c740552dd941afe27c4cf75e06dd91bec0cedf5b604016840f7365da54614f4040b03d57ec27a53592a1875d61e37
++  languageName: node
++  linkType: hard
++
+ "baseline-browser-mapping@npm:^2.9.0":
+   version: 2.10.10
+   resolution: "baseline-browser-mapping@npm:2.10.10"
+@@ -14511,6 +15699,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"bidi-js@npm:^1.0.3":
++  version: 1.0.3
++  resolution: "bidi-js@npm:1.0.3"
++  dependencies:
++    require-from-string: "npm:^2.0.2"
++  checksum: 10/c4341c7a98797efe3d186cd99d6f97e9030a4f959794ca200ef2ec0a678483a916335bba6c2c0608a21d04a221288a31c9fd0faa0cd9b3903b93594b42466a6a
++  languageName: node
++  linkType: hard
++
+ "big.js@npm:^5.2.2":
+   version: 5.2.2
+   resolution: "big.js@npm:5.2.2"
+@@ -14780,6 +15977,30 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"browserslist@npm:^4.24.0":
++  version: 4.28.2
++  resolution: "browserslist@npm:4.28.2"
++  dependencies:
++    baseline-browser-mapping: "npm:^2.10.12"
++    caniuse-lite: "npm:^1.0.30001782"
++    electron-to-chromium: "npm:^1.5.328"
++    node-releases: "npm:^2.0.36"
++    update-browserslist-db: "npm:^1.2.3"
++  bin:
++    browserslist: cli.js
++  checksum: 10/cff88386e5b5ba5614c9063bd32ef94865bba22b6a381844c7d09ea1eea62a2247e7106e516abdbfda6b75b9986044c991dfe45f92f10add5ad63dccc07589ec
++  languageName: node
++  linkType: hard
++
++"bser@npm:2.1.1":
++  version: 2.1.1
++  resolution: "bser@npm:2.1.1"
++  dependencies:
++    node-int64: "npm:^0.4.0"
++  checksum: 10/edba1b65bae682450be4117b695997972bd9a3c4dfee029cab5bcb72ae5393a79a8f909b8bc77957eb0deec1c7168670f18f4d5c556f46cdd3bca5f3b3a8d020
++  languageName: node
++  linkType: hard
++
+ "btoa-lite@npm:^1.0.0":
+   version: 1.0.0
+   resolution: "btoa-lite@npm:1.0.0"
+@@ -14989,7 +16210,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"callsites@npm:^3.0.0":
++"callsites@npm:^3.0.0, callsites@npm:^3.1.0":
+   version: 3.1.0
+   resolution: "callsites@npm:3.1.0"
+   checksum: 10/072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
+@@ -15013,6 +16234,20 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"camelcase@npm:^5.3.1":
++  version: 5.3.1
++  resolution: "camelcase@npm:5.3.1"
++  checksum: 10/e6effce26b9404e3c0f301498184f243811c30dfe6d0b9051863bd8e4034d09c8c2923794f280d6827e5aa055f6c434115ff97864a16a963366fb35fd673024b
++  languageName: node
++  linkType: hard
++
++"camelcase@npm:^6.3.0":
++  version: 6.3.0
++  resolution: "camelcase@npm:6.3.0"
++  checksum: 10/8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
++  languageName: node
++  linkType: hard
++
+ "camelize@npm:^1.0.0":
+   version: 1.0.1
+   resolution: "camelize@npm:1.0.1"
+@@ -15039,6 +16274,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"caniuse-lite@npm:^1.0.30001782":
++  version: 1.0.30001792
++  resolution: "caniuse-lite@npm:1.0.30001792"
++  checksum: 10/96635acd22e8bd5d02c165de659cc14265b96f5e7253acd0117ad94a3310297f2402e4a8665d6f20003bf6193c3b995d2cb9fda6b3c2f731194dc9299c90f905
++  languageName: node
++  linkType: hard
++
+ "ccount@npm:^2.0.0":
+   version: 2.0.1
+   resolution: "ccount@npm:2.0.1"
+@@ -15077,6 +16319,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"char-regex@npm:^1.0.2":
++  version: 1.0.2
++  resolution: "char-regex@npm:1.0.2"
++  checksum: 10/1ec5c2906adb9f84e7f6732a40baef05d7c85401b82ffcbc44b85fbd0f7a2b0c2a96f2eb9cf55cae3235dc12d4023003b88f09bcae8be9ae894f52ed746f4d48
++  languageName: node
++  linkType: hard
++
+ "character-entities-legacy@npm:^1.0.0":
+   version: 1.1.4
+   resolution: "character-entities-legacy@npm:1.1.4"
+@@ -15182,6 +16431,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"ci-info@npm:^4.2.0":
++  version: 4.4.0
++  resolution: "ci-info@npm:4.4.0"
++  checksum: 10/dfded0c630267d89660c8abb988ac8395a382bdfefedcc03e3e2858523312c5207db777c239c34774e3fcff11f015477c19d2ac8a58ea58aa476614a2e64f434
++  languageName: node
++  linkType: hard
++
+ "cipher-base@npm:^1.0.0, cipher-base@npm:^1.0.1, cipher-base@npm:^1.0.3":
+   version: 1.0.4
+   resolution: "cipher-base@npm:1.0.4"
+@@ -15192,6 +16448,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"cjs-module-lexer@npm:^2.1.0":
++  version: 2.2.0
++  resolution: "cjs-module-lexer@npm:2.2.0"
++  checksum: 10/fc8eb5c1919504366d8260a150d93c4e857740e770467dc59ca0cc34de4b66c93075559a5af65618f359187866b1be40e036f4e1a1bab2f1e06001c216415f74
++  languageName: node
++  linkType: hard
++
+ "classnames@npm:^2.2.6, classnames@npm:^2.3.1, classnames@npm:^2.5.1":
+   version: 2.5.1
+   resolution: "classnames@npm:2.5.1"
+@@ -15326,6 +16589,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"co@npm:^4.6.0":
++  version: 4.6.0
++  resolution: "co@npm:4.6.0"
++  checksum: 10/a5d9f37091c70398a269e625cedff5622f200ed0aa0cff22ee7b55ed74a123834b58711776eb0f1dc58eb6ebbc1185aa7567b57bd5979a948c6e4f85073e2c05
++  languageName: node
++  linkType: hard
++
+ "code-block-writer@npm:^13.0.3":
+   version: 13.0.3
+   resolution: "code-block-writer@npm:13.0.3"
+@@ -15381,6 +16651,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"collect-v8-coverage@npm:^1.0.2":
++  version: 1.0.3
++  resolution: "collect-v8-coverage@npm:1.0.3"
++  checksum: 10/656443261fb7b79cf79e89cba4b55622b07c1d4976c630829d7c5c585c73cda1c2ff101f316bfb19bb9e2c58d724c7db1f70a21e213dcd14099227c5e6019860
++  languageName: node
++  linkType: hard
++
+ "color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
+   version: 1.9.3
+   resolution: "color-convert@npm:1.9.3"
+@@ -15790,6 +17067,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"convert-source-map@npm:^2.0.0":
++  version: 2.0.0
++  resolution: "convert-source-map@npm:2.0.0"
++  checksum: 10/c987be3ec061348cdb3c2bfb924bec86dea1eacad10550a85ca23edb0fe3556c3a61c7399114f3331ccb3499d7fd0285ab24566e5745929412983494c3926e15
++  languageName: node
++  linkType: hard
++
+ "cookie-parser@npm:^1.4.5":
+   version: 1.4.6
+   resolution: "cookie-parser@npm:1.4.6"
+@@ -16230,6 +17514,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"css-tree@npm:^3.1.0":
++  version: 3.2.1
++  resolution: "css-tree@npm:3.2.1"
++  dependencies:
++    mdn-data: "npm:2.27.1"
++    source-map-js: "npm:^1.2.1"
++  checksum: 10/9945b387bdec756738c34d64b8287f05ca6645f51d1c8abaaa5822ec3e74533604103aaad164b8100afd8495e92120be7c1c6afbe5be89f867acc5b456ddd79c
++  languageName: node
++  linkType: hard
++
+ "css-vendor@npm:^2.0.8":
+   version: 2.0.8
+   resolution: "css-vendor@npm:2.0.8"
+@@ -16342,6 +17636,18 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"cssstyle@npm:^5.3.4":
++  version: 5.3.7
++  resolution: "cssstyle@npm:5.3.7"
++  dependencies:
++    "@asamuzakjp/css-color": "npm:^4.1.1"
++    "@csstools/css-syntax-patches-for-csstree": "npm:^1.0.21"
++    css-tree: "npm:^3.1.0"
++    lru-cache: "npm:^11.2.4"
++  checksum: 10/bd4469af81f068537dbbce53c4247f192e91202c19abc066b77b4ee7bbf256526bc82471198bec762ac70ea53ce17b8044aec69fd7982d2d0fd9fd7780329e2d
++  languageName: node
++  linkType: hard
++
+ "csstype@npm:3.1.3, csstype@npm:^3.0.2, csstype@npm:^3.1.2, csstype@npm:^3.1.3":
+   version: 3.1.3
+   resolution: "csstype@npm:3.1.3"
+@@ -16503,6 +17809,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"data-urls@npm:^6.0.0":
++  version: 6.0.1
++  resolution: "data-urls@npm:6.0.1"
++  dependencies:
++    whatwg-mimetype: "npm:^5.0.0"
++    whatwg-url: "npm:^15.1.0"
++  checksum: 10/6ab8025df0ee497bfb12241f815fd3f3438dd34cd851c0801c16aa4e1e70f4f68d6334e3176ca340fe4084622b8a299a98b3d3059bbca671f1eaf8bae1088ec2
++  languageName: node
++  linkType: hard
++
+ "data-view-buffer@npm:^1.0.2":
+   version: 1.0.2
+   resolution: "data-view-buffer@npm:1.0.2"
+@@ -16629,6 +17945,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"decimal.js@npm:^10.6.0":
++  version: 10.6.0
++  resolution: "decimal.js@npm:10.6.0"
++  checksum: 10/c0d45842d47c311d11b38ce7ccc911121953d4df3ebb1465d92b31970eb4f6738a065426a06094af59bee4b0d64e42e7c8984abd57b6767c64ea90cf90bb4a69
++  languageName: node
++  linkType: hard
++
+ "decode-named-character-reference@npm:^1.0.0":
+   version: 1.0.2
+   resolution: "decode-named-character-reference@npm:1.0.2"
+@@ -16647,6 +17970,18 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"dedent@npm:^1.6.0":
++  version: 1.7.2
++  resolution: "dedent@npm:1.7.2"
++  peerDependencies:
++    babel-plugin-macros: ^3.1.0
++  peerDependenciesMeta:
++    babel-plugin-macros:
++      optional: true
++  checksum: 10/30b9062290dca72b0f5a6cd3667633448cef8cd0dec602eab61015741269ad49df90cabf0521f9a32d134ceab4e21aa7f097258c55cc3baadef94874686d6480
++  languageName: node
++  linkType: hard
++
+ "deep-equal@npm:^2.0.5":
+   version: 2.2.3
+   resolution: "deep-equal@npm:2.2.3"
+@@ -16879,6 +18214,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"detect-newline@npm:^3.1.0":
++  version: 3.1.0
++  resolution: "detect-newline@npm:3.1.0"
++  checksum: 10/ae6cd429c41ad01b164c59ea36f264a2c479598e61cba7c99da24175a7ab80ddf066420f2bec9a1c57a6bead411b4655ff15ad7d281c000a89791f48cbe939e7
++  languageName: node
++  linkType: hard
++
+ "detect-node-es@npm:^1.1.0":
+   version: 1.1.0
+   resolution: "detect-node-es@npm:1.1.0"
+@@ -17266,6 +18608,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"electron-to-chromium@npm:^1.5.328":
++  version: 1.5.352
++  resolution: "electron-to-chromium@npm:1.5.352"
++  checksum: 10/c32597ccad678c1af2155992112b56ea5fbab17e5de0cb968c3528ee5706fe8adb39cc1b02c8bde72d9d4cad1e999e3eee9d187a0bb7be998768b37f60003f65
++  languageName: node
++  linkType: hard
++
+ "elliptic@npm:^6.5.3, elliptic@npm:^6.5.5":
+   version: 6.5.7
+   resolution: "elliptic@npm:6.5.7"
+@@ -17281,6 +18630,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"emittery@npm:^0.13.1":
++  version: 0.13.1
++  resolution: "emittery@npm:0.13.1"
++  checksum: 10/fbe214171d878b924eedf1757badf58a5dce071cd1fa7f620fa841a0901a80d6da47ff05929d53163105e621ce11a71b9d8acb1148ffe1745e045145f6e69521
++  languageName: node
++  linkType: hard
++
+ "emoji-regex@npm:^8.0.0":
+   version: 8.0.0
+   resolution: "emoji-regex@npm:8.0.0"
+@@ -17375,8 +18731,22 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"env-paths@npm:^2.2.0":
+-  version: 2.2.1
++"entities@npm:^6.0.0":
++  version: 6.0.1
++  resolution: "entities@npm:6.0.1"
++  checksum: 10/62af1307202884349d2867f0aac5c60d8b57102ea0b0e768b16246099512c28e239254ad772d6834e7e14cb1b6f153fc3d0c031934e3183b086c86d3838d874a
++  languageName: node
++  linkType: hard
++
++"entities@npm:^8.0.0":
++  version: 8.0.0
++  resolution: "entities@npm:8.0.0"
++  checksum: 10/d6e2ba75e444fb101ee2fbb07c839e687306c8a509426b75186619c19196f97c1db9932ca083f823c03e4a20e7407b654aa34de8cbb7770468e20fb2d4573a0e
++  languageName: node
++  linkType: hard
++
++"env-paths@npm:^2.2.0":
++  version: 2.2.1
+   resolution: "env-paths@npm:2.2.1"
+   checksum: 10/65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
+   languageName: node
+@@ -17723,6 +19093,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"escape-string-regexp@npm:^2.0.0":
++  version: 2.0.0
++  resolution: "escape-string-regexp@npm:2.0.0"
++  checksum: 10/9f8a2d5743677c16e85c810e3024d54f0c8dea6424fad3c79ef6666e81dd0846f7437f5e729dfcdac8981bc9e5294c39b4580814d114076b8d36318f46ae4395
++  languageName: node
++  linkType: hard
++
+ "escape-string-regexp@npm:^4.0.0":
+   version: 4.0.0
+   resolution: "escape-string-regexp@npm:4.0.0"
+@@ -18187,6 +19564,30 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"execa@npm:^5.1.1":
++  version: 5.1.1
++  resolution: "execa@npm:5.1.1"
++  dependencies:
++    cross-spawn: "npm:^7.0.3"
++    get-stream: "npm:^6.0.0"
++    human-signals: "npm:^2.1.0"
++    is-stream: "npm:^2.0.0"
++    merge-stream: "npm:^2.0.0"
++    npm-run-path: "npm:^4.0.1"
++    onetime: "npm:^5.1.2"
++    signal-exit: "npm:^3.0.3"
++    strip-final-newline: "npm:^2.0.0"
++  checksum: 10/8ada91f2d70f7dff702c861c2c64f21dfdc1525628f3c0454fd6f02fce65f7b958616cbd2b99ca7fa4d474e461a3d363824e91b3eb881705231abbf387470597
++  languageName: node
++  linkType: hard
++
++"exit-x@npm:^0.2.2":
++  version: 0.2.2
++  resolution: "exit-x@npm:0.2.2"
++  checksum: 10/ee043053e6c1e237adf5ad9c4faf9f085b606f64a4ff859e2b138fab63fe642711d00c9af452a9134c4c92c55f752e818bfabab78c24d345022db163f3137027
++  languageName: node
++  linkType: hard
++
+ "expand-template@npm:^2.0.3":
+   version: 2.0.3
+   resolution: "expand-template@npm:2.0.3"
+@@ -18203,6 +19604,20 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"expect@npm:30.4.1, expect@npm:^30.0.0":
++  version: 30.4.1
++  resolution: "expect@npm:30.4.1"
++  dependencies:
++    "@jest/expect-utils": "npm:30.4.1"
++    "@jest/get-type": "npm:30.1.0"
++    jest-matcher-utils: "npm:30.4.1"
++    jest-message-util: "npm:30.4.1"
++    jest-mock: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++  checksum: 10/f25051e5073c55369199ec3108ac01c60074bd09dad0b5a6c9fe40596438051cb52607e0e97505126422535b8d0dacab13aa29bb14e9fac71630bc710201a3f1
++  languageName: node
++  linkType: hard
++
+ "exponential-backoff@npm:^3.1.1":
+   version: 3.1.1
+   resolution: "exponential-backoff@npm:3.1.1"
+@@ -18502,6 +19917,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"fb-watchman@npm:^2.0.2":
++  version: 2.0.2
++  resolution: "fb-watchman@npm:2.0.2"
++  dependencies:
++    bser: "npm:2.1.1"
++  checksum: 10/4f95d336fb805786759e383fd7fff342ceb7680f53efcc0ef82f502eb479ce35b98e8b207b6dfdfeea0eba845862107dc73813775fc6b56b3098c6e90a2dad77
++  languageName: node
++  linkType: hard
++
+ "fdir@npm:^6.4.2":
+   version: 6.4.2
+   resolution: "fdir@npm:6.4.2"
+@@ -18637,7 +20061,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"find-up@npm:^4.1.0":
++"find-up@npm:^4.0.0, find-up@npm:^4.1.0":
+   version: 4.1.0
+   resolution: "find-up@npm:4.1.0"
+   dependencies:
+@@ -19028,7 +20452,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"fsevents@npm:~2.3.2":
++"fsevents@npm:^2.3.3, fsevents@npm:~2.3.2":
+   version: 2.3.3
+   resolution: "fsevents@npm:2.3.3"
+   dependencies:
+@@ -19047,7 +20471,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
++"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+   version: 2.3.3
+   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
+   dependencies:
+@@ -19139,6 +20563,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"gensync@npm:^1.0.0-beta.2":
++  version: 1.0.0-beta.2
++  resolution: "gensync@npm:1.0.0-beta.2"
++  checksum: 10/17d8333460204fbf1f9160d067e1e77f908a5447febb49424b8ab043026049835c9ef3974445c57dbd39161f4d2b04356d7de12b2eecaa27a7a7ea7d871cbedd
++  languageName: node
++  linkType: hard
++
+ "get-caller-file@npm:^2.0.5":
+   version: 2.0.5
+   resolution: "get-caller-file@npm:2.0.5"
+@@ -19202,6 +20633,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"get-stream@npm:^6.0.0":
++  version: 6.0.1
++  resolution: "get-stream@npm:6.0.1"
++  checksum: 10/781266d29725f35c59f1d214aedc92b0ae855800a980800e2923b3fbc4e56b3cb6e462c42e09a1cf1a00c64e056a78fa407cbe06c7c92b7e5cd49b4b85c2a497
++  languageName: node
++  linkType: hard
++
+ "get-symbol-description@npm:^1.1.0":
+   version: 1.1.0
+   resolution: "get-symbol-description@npm:1.1.0"
+@@ -19301,7 +20739,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"glob@npm:7.2.3, glob@npm:^7.1.3, glob@npm:^7.1.6, glob@npm:^7.1.7":
++"glob@npm:7.2.3, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.1.7":
+   version: 7.2.3
+   resolution: "glob@npm:7.2.3"
+   dependencies:
+@@ -19331,6 +20769,22 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"glob@npm:^10.5.0":
++  version: 10.5.0
++  resolution: "glob@npm:10.5.0"
++  dependencies:
++    foreground-child: "npm:^3.1.0"
++    jackspeak: "npm:^3.1.2"
++    minimatch: "npm:^9.0.4"
++    minipass: "npm:^7.1.2"
++    package-json-from-dist: "npm:^1.0.0"
++    path-scurry: "npm:^1.11.1"
++  bin:
++    glob: dist/esm/bin.mjs
++  checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
++  languageName: node
++  linkType: hard
++
+ "glob@npm:^8.0.1, glob@npm:^8.0.3, glob@npm:^8.1.0":
+   version: 8.1.0
+   resolution: "glob@npm:8.1.0"
+@@ -19949,6 +21403,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"html-encoding-sniffer@npm:^6.0.0":
++  version: 6.0.0
++  resolution: "html-encoding-sniffer@npm:6.0.0"
++  dependencies:
++    "@exodus/bytes": "npm:^1.6.0"
++  checksum: 10/97392e45d8aff57f180f62a1b12e62201c8451af68424b8bc3196f78e273891f2df285e5be43a3f28c7ba4badf9524ef305db65c4e4935a9e796afc86d9654b8
++  languageName: node
++  linkType: hard
++
+ "html-entities@npm:^2.1.0, html-entities@npm:^2.5.2, html-entities@npm:^2.6.0":
+   version: 2.6.0
+   resolution: "html-entities@npm:2.6.0"
+@@ -19956,6 +21419,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"html-escaper@npm:^2.0.0":
++  version: 2.0.2
++  resolution: "html-escaper@npm:2.0.2"
++  checksum: 10/034d74029dcca544a34fb6135e98d427acd73019796ffc17383eaa3ec2fe1c0471dcbbc8f8ed39e46e86d43ccd753a160631615e4048285e313569609b66d5b7
++  languageName: node
++  linkType: hard
++
+ "html-minifier-terser@npm:^6.0.2":
+   version: 6.1.0
+   resolution: "html-minifier-terser@npm:6.1.0"
+@@ -20190,6 +21660,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"https-proxy-agent@npm:^7.0.6":
++  version: 7.0.6
++  resolution: "https-proxy-agent@npm:7.0.6"
++  dependencies:
++    agent-base: "npm:^7.1.2"
++    debug: "npm:4"
++  checksum: 10/784b628cbd55b25542a9d85033bdfd03d4eda630fb8b3c9477959367f3be95dc476ed2ecbb9836c359c7c698027fc7b45723a302324433590f45d6c1706e8c13
++  languageName: node
++  linkType: hard
++
+ "human-id@npm:^1.0.2":
+   version: 1.0.2
+   resolution: "human-id@npm:1.0.2"
+@@ -20197,6 +21677,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"human-signals@npm:^2.1.0":
++  version: 2.1.0
++  resolution: "human-signals@npm:2.1.0"
++  checksum: 10/df59be9e0af479036798a881d1f136c4a29e0b518d4abb863afbd11bf30efa3eeb1d0425fc65942dcc05ab3bf40205ea436b0ff389f2cd20b75b8643d539bf86
++  languageName: node
++  linkType: hard
++
+ "humanize-duration@npm:^3.25.1":
+   version: 3.32.1
+   resolution: "humanize-duration@npm:3.32.1"
+@@ -20367,6 +21854,18 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"import-local@npm:^3.2.0":
++  version: 3.2.0
++  resolution: "import-local@npm:3.2.0"
++  dependencies:
++    pkg-dir: "npm:^4.2.0"
++    resolve-cwd: "npm:^3.0.0"
++  bin:
++    import-local-fixture: fixtures/cli.js
++  checksum: 10/0b0b0b412b2521739fbb85eeed834a3c34de9bc67e670b3d0b86248fc460d990a7b116ad056c084b87a693ef73d1f17268d6a5be626bb43c998a8b1c8a230004
++  languageName: node
++  linkType: hard
++
+ "imurmurhash@npm:^0.1.4":
+   version: 0.1.4
+   resolution: "imurmurhash@npm:0.1.4"
+@@ -20732,6 +22231,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"is-generator-fn@npm:^2.1.0":
++  version: 2.1.0
++  resolution: "is-generator-fn@npm:2.1.0"
++  checksum: 10/a6ad5492cf9d1746f73b6744e0c43c0020510b59d56ddcb78a91cbc173f09b5e6beff53d75c9c5a29feb618bfef2bf458e025ecf3a57ad2268e2fb2569f56215
++  languageName: node
++  linkType: hard
++
+ "is-generator-function@npm:^1.0.10, is-generator-function@npm:^1.0.7":
+   version: 1.0.10
+   resolution: "is-generator-function@npm:1.0.10"
+@@ -21190,6 +22696,58 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
++  version: 3.2.2
++  resolution: "istanbul-lib-coverage@npm:3.2.2"
++  checksum: 10/40bbdd1e937dfd8c830fa286d0f665e81b7a78bdabcd4565f6d5667c99828bda3db7fb7ac6b96a3e2e8a2461ddbc5452d9f8bc7d00cb00075fa6a3e99f5b6a81
++  languageName: node
++  linkType: hard
++
++"istanbul-lib-instrument@npm:^6.0.0, istanbul-lib-instrument@npm:^6.0.2":
++  version: 6.0.3
++  resolution: "istanbul-lib-instrument@npm:6.0.3"
++  dependencies:
++    "@babel/core": "npm:^7.23.9"
++    "@babel/parser": "npm:^7.23.9"
++    "@istanbuljs/schema": "npm:^0.1.3"
++    istanbul-lib-coverage: "npm:^3.2.0"
++    semver: "npm:^7.5.4"
++  checksum: 10/aa5271c0008dfa71b6ecc9ba1e801bf77b49dc05524e8c30d58aaf5b9505e0cd12f25f93165464d4266a518c5c75284ecb598fbd89fec081ae77d2c9d3327695
++  languageName: node
++  linkType: hard
++
++"istanbul-lib-report@npm:^3.0.0":
++  version: 3.0.1
++  resolution: "istanbul-lib-report@npm:3.0.1"
++  dependencies:
++    istanbul-lib-coverage: "npm:^3.0.0"
++    make-dir: "npm:^4.0.0"
++    supports-color: "npm:^7.1.0"
++  checksum: 10/86a83421ca1cf2109a9f6d193c06c31ef04a45e72a74579b11060b1e7bb9b6337a4e6f04abfb8857e2d569c271273c65e855ee429376a0d7c91ad91db42accd1
++  languageName: node
++  linkType: hard
++
++"istanbul-lib-source-maps@npm:^5.0.0":
++  version: 5.0.6
++  resolution: "istanbul-lib-source-maps@npm:5.0.6"
++  dependencies:
++    "@jridgewell/trace-mapping": "npm:^0.3.23"
++    debug: "npm:^4.1.1"
++    istanbul-lib-coverage: "npm:^3.0.0"
++  checksum: 10/569dd0a392ee3464b1fe1accbaef5cc26de3479eacb5b91d8c67ebb7b425d39fd02247d85649c3a0e9c29b600809fa60b5af5a281a75a89c01f385b1e24823a2
++  languageName: node
++  linkType: hard
++
++"istanbul-reports@npm:^3.1.3":
++  version: 3.2.0
++  resolution: "istanbul-reports@npm:3.2.0"
++  dependencies:
++    html-escaper: "npm:^2.0.0"
++    istanbul-lib-report: "npm:^3.0.0"
++  checksum: 10/6773a1d5c7d47eeec75b317144fe2a3b1da84a44b6282bebdc856e09667865e58c9b025b75b3d87f5bc62939126cbba4c871ee84254537d934ba5da5d4c4ec4e
++  languageName: node
++  linkType: hard
++
+ "iterall@npm:^1.2.1, iterall@npm:^1.3.0":
+   version: 1.3.0
+   resolution: "iterall@npm:1.3.0"
+@@ -21231,6 +22789,112 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"jest-changed-files@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-changed-files@npm:30.4.1"
++  dependencies:
++    execa: "npm:^5.1.1"
++    jest-util: "npm:30.4.1"
++    p-limit: "npm:^3.1.0"
++  checksum: 10/e566af0d6c53115edf34fd1d9bda3b857fcc6626bd032516a480b60ec208d515558eda1e693e76ef992633d71828a4c38a3e91a236142459855483cbd03ff4c4
++  languageName: node
++  linkType: hard
++
++"jest-circus@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-circus@npm:30.4.1"
++  dependencies:
++    "@jest/environment": "npm:30.4.1"
++    "@jest/expect": "npm:30.4.1"
++    "@jest/test-result": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    chalk: "npm:^4.1.2"
++    co: "npm:^4.6.0"
++    dedent: "npm:^1.6.0"
++    is-generator-fn: "npm:^2.1.0"
++    jest-each: "npm:30.4.1"
++    jest-matcher-utils: "npm:30.4.1"
++    jest-message-util: "npm:30.4.1"
++    jest-runtime: "npm:30.4.1"
++    jest-snapshot: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    p-limit: "npm:^3.1.0"
++    pretty-format: "npm:30.4.1"
++    pure-rand: "npm:^7.0.0"
++    slash: "npm:^3.0.0"
++    stack-utils: "npm:^2.0.6"
++  checksum: 10/768ba9d728f3daa065bfd56cbe938cfdd72065afb49002b78d767938bc8ec24a4ea68bd26236eb7d5bcf4f6194aa1e6b38671ee276b9010fbf8aeaa931448613
++  languageName: node
++  linkType: hard
++
++"jest-cli@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-cli@npm:30.4.1"
++  dependencies:
++    "@jest/core": "npm:30.4.1"
++    "@jest/test-result": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    chalk: "npm:^4.1.2"
++    exit-x: "npm:^0.2.2"
++    import-local: "npm:^3.2.0"
++    jest-config: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    jest-validate: "npm:30.4.1"
++    yargs: "npm:^17.7.2"
++  peerDependencies:
++    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
++  peerDependenciesMeta:
++    node-notifier:
++      optional: true
++  bin:
++    jest: ./bin/jest.js
++  checksum: 10/cb1d0d4d8f99027d1f44c3529d2880ddb54014970d87d376b2305059a9a1ad67e12c9e1ffc5c092b4ce081d40dc073bee5efcfed443c782c0b65505ea295cd1d
++  languageName: node
++  linkType: hard
++
++"jest-config@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-config@npm:30.4.1"
++  dependencies:
++    "@babel/core": "npm:^7.27.4"
++    "@jest/get-type": "npm:30.1.0"
++    "@jest/pattern": "npm:30.4.0"
++    "@jest/test-sequencer": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    babel-jest: "npm:30.4.1"
++    chalk: "npm:^4.1.2"
++    ci-info: "npm:^4.2.0"
++    deepmerge: "npm:^4.3.1"
++    glob: "npm:^10.5.0"
++    graceful-fs: "npm:^4.2.11"
++    jest-circus: "npm:30.4.1"
++    jest-docblock: "npm:30.4.0"
++    jest-environment-node: "npm:30.4.1"
++    jest-regex-util: "npm:30.4.0"
++    jest-resolve: "npm:30.4.1"
++    jest-runner: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    jest-validate: "npm:30.4.1"
++    parse-json: "npm:^5.2.0"
++    pretty-format: "npm:30.4.1"
++    slash: "npm:^3.0.0"
++    strip-json-comments: "npm:^3.1.1"
++  peerDependencies:
++    "@types/node": "*"
++    esbuild-register: ">=3.4.0"
++    ts-node: ">=9.0.0"
++  peerDependenciesMeta:
++    "@types/node":
++      optional: true
++    esbuild-register:
++      optional: true
++    ts-node:
++      optional: true
++  checksum: 10/e04ba72a13a1e2d47f98177c94349c610444a0adc90c0a320bad92f3a1688242ae3f2760c2812e71aa8781833a6fa5be9683d79e6de9fff46cc52489f2ebb4e1
++  languageName: node
++  linkType: hard
++
+ "jest-css-modules@npm:^2.1.0":
+   version: 2.1.0
+   resolution: "jest-css-modules@npm:2.1.0"
+@@ -21240,6 +22904,140 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"jest-diff@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-diff@npm:30.4.1"
++  dependencies:
++    "@jest/diff-sequences": "npm:30.4.0"
++    "@jest/get-type": "npm:30.1.0"
++    chalk: "npm:^4.1.2"
++    pretty-format: "npm:30.4.1"
++  checksum: 10/594212df96bf101170afdb7eebd188d6d7d27241cbdd18b61d95f1142a3c94ae3b270377d15e719fb3c5efe4458d32acba8ad13dd6230dd7d6917a9eebb32625
++  languageName: node
++  linkType: hard
++
++"jest-docblock@npm:30.4.0":
++  version: 30.4.0
++  resolution: "jest-docblock@npm:30.4.0"
++  dependencies:
++    detect-newline: "npm:^3.1.0"
++  checksum: 10/0ee25351ef941e832e53d10e74f34b38941b8f5fe750584661f6c5a115771818b081b8e39830c49d152fd361af81c7800c2d3a3c3a0e2dc742f7bfdbb6b1baaa
++  languageName: node
++  linkType: hard
++
++"jest-each@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-each@npm:30.4.1"
++  dependencies:
++    "@jest/get-type": "npm:30.1.0"
++    "@jest/types": "npm:30.4.1"
++    chalk: "npm:^4.1.2"
++    jest-util: "npm:30.4.1"
++    pretty-format: "npm:30.4.1"
++  checksum: 10/077365c3fd0dc0d74aaa180fe4e3728533685413db58e7a30c8502d19a60a0b08259825d8aa36c569c8175a9d0cf901dd69c0a4eb63567c22c07bd0b566ddf89
++  languageName: node
++  linkType: hard
++
++"jest-environment-node@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-environment-node@npm:30.4.1"
++  dependencies:
++    "@jest/environment": "npm:30.4.1"
++    "@jest/fake-timers": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    jest-mock: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    jest-validate: "npm:30.4.1"
++  checksum: 10/b93157061c6fa4b62808741bdda5fbc0372a9d2a3db844f0ffb819ed104b3b5c6ff73375d9f57c0d8485a0ad6aed07d4cfbb98aca985c38e1a29f64096b940bc
++  languageName: node
++  linkType: hard
++
++"jest-haste-map@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-haste-map@npm:30.4.1"
++  dependencies:
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    anymatch: "npm:^3.1.3"
++    fb-watchman: "npm:^2.0.2"
++    fsevents: "npm:^2.3.3"
++    graceful-fs: "npm:^4.2.11"
++    jest-regex-util: "npm:30.4.0"
++    jest-util: "npm:30.4.1"
++    jest-worker: "npm:30.4.1"
++    picomatch: "npm:^4.0.3"
++    walker: "npm:^1.0.8"
++  dependenciesMeta:
++    fsevents:
++      optional: true
++  checksum: 10/d26404c7258d03fa423604191bca39707438ca1e62a9a471c92fcd468fa386cbdce2c50b3834fb830b25836e3eee34e3070d22b016b42f0ab626c157f5726eeb
++  languageName: node
++  linkType: hard
++
++"jest-leak-detector@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-leak-detector@npm:30.4.1"
++  dependencies:
++    "@jest/get-type": "npm:30.1.0"
++    pretty-format: "npm:30.4.1"
++  checksum: 10/8c0945d1c73f6a2abde8660f7fc5693b344cd1f5fd66153c0c2d13007f8429486eb99ecf15ac68d3d4410534fd0fad1ed430c32a641cdac66e021dbd33204c9a
++  languageName: node
++  linkType: hard
++
++"jest-matcher-utils@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-matcher-utils@npm:30.4.1"
++  dependencies:
++    "@jest/get-type": "npm:30.1.0"
++    chalk: "npm:^4.1.2"
++    jest-diff: "npm:30.4.1"
++    pretty-format: "npm:30.4.1"
++  checksum: 10/4da6e5c7fe5903fae7394233ea4b892567fb027065670c03096d01be0b389f858055c5ade20d59e82fedec6f3287e6f1720de526cd9a9ad3495432320adb9194
++  languageName: node
++  linkType: hard
++
++"jest-message-util@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-message-util@npm:30.4.1"
++  dependencies:
++    "@babel/code-frame": "npm:^7.27.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/stack-utils": "npm:^2.0.3"
++    chalk: "npm:^4.1.2"
++    graceful-fs: "npm:^4.2.11"
++    jest-util: "npm:30.4.1"
++    picomatch: "npm:^4.0.3"
++    pretty-format: "npm:30.4.1"
++    slash: "npm:^3.0.0"
++    stack-utils: "npm:^2.0.6"
++  checksum: 10/f83894efa37aa9c61c0a559b1027ecdb0d0cd8afd3e8ea74e797c707d58daea814e72f04b6db0bb6a148c12ae203e9c6e6c5544832ca5fae286c4f80c18ddc3f
++  languageName: node
++  linkType: hard
++
++"jest-mock@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-mock@npm:30.4.1"
++  dependencies:
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    jest-util: "npm:30.4.1"
++  checksum: 10/8d0c2794130217b9030b888ce380fe57d82388eec19351bd666440ba46f1e24a7e2bdf42cbe9bcfda2b881d4c0ea09db3c80131b9ab788fb5224af2a1339b422
++  languageName: node
++  linkType: hard
++
++"jest-pnp-resolver@npm:^1.2.3":
++  version: 1.2.3
++  resolution: "jest-pnp-resolver@npm:1.2.3"
++  peerDependencies:
++    jest-resolve: "*"
++  peerDependenciesMeta:
++    jest-resolve:
++      optional: true
++  checksum: 10/db1a8ab2cb97ca19c01b1cfa9a9c8c69a143fde833c14df1fab0766f411b1148ff0df878adea09007ac6a2085ec116ba9a996a6ad104b1e58c20adbf88eed9b2
++  languageName: node
++  linkType: hard
++
+ "jest-regex-util@npm:30.0.1":
+   version: 30.0.1
+   resolution: "jest-regex-util@npm:30.0.1"
+@@ -21247,17 +23045,196 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"jest-regex-util@npm:30.4.0":
++  version: 30.4.0
++  resolution: "jest-regex-util@npm:30.4.0"
++  checksum: 10/8664fcc1d07c8236a3bd012c0f06ae9d14d96e758b32ee340a3a7c4c326d0b5052d8c4ae4f4c4184f08bf78723d905352f22923647df9658ace3604f03bf074f
++  languageName: node
++  linkType: hard
++
++"jest-resolve-dependencies@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-resolve-dependencies@npm:30.4.1"
++  dependencies:
++    jest-regex-util: "npm:30.4.0"
++    jest-snapshot: "npm:30.4.1"
++  checksum: 10/0b757d1841ce093526ed21e363018c71f28369e2b36c54df302a40ae7d400e2a81ffd18b20c83fdeeb736cc562919cbb35e2995870089e71c38ae514468e49b2
++  languageName: node
++  linkType: hard
++
++"jest-resolve@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-resolve@npm:30.4.1"
++  dependencies:
++    chalk: "npm:^4.1.2"
++    graceful-fs: "npm:^4.2.11"
++    jest-haste-map: "npm:30.4.1"
++    jest-pnp-resolver: "npm:^1.2.3"
++    jest-util: "npm:30.4.1"
++    jest-validate: "npm:30.4.1"
++    slash: "npm:^3.0.0"
++    unrs-resolver: "npm:^1.7.11"
++  checksum: 10/197ca741df92c1006c2367142b5e44827d995f062e94a923f574e87ce04f966634851bb31f54ea377ca163a8362613947cd2311abf8a5712fe879b1ac15f662f
++  languageName: node
++  linkType: hard
++
++"jest-runner@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-runner@npm:30.4.1"
++  dependencies:
++    "@jest/console": "npm:30.4.1"
++    "@jest/environment": "npm:30.4.1"
++    "@jest/test-result": "npm:30.4.1"
++    "@jest/transform": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    chalk: "npm:^4.1.2"
++    emittery: "npm:^0.13.1"
++    exit-x: "npm:^0.2.2"
++    graceful-fs: "npm:^4.2.11"
++    jest-docblock: "npm:30.4.0"
++    jest-environment-node: "npm:30.4.1"
++    jest-haste-map: "npm:30.4.1"
++    jest-leak-detector: "npm:30.4.1"
++    jest-message-util: "npm:30.4.1"
++    jest-resolve: "npm:30.4.1"
++    jest-runtime: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    jest-watcher: "npm:30.4.1"
++    jest-worker: "npm:30.4.1"
++    p-limit: "npm:^3.1.0"
++    source-map-support: "npm:0.5.13"
++  checksum: 10/08a9be62ef558e7f4200c755882a1e09e990ce2a23ca1756dc9ce934206d682e871d4e4bcffded09e820e98da3b59dba60ee4f9f5098e944c9178e9932a461d4
++  languageName: node
++  linkType: hard
++
++"jest-runtime@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-runtime@npm:30.4.1"
++  dependencies:
++    "@jest/environment": "npm:30.4.1"
++    "@jest/fake-timers": "npm:30.4.1"
++    "@jest/globals": "npm:30.4.1"
++    "@jest/source-map": "npm:30.0.1"
++    "@jest/test-result": "npm:30.4.1"
++    "@jest/transform": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    chalk: "npm:^4.1.2"
++    cjs-module-lexer: "npm:^2.1.0"
++    collect-v8-coverage: "npm:^1.0.2"
++    glob: "npm:^10.5.0"
++    graceful-fs: "npm:^4.2.11"
++    jest-haste-map: "npm:30.4.1"
++    jest-message-util: "npm:30.4.1"
++    jest-mock: "npm:30.4.1"
++    jest-regex-util: "npm:30.4.0"
++    jest-resolve: "npm:30.4.1"
++    jest-snapshot: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    slash: "npm:^3.0.0"
++    strip-bom: "npm:^4.0.0"
++  checksum: 10/9cb033965f2e788073199abfa6991921c20c1eccff250a159967e103ac606deaf5c5c3d9c8681cf1278d0d287d2581080fefcedbdabf01d2aa6b83a77ee9fb60
++  languageName: node
++  linkType: hard
++
++"jest-snapshot@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-snapshot@npm:30.4.1"
++  dependencies:
++    "@babel/core": "npm:^7.27.4"
++    "@babel/generator": "npm:^7.27.5"
++    "@babel/plugin-syntax-jsx": "npm:^7.27.1"
++    "@babel/plugin-syntax-typescript": "npm:^7.27.1"
++    "@babel/types": "npm:^7.27.3"
++    "@jest/expect-utils": "npm:30.4.1"
++    "@jest/get-type": "npm:30.1.0"
++    "@jest/snapshot-utils": "npm:30.4.1"
++    "@jest/transform": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    babel-preset-current-node-syntax: "npm:^1.2.0"
++    chalk: "npm:^4.1.2"
++    expect: "npm:30.4.1"
++    graceful-fs: "npm:^4.2.11"
++    jest-diff: "npm:30.4.1"
++    jest-matcher-utils: "npm:30.4.1"
++    jest-message-util: "npm:30.4.1"
++    jest-util: "npm:30.4.1"
++    pretty-format: "npm:30.4.1"
++    semver: "npm:^7.7.2"
++    synckit: "npm:^0.11.8"
++  checksum: 10/6135108d3e0e9fb93ed10fd9ad91d8dbe56f90a9ea84c32a0b551518f8c71f363299dcc301717f3ed82cfe2a276d7993d2b3ccfabea3e8020d49ae8b0f9b6cd8
++  languageName: node
++  linkType: hard
++
++"jest-util@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-util@npm:30.4.1"
++  dependencies:
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    chalk: "npm:^4.1.2"
++    ci-info: "npm:^4.2.0"
++    graceful-fs: "npm:^4.2.11"
++    picomatch: "npm:^4.0.3"
++  checksum: 10/603093e12076906afcf28be514d5b7ac4e3c0e26997b0047614cf2a308b65d773137304a1fb011d747517e881aeed067f6606b9937f5b838d67f6e5734b49ebe
++  languageName: node
++  linkType: hard
++
+ "jest-util@npm:^29.7.0":
+   version: 29.7.0
+   resolution: "jest-util@npm:29.7.0"
+   dependencies:
+     "@jest/types": "npm:^29.6.3"
+     "@types/node": "npm:*"
+-    chalk: "npm:^4.0.0"
+-    ci-info: "npm:^3.2.0"
+-    graceful-fs: "npm:^4.2.9"
+-    picomatch: "npm:^2.2.3"
+-  checksum: 10/30d58af6967e7d42bd903ccc098f3b4d3859ed46238fbc88d4add6a3f10bea00c226b93660285f058bc7a65f6f9529cf4eb80f8d4707f79f9e3a23686b4ab8f3
++    chalk: "npm:^4.0.0"
++    ci-info: "npm:^3.2.0"
++    graceful-fs: "npm:^4.2.9"
++    picomatch: "npm:^2.2.3"
++  checksum: 10/30d58af6967e7d42bd903ccc098f3b4d3859ed46238fbc88d4add6a3f10bea00c226b93660285f058bc7a65f6f9529cf4eb80f8d4707f79f9e3a23686b4ab8f3
++  languageName: node
++  linkType: hard
++
++"jest-validate@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-validate@npm:30.4.1"
++  dependencies:
++    "@jest/get-type": "npm:30.1.0"
++    "@jest/types": "npm:30.4.1"
++    camelcase: "npm:^6.3.0"
++    chalk: "npm:^4.1.2"
++    leven: "npm:^3.1.0"
++    pretty-format: "npm:30.4.1"
++  checksum: 10/527fe8ad02df9a4f7f467ecc4e3ac2a37a27b7b30345e7bc3cb9c2ead33fbc8ed1290c0827baa06471281012c38abb96cb268af274a0a2350548e50db20a434f
++  languageName: node
++  linkType: hard
++
++"jest-watcher@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-watcher@npm:30.4.1"
++  dependencies:
++    "@jest/test-result": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    "@types/node": "npm:*"
++    ansi-escapes: "npm:^4.3.2"
++    chalk: "npm:^4.1.2"
++    emittery: "npm:^0.13.1"
++    jest-util: "npm:30.4.1"
++    string-length: "npm:^4.0.2"
++  checksum: 10/05350ed3d5643e87e22cc5faee14f912dfc06ba63d56944006d9837f2070ed509a1d124c7e7be3e3a9a6a382bd31d491146da6fda4483acd4b8292091888e9bd
++  languageName: node
++  linkType: hard
++
++"jest-worker@npm:30.4.1":
++  version: 30.4.1
++  resolution: "jest-worker@npm:30.4.1"
++  dependencies:
++    "@types/node": "npm:*"
++    "@ungap/structured-clone": "npm:^1.3.0"
++    jest-util: "npm:30.4.1"
++    merge-stream: "npm:^2.0.0"
++    supports-color: "npm:^8.1.1"
++  checksum: 10/ff6af73c9097fc07e90490d3e1e354c702390ef66f7f40054a15dd6d56809a25634179969ff80bde782a6c645f49fa48bf3aacfe7d05af7315c48020f9b2b1cd
+   languageName: node
+   linkType: hard
+ 
+@@ -21284,6 +23261,25 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"jest@npm:^30":
++  version: 30.4.1
++  resolution: "jest@npm:30.4.1"
++  dependencies:
++    "@jest/core": "npm:30.4.1"
++    "@jest/types": "npm:30.4.1"
++    import-local: "npm:^3.2.0"
++    jest-cli: "npm:30.4.1"
++  peerDependencies:
++    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
++  peerDependenciesMeta:
++    node-notifier:
++      optional: true
++  bin:
++    jest: ./bin/jest.js
++  checksum: 10/a405ddb62f075e54120cd0aa3919c6ea98278699172d905c273324edcf68ca8ed3e8b91c6c93c6e99249468a809618160969bddbfc2dd9b182dd0908afa6818c
++  languageName: node
++  linkType: hard
++
+ "jiti@npm:2.4.2, jiti@npm:^2.4.2":
+   version: 2.4.2
+   resolution: "jiti@npm:2.4.2"
+@@ -21417,6 +23413,39 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"jsdom@npm:^27":
++  version: 27.4.0
++  resolution: "jsdom@npm:27.4.0"
++  dependencies:
++    "@acemir/cssom": "npm:^0.9.28"
++    "@asamuzakjp/dom-selector": "npm:^6.7.6"
++    "@exodus/bytes": "npm:^1.6.0"
++    cssstyle: "npm:^5.3.4"
++    data-urls: "npm:^6.0.0"
++    decimal.js: "npm:^10.6.0"
++    html-encoding-sniffer: "npm:^6.0.0"
++    http-proxy-agent: "npm:^7.0.2"
++    https-proxy-agent: "npm:^7.0.6"
++    is-potential-custom-element-name: "npm:^1.0.1"
++    parse5: "npm:^8.0.0"
++    saxes: "npm:^6.0.0"
++    symbol-tree: "npm:^3.2.4"
++    tough-cookie: "npm:^6.0.0"
++    w3c-xmlserializer: "npm:^5.0.0"
++    webidl-conversions: "npm:^8.0.0"
++    whatwg-mimetype: "npm:^4.0.0"
++    whatwg-url: "npm:^15.1.0"
++    ws: "npm:^8.18.3"
++    xml-name-validator: "npm:^5.0.0"
++  peerDependencies:
++    canvas: ^3.0.0
++  peerDependenciesMeta:
++    canvas:
++      optional: true
++  checksum: 10/7c6db85ab91183b95204648e086cfc09ecee36d9e8fee0bb5d68e27543eca632de0af6d43de461176a7823820543d5c53561778af5f712b1a1cd28bfac084d51
++  languageName: node
++  linkType: hard
++
+ "jsep@npm:^1.1.2, jsep@npm:^1.2.0, jsep@npm:^1.4.0":
+   version: 1.4.0
+   resolution: "jsep@npm:1.4.0"
+@@ -21433,6 +23462,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"jsesc@npm:^3.0.2":
++  version: 3.1.0
++  resolution: "jsesc@npm:3.1.0"
++  bin:
++    jsesc: bin/jsesc
++  checksum: 10/20bd37a142eca5d1794f354db8f1c9aeb54d85e1f5c247b371de05d23a9751ecd7bd3a9c4fc5298ea6fa09a100dafb4190fa5c98c6610b75952c3487f3ce7967
++  languageName: node
++  linkType: hard
++
+ "json-bigint@npm:^1.0.0":
+   version: 1.0.0
+   resolution: "json-bigint@npm:1.0.0"
+@@ -21568,7 +23606,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"json5@npm:^2.1.2, json5@npm:^2.1.3":
++"json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.3":
+   version: 2.2.3
+   resolution: "json5@npm:2.2.3"
+   bin:
+@@ -22469,6 +24507,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"lru-cache@npm:^11.2.4, lru-cache@npm:^11.2.5, lru-cache@npm:^11.2.6":
++  version: 11.3.6
++  resolution: "lru-cache@npm:11.3.6"
++  checksum: 10/d69ab552776954c7d310a6b2843e7d6be3a1c36c0ce45fca373c225ce5a06b95fd4ed724305d9d15fa55aa24d3cd42f854aa061bc481241225b3accf32993eab
++  languageName: node
++  linkType: hard
++
+ "lru-cache@npm:^4.0.1":
+   version: 4.1.5
+   resolution: "lru-cache@npm:4.1.5"
+@@ -22550,6 +24595,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"make-dir@npm:^4.0.0":
++  version: 4.0.0
++  resolution: "make-dir@npm:4.0.0"
++  dependencies:
++    semver: "npm:^7.5.3"
++  checksum: 10/bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
++  languageName: node
++  linkType: hard
++
+ "make-error@npm:^1.1.1":
+   version: 1.3.6
+   resolution: "make-error@npm:1.3.6"
+@@ -22584,6 +24638,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"makeerror@npm:1.0.12":
++  version: 1.0.12
++  resolution: "makeerror@npm:1.0.12"
++  dependencies:
++    tmpl: "npm:1.0.5"
++  checksum: 10/4c66ddfc654537333da952c084f507fa4c30c707b1635344eb35be894d797ba44c901a9cebe914aa29a7f61357543ba09b09dddbd7f65b4aee756b450f169f40
++  languageName: node
++  linkType: hard
++
+ "markdown-escape@npm:^2.0.0":
+   version: 2.0.0
+   resolution: "markdown-escape@npm:2.0.0"
+@@ -22858,6 +24921,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"mdn-data@npm:2.27.1":
++  version: 2.27.1
++  resolution: "mdn-data@npm:2.27.1"
++  checksum: 10/5046dc83a961b8ea82a5d6d8331d07df6b15faec61519ce2f83e49766702358e7e6af96413be977ff89080534be6762c1d5963b5dd1180c208a47c0a663226b2
++  languageName: node
++  linkType: hard
++
+ "mdurl@npm:^2.0.0":
+   version: 2.0.0
+   resolution: "mdurl@npm:2.0.0"
+@@ -23905,6 +25975,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"napi-postinstall@npm:^0.3.0":
++  version: 0.3.4
++  resolution: "napi-postinstall@npm:0.3.4"
++  bin:
++    napi-postinstall: lib/cli.js
++  checksum: 10/5541381508f9e1051ff3518701c7130ebac779abb3a1ffe9391fcc3cab4cc0569b0ba0952357db3f6b12909c3bb508359a7a60261ffd795feebbdab967175832
++  languageName: node
++  linkType: hard
++
+ "native-duplexpair@npm:^1.0.0":
+   version: 1.0.0
+   resolution: "native-duplexpair@npm:1.0.0"
+@@ -24124,6 +26203,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"node-int64@npm:^0.4.0":
++  version: 0.4.0
++  resolution: "node-int64@npm:0.4.0"
++  checksum: 10/b7afc2b65e56f7035b1a2eec57ae0fbdee7d742b1cdcd0f4387562b6527a011ab1cbe9f64cc8b3cca61e3297c9637c8bf61cec2e6b8d3a711d4b5267dfafbe02
++  languageName: node
++  linkType: hard
++
+ "node-machine-id@npm:^1.1.12":
+   version: 1.1.12
+   resolution: "node-machine-id@npm:1.1.12"
+@@ -24138,6 +26224,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"node-releases@npm:^2.0.36":
++  version: 2.0.38
++  resolution: "node-releases@npm:2.0.38"
++  checksum: 10/0e6bba9d7e75dddf7d45c099f202ac7cb0eaeb363c36a34880c219e1697cf7369b6548e48f538490b706501ff9aa017e102adf3362184b9b64786de8377e0501
++  languageName: node
++  linkType: hard
++
+ "node-sarif-builder@npm:^2.0.3":
+   version: 2.0.3
+   resolution: "node-sarif-builder@npm:2.0.3"
+@@ -24249,6 +26342,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"npm-run-path@npm:^4.0.1":
++  version: 4.0.1
++  resolution: "npm-run-path@npm:4.0.1"
++  dependencies:
++    path-key: "npm:^3.0.0"
++  checksum: 10/5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
++  languageName: node
++  linkType: hard
++
+ "nth-check@npm:^2.0.1":
+   version: 2.1.1
+   resolution: "nth-check@npm:2.1.1"
+@@ -24452,7 +26554,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"onetime@npm:^5.1.0":
++"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
+   version: 5.1.2
+   resolution: "onetime@npm:5.1.2"
+   dependencies:
+@@ -24923,6 +27025,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"parse5@npm:^7.0.0":
++  version: 7.3.0
++  resolution: "parse5@npm:7.3.0"
++  dependencies:
++    entities: "npm:^6.0.0"
++  checksum: 10/b0e48be20b820c655b138b86fa6fb3a790de6c891aa2aba536524f8027b4dca4fe538f11a0e5cf2f6f847d120dbb9e4822dcaeb933ff1e10850a2ef0154d1d88
++  languageName: node
++  linkType: hard
++
+ "parse5@npm:^7.1.2":
+   version: 7.2.1
+   resolution: "parse5@npm:7.2.1"
+@@ -24932,6 +27043,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"parse5@npm:^8.0.0":
++  version: 8.0.1
++  resolution: "parse5@npm:8.0.1"
++  dependencies:
++    entities: "npm:^8.0.0"
++  checksum: 10/671dedfe7cbf4714414317bc8c6b2a14c61ef44f8fd90c983b5b1870653af5aa2e3b4e25e38e9538a7120ea2b688c50908830da2bd0930d8fd4bce34aed024eb
++  languageName: node
++  linkType: hard
++
+ "parseurl@npm:^1.3.3, parseurl@npm:~1.3.2, parseurl@npm:~1.3.3":
+   version: 1.3.3
+   resolution: "parseurl@npm:1.3.3"
+@@ -25024,7 +27144,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"path-key@npm:^3.1.0":
++"path-key@npm:^3.0.0, path-key@npm:^3.1.0":
+   version: 3.1.1
+   resolution: "path-key@npm:3.1.1"
+   checksum: 10/55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
+@@ -25263,6 +27383,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"picomatch@npm:^4.0.3":
++  version: 4.0.4
++  resolution: "picomatch@npm:4.0.4"
++  checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
++  languageName: node
++  linkType: hard
++
+ "pify@npm:^2.3.0":
+   version: 2.3.0
+   resolution: "pify@npm:2.3.0"
+@@ -25333,6 +27460,22 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"pirates@npm:^4.0.7":
++  version: 4.0.7
++  resolution: "pirates@npm:4.0.7"
++  checksum: 10/2427f371366081ae42feb58214f04805d6b41d6b84d74480ebcc9e0ddbd7105a139f7c653daeaf83ad8a1a77214cf07f64178e76de048128fec501eab3305a96
++  languageName: node
++  linkType: hard
++
++"pkg-dir@npm:^4.2.0":
++  version: 4.2.0
++  resolution: "pkg-dir@npm:4.2.0"
++  dependencies:
++    find-up: "npm:^4.0.0"
++  checksum: 10/9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
++  languageName: node
++  linkType: hard
++
+ "pkg-dir@npm:^5.0.0":
+   version: 5.0.0
+   resolution: "pkg-dir@npm:5.0.0"
+@@ -25955,6 +28098,18 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"pretty-format@npm:30.4.1, pretty-format@npm:^30.0.0":
++  version: 30.4.1
++  resolution: "pretty-format@npm:30.4.1"
++  dependencies:
++    "@jest/schemas": "npm:30.4.1"
++    ansi-styles: "npm:^5.2.0"
++    react-is-18: "npm:react-is@^18.3.1"
++    react-is-19: "npm:react-is@^19.2.5"
++  checksum: 10/60311ef47a646eeaec0432efe66290cb6f0d2eccb123a28ad4ab6d7e53087bc62db91cfd54c3cc00c89d6875aefb2bf6264381b6c9411ce6bff3d6aa8280abad
++  languageName: node
++  linkType: hard
++
+ "pretty-format@npm:^27.0.2":
+   version: 27.5.1
+   resolution: "pretty-format@npm:27.5.1"
+@@ -26206,6 +28361,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"pure-rand@npm:^7.0.0":
++  version: 7.0.1
++  resolution: "pure-rand@npm:7.0.1"
++  checksum: 10/c61a576fda5032ec9763ecb000da4a8f19263b9e2f9ae9aa2759c8fbd9dc6b192b2ce78391ebd41abb394a5fedb7bcc4b03c9e6141ac8ab20882dd5717698b80
++  languageName: node
++  linkType: hard
++
+ "pvtsutils@npm:^1.3.6":
+   version: 1.3.6
+   resolution: "pvtsutils@npm:1.3.6"
+@@ -26740,6 +28902,20 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"react-is-18@npm:react-is@^18.3.1, react-is@npm:^18.0.0, react-is@npm:^18.2.0, react-is@npm:^18.3.1":
++  version: 18.3.1
++  resolution: "react-is@npm:18.3.1"
++  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
++  languageName: node
++  linkType: hard
++
++"react-is-19@npm:react-is@^19.2.5":
++  version: 19.2.6
++  resolution: "react-is@npm:19.2.6"
++  checksum: 10/5248eb5cfc135794c110f97fc0716a9439dc641d6bccbb8c00487c6c492644592ce4dd959fd23790bf05c1f26e0b62f11322b1e51372715a96a4bc4565a17d74
++  languageName: node
++  linkType: hard
++
+ "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+   version: 16.13.1
+   resolution: "react-is@npm:16.13.1"
+@@ -26754,13 +28930,6 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"react-is@npm:^18.0.0, react-is@npm:^18.2.0, react-is@npm:^18.3.1":
+-  version: 18.3.1
+-  resolution: "react-is@npm:18.3.1"
+-  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
+-  languageName: node
+-  linkType: hard
+-
+ "react-markdown@npm:^8.0.0":
+   version: 8.0.7
+   resolution: "react-markdown@npm:8.0.7"
+@@ -27504,6 +29673,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"resolve-cwd@npm:^3.0.0":
++  version: 3.0.0
++  resolution: "resolve-cwd@npm:3.0.0"
++  dependencies:
++    resolve-from: "npm:^5.0.0"
++  checksum: 10/546e0816012d65778e580ad62b29e975a642989108d9a3c5beabfb2304192fa3c9f9146fbdfe213563c6ff51975ae41bac1d3c6e047dd9572c94863a057b4d81
++  languageName: node
++  linkType: hard
++
+ "resolve-dir@npm:^1.0.0, resolve-dir@npm:^1.0.1":
+   version: 1.0.1
+   resolution: "resolve-dir@npm:1.0.1"
+@@ -28133,6 +30311,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"semver@npm:^7.7.2":
++  version: 7.7.4
++  resolution: "semver@npm:7.7.4"
++  bin:
++    semver: bin/semver.js
++  checksum: 10/26bdc6d58b29528f4142d29afb8526bc335f4fc04c4a10f2b98b217f277a031c66736bf82d3d3bb354a2f6a3ae50f18fd62b053c4ac3f294a3d10a61f5075b75
++  languageName: node
++  linkType: hard
++
+ "semver@npm:~7.5.4":
+   version: 7.5.4
+   resolution: "semver@npm:7.5.4"
+@@ -28409,7 +30596,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"signal-exit@npm:^3.0.2":
++"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
+   version: 3.0.7
+   resolution: "signal-exit@npm:3.0.7"
+   checksum: 10/a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
+@@ -28570,6 +30757,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"source-map-support@npm:0.5.13":
++  version: 0.5.13
++  resolution: "source-map-support@npm:0.5.13"
++  dependencies:
++    buffer-from: "npm:^1.0.0"
++    source-map: "npm:^0.6.0"
++  checksum: 10/d1514a922ac9c7e4786037eeff6c3322f461cd25da34bb9fefb15387b3490531774e6e31d95ab6d5b84a3e139af9c3a570ccaee6b47bd7ea262691ed3a8bc34e
++  languageName: node
++  linkType: hard
++
+ "source-map-support@npm:~0.5.20":
+   version: 0.5.21
+   resolution: "source-map-support@npm:0.5.21"
+@@ -28769,6 +30966,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"stack-utils@npm:^2.0.6":
++  version: 2.0.6
++  resolution: "stack-utils@npm:2.0.6"
++  dependencies:
++    escape-string-regexp: "npm:^2.0.0"
++  checksum: 10/cdc988acbc99075b4b036ac6014e5f1e9afa7e564482b687da6384eee6a1909d7eaffde85b0a17ffbe186c5247faf6c2b7544e802109f63b72c7be69b13151bb
++  languageName: node
++  linkType: hard
++
+ "stackframe@npm:^1.3.4":
+   version: 1.3.4
+   resolution: "stackframe@npm:1.3.4"
+@@ -28922,6 +31128,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"string-length@npm:^4.0.2":
++  version: 4.0.2
++  resolution: "string-length@npm:4.0.2"
++  dependencies:
++    char-regex: "npm:^1.0.2"
++    strip-ansi: "npm:^6.0.0"
++  checksum: 10/ce85533ef5113fcb7e522bcf9e62cb33871aa99b3729cec5595f4447f660b0cefd542ca6df4150c97a677d58b0cb727a3fe09ac1de94071d05526c73579bf505
++  languageName: node
++  linkType: hard
++
+ "string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+   version: 4.2.3
+   resolution: "string-width@npm:4.2.3"
+@@ -29076,6 +31292,20 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"strip-bom@npm:^4.0.0":
++  version: 4.0.0
++  resolution: "strip-bom@npm:4.0.0"
++  checksum: 10/9dbcfbaf503c57c06af15fe2c8176fb1bf3af5ff65003851a102749f875a6dbe0ab3b30115eccf6e805e9d756830d3e40ec508b62b3f1ddf3761a20ebe29d3f3
++  languageName: node
++  linkType: hard
++
++"strip-final-newline@npm:^2.0.0":
++  version: 2.0.0
++  resolution: "strip-final-newline@npm:2.0.0"
++  checksum: 10/69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
++  languageName: node
++  linkType: hard
++
+ "strip-indent@npm:^3.0.0":
+   version: 3.0.0
+   resolution: "strip-indent@npm:3.0.0"
+@@ -29295,7 +31525,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"supports-color@npm:^8.0.0, supports-color@npm:^8.1.0, supports-color@npm:~8.1.1":
++"supports-color@npm:^8.0.0, supports-color@npm:^8.1.0, supports-color@npm:^8.1.1, supports-color@npm:~8.1.1":
+   version: 8.1.1
+   resolution: "supports-color@npm:8.1.1"
+   dependencies:
+@@ -29437,6 +31667,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"synckit@npm:^0.11.8":
++  version: 0.11.12
++  resolution: "synckit@npm:0.11.12"
++  dependencies:
++    "@pkgr/core": "npm:^0.2.9"
++  checksum: 10/2f51978bfed81aaf0b093f596709a72c49b17909020f42b43c5549f9c0fe18b1fe29f82e41ef771172d729b32e9ce82900a85d2b87fa14d59f886d4df8d7a329
++  languageName: node
++  linkType: hard
++
+ "tapable@npm:^1.0.0":
+   version: 1.1.3
+   resolution: "tapable@npm:1.1.3"
+@@ -29609,6 +31848,17 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"test-exclude@npm:^6.0.0":
++  version: 6.0.0
++  resolution: "test-exclude@npm:6.0.0"
++  dependencies:
++    "@istanbuljs/schema": "npm:^0.1.2"
++    glob: "npm:^7.1.4"
++    minimatch: "npm:^3.0.4"
++  checksum: 10/8fccb2cb6c8fcb6bb4115394feb833f8b6cf4b9503ec2485c2c90febf435cac62abe882a0c5c51a37b9bbe70640cdd05acf5f45e486ac4583389f4b0855f69e5
++  languageName: node
++  linkType: hard
++
+ "testcontainers@npm:^11.9.0":
+   version: 11.11.0
+   resolution: "testcontainers@npm:11.11.0"
+@@ -29757,6 +32007,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"tldts-core@npm:^7.0.30":
++  version: 7.0.30
++  resolution: "tldts-core@npm:7.0.30"
++  checksum: 10/ac2c06a9c51c2638177893a9a799aca66f7032a2fe73b891a39d1d38093d9bcd8904e23893a6aaebd864dcdead701a9c4c9c88243e8b7cf347f57696304d8fa0
++  languageName: node
++  linkType: hard
++
+ "tldts@npm:^6.1.32":
+   version: 6.1.69
+   resolution: "tldts@npm:6.1.69"
+@@ -29768,6 +32025,17 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"tldts@npm:^7.0.5":
++  version: 7.0.30
++  resolution: "tldts@npm:7.0.30"
++  dependencies:
++    tldts-core: "npm:^7.0.30"
++  bin:
++    tldts: bin/cli.js
++  checksum: 10/93e43ee4c77c408af892387e3be7501d5c1a536a3162c848ef7d031dc257a501f37e88fea0766c52dea1df5f00ad8e28e1d228281ca4129a9f15816f2bc9bc68
++  languageName: node
++  linkType: hard
++
+ "tmp@npm:^0.0.33":
+   version: 0.0.33
+   resolution: "tmp@npm:0.0.33"
+@@ -29784,6 +32052,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"tmpl@npm:1.0.5":
++  version: 1.0.5
++  resolution: "tmpl@npm:1.0.5"
++  checksum: 10/cd922d9b853c00fe414c5a774817be65b058d54a2d01ebb415840960406c669a0fc632f66df885e24cb022ec812739199ccbdb8d1164c3e513f85bfca5ab2873
++  languageName: node
++  linkType: hard
++
+ "to-buffer@npm:^1.2.0":
+   version: 1.2.2
+   resolution: "to-buffer@npm:1.2.2"
+@@ -29863,6 +32138,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"tough-cookie@npm:^6.0.0":
++  version: 6.0.1
++  resolution: "tough-cookie@npm:6.0.1"
++  dependencies:
++    tldts: "npm:^7.0.5"
++  checksum: 10/915b1167e0630598eb0644e8bc089ddc28a23bf05f3c329a4a0d879c6b9801a2603be65acb06b5d2dd0f589cabb06bb638837f8222dd82a7023655f07269451a
++  languageName: node
++  linkType: hard
++
+ "tr46@npm:^5.0.0":
+   version: 5.0.0
+   resolution: "tr46@npm:5.0.0"
+@@ -29872,6 +32156,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"tr46@npm:^6.0.0":
++  version: 6.0.0
++  resolution: "tr46@npm:6.0.0"
++  dependencies:
++    punycode: "npm:^2.3.1"
++  checksum: 10/e6d402eb2b780a40042f327f77b4ae316da1d2b18a29c16e48c239f5267c6005bbf780f854179cfae62b02dfaa70b0e9aad8f0078ccc4225f5b3b3b131928e8f
++  languageName: node
++  linkType: hard
++
+ "tr46@npm:~0.0.3":
+   version: 0.0.3
+   resolution: "tr46@npm:0.0.3"
+@@ -30189,6 +32482,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"type-detect@npm:4.0.8":
++  version: 4.0.8
++  resolution: "type-detect@npm:4.0.8"
++  checksum: 10/5179e3b8ebc51fce1b13efb75fdea4595484433f9683bbc2dca6d99789dba4e602ab7922d2656f2ce8383987467f7770131d4a7f06a26287db0615d2f4c4ce7d
++  languageName: node
++  linkType: hard
++
+ "type-fest@npm:^0.13.1":
+   version: 0.13.1
+   resolution: "type-fest@npm:0.13.1"
+@@ -30460,6 +32760,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"undici-types@npm:^7.21.0":
++  version: 7.25.0
++  resolution: "undici-types@npm:7.25.0"
++  checksum: 10/66f3a460cbc9e83e73c11c3a1869c32eef6c92b32450cc9dc677c671d958b9d1bb8635ff36a421019e4b1114dfc79d187aecf4dc75cf167a85535e03559b9250
++  languageName: node
++  linkType: hard
++
+ "undici-types@npm:~5.26.4":
+   version: 5.26.5
+   resolution: "undici-types@npm:5.26.5"
+@@ -30630,6 +32937,73 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"unrs-resolver@npm:^1.7.11":
++  version: 1.11.1
++  resolution: "unrs-resolver@npm:1.11.1"
++  dependencies:
++    "@unrs/resolver-binding-android-arm-eabi": "npm:1.11.1"
++    "@unrs/resolver-binding-android-arm64": "npm:1.11.1"
++    "@unrs/resolver-binding-darwin-arm64": "npm:1.11.1"
++    "@unrs/resolver-binding-darwin-x64": "npm:1.11.1"
++    "@unrs/resolver-binding-freebsd-x64": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-arm-gnueabihf": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-arm-musleabihf": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-arm64-gnu": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-arm64-musl": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-ppc64-gnu": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-riscv64-gnu": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-riscv64-musl": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-s390x-gnu": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-x64-gnu": "npm:1.11.1"
++    "@unrs/resolver-binding-linux-x64-musl": "npm:1.11.1"
++    "@unrs/resolver-binding-wasm32-wasi": "npm:1.11.1"
++    "@unrs/resolver-binding-win32-arm64-msvc": "npm:1.11.1"
++    "@unrs/resolver-binding-win32-ia32-msvc": "npm:1.11.1"
++    "@unrs/resolver-binding-win32-x64-msvc": "npm:1.11.1"
++    napi-postinstall: "npm:^0.3.0"
++  dependenciesMeta:
++    "@unrs/resolver-binding-android-arm-eabi":
++      optional: true
++    "@unrs/resolver-binding-android-arm64":
++      optional: true
++    "@unrs/resolver-binding-darwin-arm64":
++      optional: true
++    "@unrs/resolver-binding-darwin-x64":
++      optional: true
++    "@unrs/resolver-binding-freebsd-x64":
++      optional: true
++    "@unrs/resolver-binding-linux-arm-gnueabihf":
++      optional: true
++    "@unrs/resolver-binding-linux-arm-musleabihf":
++      optional: true
++    "@unrs/resolver-binding-linux-arm64-gnu":
++      optional: true
++    "@unrs/resolver-binding-linux-arm64-musl":
++      optional: true
++    "@unrs/resolver-binding-linux-ppc64-gnu":
++      optional: true
++    "@unrs/resolver-binding-linux-riscv64-gnu":
++      optional: true
++    "@unrs/resolver-binding-linux-riscv64-musl":
++      optional: true
++    "@unrs/resolver-binding-linux-s390x-gnu":
++      optional: true
++    "@unrs/resolver-binding-linux-x64-gnu":
++      optional: true
++    "@unrs/resolver-binding-linux-x64-musl":
++      optional: true
++    "@unrs/resolver-binding-wasm32-wasi":
++      optional: true
++    "@unrs/resolver-binding-win32-arm64-msvc":
++      optional: true
++    "@unrs/resolver-binding-win32-ia32-msvc":
++      optional: true
++    "@unrs/resolver-binding-win32-x64-msvc":
++      optional: true
++  checksum: 10/4de653508cbaae47883a896bd5cdfef0e5e87b428d62620d16fd35cd534beaebf08ebf0cf2f8b4922aa947b2fe745180facf6cc3f39ba364f7ce0f974cb06a70
++  languageName: node
++  linkType: hard
++
+ "upath@npm:2.0.1":
+   version: 2.0.1
+   resolution: "upath@npm:2.0.1"
+@@ -30637,7 +33011,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"update-browserslist-db@npm:^1.2.0":
++"update-browserslist-db@npm:^1.2.0, update-browserslist-db@npm:^1.2.3":
+   version: 1.2.3
+   resolution: "update-browserslist-db@npm:1.2.3"
+   dependencies:
+@@ -30907,6 +33281,17 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"v8-to-istanbul@npm:^9.0.1":
++  version: 9.3.0
++  resolution: "v8-to-istanbul@npm:9.3.0"
++  dependencies:
++    "@jridgewell/trace-mapping": "npm:^0.3.12"
++    "@types/istanbul-lib-coverage": "npm:^2.0.1"
++    convert-source-map: "npm:^2.0.0"
++  checksum: 10/fb1d70f1176cb9dc46cabbb3fd5c52c8f3e8738b61877b6e7266029aed0870b04140e3f9f4550ac32aebcfe1d0f38b0bac57e1e8fb97d68fec82f2b416148166
++  languageName: node
++  linkType: hard
++
+ "valid-url@npm:^1.0.9":
+   version: 1.0.9
+   resolution: "valid-url@npm:1.0.9"
+@@ -31042,6 +33427,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"walker@npm:^1.0.8":
++  version: 1.0.8
++  resolution: "walker@npm:1.0.8"
++  dependencies:
++    makeerror: "npm:1.0.12"
++  checksum: 10/ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
++  languageName: node
++  linkType: hard
++
+ "watchpack@npm:^2.5.1":
+   version: 2.5.1
+   resolution: "watchpack@npm:2.5.1"
+@@ -31112,6 +33506,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"webidl-conversions@npm:^8.0.0":
++  version: 8.0.1
++  resolution: "webidl-conversions@npm:8.0.1"
++  checksum: 10/0f7007311f1fc257a8e406dd236f13b61fb57cf0fddb476aec33457d2d0add2d012d6df0eeb00934399238e3f3b9dad30f59dc6ac83024ae0ebd5a518bf365e8
++  languageName: node
++  linkType: hard
++
+ "webpack-dev-middleware@npm:^7.4.2":
+   version: 7.4.2
+   resolution: "webpack-dev-middleware@npm:7.4.2"
+@@ -31310,6 +33711,13 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"whatwg-mimetype@npm:^5.0.0":
++  version: 5.0.0
++  resolution: "whatwg-mimetype@npm:5.0.0"
++  checksum: 10/a2d5da445f671ed34010b45283ffb9ba3c68c695b8ec91f7400cfc9149c35eb2bc47bd2c39bbe8e026786b955ace03402ba2e5cfde4955434a3ec3c511a85d0a
++  languageName: node
++  linkType: hard
++
+ "whatwg-url@npm:^14.0.0":
+   version: 14.1.0
+   resolution: "whatwg-url@npm:14.1.0"
+@@ -31320,6 +33728,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"whatwg-url@npm:^15.1.0":
++  version: 15.1.0
++  resolution: "whatwg-url@npm:15.1.0"
++  dependencies:
++    tr46: "npm:^6.0.0"
++    webidl-conversions: "npm:^8.0.0"
++  checksum: 10/9ae5ce70060f2a9ea73799062af6e796ec2477f44bf1a886953b405700e3ab11d15aa0fe7088c4215f839e56a845d5d1c44584ed292a832837a8c8549c566886
++  languageName: node
++  linkType: hard
++
+ "whatwg-url@npm:^5.0.0":
+   version: 5.0.0
+   resolution: "whatwg-url@npm:5.0.0"
+@@ -31516,6 +33934,16 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"write-file-atomic@npm:^5.0.1":
++  version: 5.0.1
++  resolution: "write-file-atomic@npm:5.0.1"
++  dependencies:
++    imurmurhash: "npm:^0.1.4"
++    signal-exit: "npm:^4.0.1"
++  checksum: 10/648efddba54d478d0e4330ab6f239976df3b9752b123db5dc9405d9b5af768fa9d70ce60c52fdbe61d1200d24350bc4fbcbaf09288496c2be050de126bd95b7e
++  languageName: node
++  linkType: hard
++
+ "ws@npm:*, ws@npm:8.18.0, ws@npm:^8.18.0, ws@npm:^8.8.0":
+   version: 8.18.0
+   resolution: "ws@npm:8.18.0"
+@@ -31531,6 +33959,21 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"ws@npm:^8.18.3":
++  version: 8.20.0
++  resolution: "ws@npm:8.20.0"
++  peerDependencies:
++    bufferutil: ^4.0.1
++    utf-8-validate: ">=5.0.2"
++  peerDependenciesMeta:
++    bufferutil:
++      optional: true
++    utf-8-validate:
++      optional: true
++  checksum: 10/b7ab934b21ffdea9f25a5af5097e8c1ec7625db553bca026c5a23e35b7c236f3fb89782f2b57fab9da553864512f9aa7d245827ef998d26ffa1b2187a19a6d10
++  languageName: node
++  linkType: hard
++
+ "xml-but-prettier@npm:^1.0.1":
+   version: 1.0.1
+   resolution: "xml-but-prettier@npm:1.0.1"


### PR DESCRIPTION
Since the patch was denied upstream, this patch fixes the `TS2688 cannot find type definition file for jest` during `yarn tsc` error presented during plugin export.