### PR TITLE
fix: remove orphan reference to non-existent azure-container-registry.yaml

### DIFF
--- a/catalog-entities/extensions/plugins/all.yaml
+++ b/catalog-entities/extensions/plugins/all.yaml
@@ -15,7 +15,6 @@ spec:
     - ./aws-codebuild.yaml
     - ./aws-codepipeline.yaml
     - ./aws-ecs.yaml
-    - ./azure-container-registry.yaml
     - ./azure-devops.yaml
     - ./azure-repositories.yaml
     - ./azure-scaffolder-actions.yaml


### PR DESCRIPTION
## Summary
- Removes orphan reference to `./azure-container-registry.yaml` from `catalog-entities/extensions/plugins/all.yaml` (line 18)
- It was removed as part of this PR https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/1791
## Fixed
- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3144

## Problem
The `all.yaml` index file references a plugin YAML file that does not exist in the `catalog-entities/extensions/plugins/` directory. This may cause catalog ingestion failures or warnings when the Extensions UI attempts to load plugin definitions.

## Changes
- Removed line 18 (`- ./azure-container-registry.yaml`) from `all.yaml`

## Testing
- Verified the file `azure-container-registry.yaml` does not exist in the plugins directory
- Confirmed no other references to this file exist in the repository