### PR TITLE
fix: unpin RHDH_VERSION in run-e2e.sh

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -38,8 +38,7 @@ cd "$SCRIPT_DIR"
 # These use defaults that can be overridden via environment variables.
 
 # RHDH deployment
-# export RHDH_VERSION="${RHDH_VERSION:-1.10}"             # RHDH version to deploy (e.g., "1.10", "next")
-export RHDH_VERSION="1.10-114-CI"                       # Pinned due to RHDHBUGS-3030
+export RHDH_VERSION="${RHDH_VERSION:-1.10}"             # RHDH version to deploy (e.g., "1.10", "next")
 export INSTALLATION_METHOD="${INSTALLATION_METHOD:-helm}" # "helm" or "operator"
 
 # Playwright


### PR DESCRIPTION
## Summary
- Reverts the `RHDH_VERSION` pin introduced in #2326
- Restores the original `${RHDH_VERSION:-1.10}` default so the version is configurable via environment variable again
- [RHDHBUGS-3030](https://redhat.atlassian.net/browse/RHDHBUGS-3030) is resolved, so the workaround is no longer needed

Assisted-by: Claude Code