### PR TITLE
update: mark homepage backend as tech-preview plugin

### DIFF
--- a/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-homepage-backend.yaml
+++ b/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-homepage-backend.yaml
@@ -22,7 +22,7 @@ spec:
     role: backend-plugin
     supportedVersions: 1.49.4
   author: Red Hat
-  support: dev-preview
+  support: tech-preview
   lifecycle: active
   partOf:
     - home-page


### PR DESCRIPTION
Since we are onboarding this hompage-backend via konflux, we are marking this Plugin Tech preview.

