### PR TITLE
chore(e2e): tests for homepage rbac enhancement

### DIFF
--- a/workspaces/homepage/e2e-tests/package.json
+++ b/workspaces/homepage/e2e-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22",
+    "node": ">=24",
     "yarn": ">=3"
   },
   "packageManager": "yarn@4.12.0",

--- a/workspaces/homepage/e2e-tests/tests/config/app-config-rhdh.yaml
+++ b/workspaces/homepage/e2e-tests/tests/config/app-config-rhdh.yaml
@@ -1,0 +1,11 @@
+permission:
+  enabled: true
+  rbac:
+    policies-csv-file: "./rbac/rbac-policy.csv"
+    pluginsWithPermission:
+      - catalog
+      - permission
+      - homepage
+    admin:
+      users:
+        - name: user:default/homepage-admin

--- a/workspaces/homepage/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/homepage/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,6 +1,4 @@
 plugins:
-  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.49.4__0.1.0!red-hat-developer-hub-backstage-plugin-homepage-backend
-    disabled: true
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
     disabled: false
     pluginConfig:
@@ -22,6 +20,16 @@ plugins:
                   id: entity-section
                   title: Entity section
               - mountPoint: home.page/cards
+                importName: TemplateSection
+                config:
+                  id: template-section
+                  title: Template section
+              - mountPoint: home.page/cards
+                importName: QuickAccessCard
+                config:
+                  id: quickaccess-card
+                  title: Quick Access
+              - mountPoint: home.page/cards
                 importName: RecentlyVisitedCard
                 config:
                   id: recently-visited-card
@@ -31,11 +39,41 @@ plugins:
                 config:
                   id: top-visited-card
                   title: Top visited
-              - mountPoint: home.page/cards
-                importName: JokeCard
-                config:
-                  id: joke-card
-                  title: Random joke
             translationResources:
               - importName: homepageTranslations
                 ref: homepageTranslationRef
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.49.4__0.1.1!red-hat-developer-hub-backstage-plugin-homepage-backend
+    disabled: false
+    pluginConfig:
+      homepage:
+        defaultWidgets:
+          - id: onboarding-section
+            ref: onboarding-section
+            props:
+              title: Onboarding section
+          - id: entity-section
+            ref: entity-section
+            props:
+              title: Entity section
+          - if:
+              groups: [group:default/admins]
+            children:
+              - id: template-section
+                ref: template-section
+                props:
+                  title: Template section
+              - id: quickaccess-card
+                ref: quickaccess-card
+                props:
+                  title: Quick Access
+          - if:
+              groups: [group:default/developers]
+            children:
+              - id: recently-visited
+                ref: recently-visited-card
+                props:
+                  title: Recently Visited
+              - id: top-visited
+                ref: top-visited-card
+                props:
+                  title: Top Visited

--- a/workspaces/homepage/e2e-tests/tests/config/rbac-configmap.yaml
+++ b/workspaces/homepage/e2e-tests/tests/config/rbac-configmap.yaml
@@ -1,0 +1,17 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rbac-policy
+data:
+  rbac-policy.csv: |
+    g, user:default/homepage-admin, role:default/homepage-admin
+    p, role:default/homepage-admin, catalog-entity, read, allow
+    p, role:default/homepage-admin, homepage.default-widgets.read, read, allow
+
+    g, user:default/test1, role:default/homepage-user
+    p, role:default/homepage-user, catalog-entity, read, allow
+    p, role:default/homepage-user, homepage.default-widgets.read, read, allow
+
+    g, user:default/test2, role:default/homepage-user
+
+    g, user:default/test3, role:default/homepage-user

--- a/workspaces/homepage/e2e-tests/tests/config/value_file.yaml
+++ b/workspaces/homepage/e2e-tests/tests/config/value_file.yaml
@@ -1,0 +1,45 @@
+upstream:
+  backstage:
+    extraVolumeMounts:
+      # NOTE: Lists will not be merged with the default values file.
+      # Need to append all the defaults if you want to add a new item here.
+      # See https://issues.redhat.com/browse/RHDHPLAN-869
+      - name: dynamic-plugins-root
+        mountPath: /opt/app-root/src/dynamic-plugins-root
+      - name: extensions-catalog
+        mountPath: /extensions
+      - name: temp
+        mountPath: /tmp
+      - name: rbac-policy
+        mountPath: /opt/app-root/src/rbac
+    extraVolumes:
+      # NOTE: Lists will not be merged with the default values file.
+      # Need to append all the defaults if you want to add a new item here.
+      # See https://issues.redhat.com/browse/RHDHPLAN-869
+      - name: dynamic-plugins-root
+        emptyDir: {}
+      - name: dynamic-plugins
+        configMap:
+          defaultMode: 420
+          name: '{{ printf "%s-dynamic-plugins" .Release.Name }}'
+          optional: true
+      - name: dynamic-plugins-npmrc
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: '{{ printf "%s-dynamic-plugins-npmrc" .Release.Name }}'
+      - name: dynamic-plugins-registry-auth
+        secret:
+          defaultMode: 416
+          optional: true
+          secretName: '{{ printf "%s-dynamic-plugins-registry-auth" .Release.Name }}'
+      - name: npmcacache
+        emptyDir: {}
+      - name: extensions-catalog
+        emptyDir: {}
+      - name: temp
+        emptyDir: {}
+      - name: rbac-policy
+        configMap:
+          defaultMode: 420
+          name: rbac-policy

--- a/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
+++ b/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
@@ -1,50 +1,69 @@
-import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
+import { test, expect } from "@red-hat-developer-hub/e2e-test-utils/test";
 import {
   LoginHelper,
   UIhelper,
 } from "@red-hat-developer-hub/e2e-test-utils/helpers";
+import { $, WorkspacePaths } from "@red-hat-developer-hub/e2e-test-utils/utils";
 import type { BrowserContext, Page } from "@playwright/test";
-import { DynamicHomePagePo } from "../utils/dynamic-homepage";
+import {
+  DynamicHomePagePo,
+  AVAILABLE_WIDGETS,
+  DEFAULT_WIDGETS,
+  HOMEPAGE_ADMIN,
+  setupKeycloakGroups,
+} from "../utils/dynamic-homepage";
 
-/** Chart dist wrapper names (see ../metadata `spec.dynamicArtifact` basenames). */
 const DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES: string[] = [
   "red-hat-developer-hub-backstage-plugin-dynamic-home-page",
 ];
 
-/* Assertions live in DynamicHomePagePo (expect/verify*), matching RHDH core structure. */
-/* eslint-disable playwright/expect-expect -- see DynamicHomePagePo */
+/* eslint-disable playwright/expect-expect -- assertions in DynamicHomePagePo */
 test.describe.serial("Dynamic home page customization", () => {
   let context: BrowserContext | undefined;
   let page: Page;
   let uiHelper: UIhelper;
   let home: DynamicHomePagePo;
+  let baseURL: string;
+  let test1Count: number;
 
   test.beforeAll(async ({ browser, rhdh }) => {
     test.setTimeout(10 * 60 * 1000);
 
-    await rhdh.configure({
-      auth: "keycloak",
-      // Default chart tag in registry (avoid "next", which is not always published).
-      version: process.env.RHDH_VERSION ?? "1.10",
-      disableWrappers: DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES,
-    });
-    await rhdh.deploy();
+    await test.runOnce("homepage-setup", async () => {
+      await setupKeycloakGroups();
 
-    context = await browser.newContext({
-      baseURL: rhdh.rhdhUrl,
+      const rbacConfigmapPath = WorkspacePaths.resolve(
+        "tests/config/rbac-configmap.yaml",
+      );
+      const namespace = rhdh.deploymentConfig.namespace;
+      await $`oc apply -f ${rbacConfigmapPath} -n ${namespace}`;
+
+      await rhdh.configure({
+        auth: "keycloak",
+        disableWrappers: DYNAMIC_HOME_PAGE_WRAPPER_DIST_NAMES,
+      });
+      await rhdh.deploy();
     });
+    baseURL = rhdh.rhdhUrl;
+    context = await browser.newContext({ baseURL });
     page = await context.newPage();
     uiHelper = new UIhelper(page);
-    const loginHelper = new LoginHelper(page);
-    await loginHelper.loginAsKeycloakUser();
     home = new DynamicHomePagePo(page, uiHelper);
+    home.setBaseURL(baseURL);
   });
 
   test.afterAll(async () => {
     await context?.close();
   });
 
-  test("Verify cards display after login", async () => {
+  test("Verify default widgets from server config on first load", async () => {
+    await new LoginHelper(page).loginAsKeycloakUser();
+    await home.resetToDefaults();
+    await home.verifyHomePageLoaded();
+    await home.verifyDefaultWidgetsFromConfig(DEFAULT_WIDGETS.developer);
+  });
+
+  test("Verify cards display after seeding widgets", async () => {
     await home.seedHomePageWidgets();
     await home.verifyHomePageLoaded();
     await home.verifyAllCardsDisplayed();
@@ -63,7 +82,6 @@ test.describe.serial("Dynamic home page customization", () => {
     await home.exitEditMode();
   });
 
-  // restore defaults button is not working as expected
   // eslint-disable-next-line playwright/no-skipped-test -- re-enable when https://issues.redhat.com/browse/RHDHBUGS-2906 is fixed
   test.skip("Verify restore default cards and deleted with Clear all button", async () => {
     await home.restoreDefaultCards();
@@ -71,5 +89,176 @@ test.describe.serial("Dynamic home page customization", () => {
     await home.enterEditMode();
     await home.clearAllCardsWithButton();
     await home.verifyCardsDeleted();
+  });
+
+  test.describe("Plugin management", () => {
+    test("Add widget dialog lists all available plugins", async () => {
+      await home.enterEditMode();
+      await home.clearAllCardsWithButton();
+      await home.verifyAllWidgetsAvailableInDialog();
+    });
+
+    test("Each widget type can be added individually", async () => {
+      for (const widget of AVAILABLE_WIDGETS) {
+        await home.addWidget(widget);
+      }
+      await home.verifyAllCardsDisplayed();
+    });
+
+    test("Widgets can be removed and re-added in a single edit session", async () => {
+      await home.clearAllCardsWithButton();
+      await home.verifyCardsDeleted();
+
+      await home.addWidget("Entity Section");
+      await home.addWidget("Recently visited");
+      await home.exitEditMode();
+
+      await home.verifySpecificCardsDisplayed([
+        "Explore Your Software Catalog",
+        "Recently Visited",
+      ]);
+      await home.verifyCardNotDisplayed("Top Visited");
+    });
+
+    test("Multiple widgets of the same type produce distinct cards", async () => {
+      await home.enterEditMode();
+      await home.clearAllCardsWithButton();
+      await home.verifyCardsDeleted();
+      await home.addWidget("Entity Section");
+      await home.addWidget("Entity Section");
+      await home.exitEditMode();
+
+      const cardCount = await home.getVisibleCardCount();
+      expect(cardCount).toBe(2);
+    });
+
+    test("Widget layout survives edit mode toggle", async () => {
+      await home.enterEditMode();
+      await home.clearAllCardsWithButton();
+      await home.addWidget("Entity Section");
+      await home.addWidget("Onboarding Section");
+      await home.exitEditMode();
+
+      const countAfterSave = await home.getVisibleCardCount();
+
+      await home.enterEditMode();
+      await home.exitEditMode();
+
+      const countAfterToggle = await home.getVisibleCardCount();
+      expect(countAfterToggle).toBe(countAfterSave);
+    });
+  });
+
+  test.describe("Persistent storage", () => {
+    test("Customizations persist across page reload", async () => {
+      await home.seedHomePageWidgets();
+
+      const countBeforeReload = await home.getVisibleCardCount();
+      expect(countBeforeReload).toBeGreaterThan(0);
+
+      await page.reload();
+      await home.verifyHomePageLoaded();
+
+      const countAfterReload = await home.getVisibleCardCount();
+      expect(countAfterReload).toBe(countBeforeReload);
+      await home.verifyAllCardsDisplayed();
+    });
+
+    test("Customizations persist across logout and re-login", async () => {
+      const countBeforeLogout = await home.getVisibleCardCount();
+      expect(countBeforeLogout).toBeGreaterThan(0);
+
+      await home.reloginAsKeycloakUser();
+      await home.verifyHomePageLoaded();
+
+      const countAfterRelogin = await home.getVisibleCardCount();
+      expect(countAfterRelogin).toBe(countBeforeLogout);
+    });
+
+    test("Resized layout persists after reload", async () => {
+      await home.enterEditMode();
+      await home.clearAllCardsWithButton();
+      await home.addWidget("Entity Section");
+      await home.resizeFirstCard();
+      await home.exitEditMode();
+      const panel = page.locator('[class*="react-grid-item"]').first();
+      const sizeBeforeReload = await panel.boundingBox();
+      expect(sizeBeforeReload).not.toBeNull();
+      await page.reload();
+      await home.verifyHomePageLoaded();
+
+      const panelAfterReload = page
+        .locator('[class*="react-grid-item"]')
+        .first();
+      const sizeAfterReload = await panelAfterReload.boundingBox();
+      expect(sizeAfterReload).not.toBeNull();
+
+      expect(sizeAfterReload!.width).toBeCloseTo(sizeBeforeReload!.width, 0);
+      expect(sizeAfterReload!.height).toBeCloseTo(sizeBeforeReload!.height, 0);
+    });
+
+    test("Per-user isolation: test2 sees defaults", async () => {
+      await home.reloginAsKeycloakUser();
+      await home.verifyHomePageLoaded();
+      await home.seedHomePageWidgets();
+      test1Count = await home.getVisibleCardCount();
+      expect(test1Count).toBe(AVAILABLE_WIDGETS.length);
+      await home.reloginAsKeycloakUser("test2", "test2@123");
+      await home.verifyHomePageLoaded();
+      await home.verifyDefaultWidgetsFromConfig(DEFAULT_WIDGETS.developer);
+    });
+
+    test("test2 customization does not affect test1 layout", async () => {
+      await home.reloginAsKeycloakUser("test2", "test2@123");
+      await home.verifyHomePageLoaded();
+      await home.enterEditMode();
+      await home.clearAllCardsWithButton();
+      await home.verifyCardsDeleted();
+      await home.reloginAsKeycloakUser();
+      await home.verifyHomePageLoaded();
+      const test1CountAfter = await home.getVisibleCardCount();
+      expect(test1CountAfter).toBe(test1Count);
+    });
+  });
+
+  test.describe("Persona-based homepages", () => {
+    test("Admin sees all group widgets", async () => {
+      await home.reloginAsKeycloakUser(
+        HOMEPAGE_ADMIN.username,
+        HOMEPAGE_ADMIN.password,
+      );
+      await home.verifyHomePageLoaded();
+      await home.verifyDefaultWidgetsFromConfig(DEFAULT_WIDGETS.admin);
+    });
+
+    test("Developer sees developer widgets only", async () => {
+      await home.reloginAsKeycloakUser("test2", "test2@123");
+      await home.verifyHomePageLoaded();
+      await home.verifyDefaultWidgetsFromConfig(DEFAULT_WIDGETS.developer);
+      for (const widget of DEFAULT_WIDGETS.adminOnly) {
+        await home.verifyCardNotDisplayed(widget);
+      }
+    });
+
+    test("Non-group user sees only common widgets", async () => {
+      await home.reloginAsNonGroupUser();
+      await home.verifyHomePageLoaded();
+      await home.verifyDefaultWidgetsFromConfig(DEFAULT_WIDGETS.guest);
+      for (const widget of [
+        ...DEFAULT_WIDGETS.adminOnly,
+        ...DEFAULT_WIDGETS.developerOnly,
+      ]) {
+        await home.verifyCardNotDisplayed(widget);
+      }
+    });
+
+    test("Non-group user can add widgets to personalize their view", async () => {
+      await home.enterEditMode();
+      await home.addWidget("Entity section");
+      await home.exitEditMode();
+      await home.verifySpecificCardsDisplayed([
+        "Explore Your Software Catalog",
+      ]);
+    });
   });
 });

--- a/workspaces/homepage/e2e-tests/tests/utils/dynamic-homepage.ts
+++ b/workspaces/homepage/e2e-tests/tests/utils/dynamic-homepage.ts
@@ -3,7 +3,11 @@ import {
   type Locator,
   type Page,
 } from "@red-hat-developer-hub/e2e-test-utils/test";
-import type { UIhelper } from "@red-hat-developer-hub/e2e-test-utils/helpers";
+import {
+  LoginHelper,
+  type UIhelper,
+} from "@red-hat-developer-hub/e2e-test-utils/helpers";
+import { KeycloakHelper } from "@red-hat-developer-hub/e2e-test-utils/keycloak";
 
 const EXPECTED_CARD_TEXTS = [
   "Good (morning|afternoon|evening)",
@@ -12,22 +16,117 @@ const EXPECTED_CARD_TEXTS = [
   "Top Visited",
 ] as const;
 
+/** All widgets available in the "Add widget" dialog. */
+export const AVAILABLE_WIDGETS = [
+  "Onboarding Section",
+  "Entity Section",
+  "Recently visited",
+  "Top visited",
+] as const;
+
+const COMMON = ["Explore Your Software Catalog"];
+const ADMIN_ONLY = ["Explore Templates", "Quick Access"];
+const DEVELOPER_ONLY = ["Recently Visited", "Top Visited"];
+
+/** Expected default widgets per persona based on if.groups config. */
+export const DEFAULT_WIDGETS = {
+  admin: [...COMMON, ...ADMIN_ONLY, ...DEVELOPER_ONLY],
+  developer: [...COMMON, ...DEVELOPER_ONLY],
+  guest: [...COMMON],
+  adminOnly: ADMIN_ONLY,
+  developerOnly: DEVELOPER_ONLY,
+};
+
+export const HOMEPAGE_ADMIN = {
+  username: "homepage-admin",
+  password: "homepage-admin@123", // gitleaks:allow
+};
+
+const HOMEPAGE_TEST3 = {
+  username: "test3",
+  password: "test3@123", // gitleaks:allow
+};
+
+export async function setupKeycloakGroups(): Promise<void> {
+  const keycloak = new KeycloakHelper();
+  await keycloak.connect({
+    baseUrl: process.env.KEYCLOAK_BASE_URL!,
+    username: process.env.VAULT_KEYCLOAK_ADMIN_USERNAME!,
+    password: process.env.VAULT_KEYCLOAK_ADMIN_PASSWORD!,
+  });
+
+  await keycloak.deleteUser("rhdh", HOMEPAGE_ADMIN.username).catch(() => {});
+  await keycloak.createUser("rhdh", {
+    username: HOMEPAGE_ADMIN.username,
+    password: HOMEPAGE_ADMIN.password,
+    firstName: "Homepage",
+    lastName: "Admin",
+    email: "homepage-admin@rhdh.test",
+    groups: ["admins", "developers"],
+  });
+
+  await keycloak.deleteUser("rhdh", HOMEPAGE_TEST3.username).catch(() => {});
+  await keycloak.createUser("rhdh", {
+    username: HOMEPAGE_TEST3.username,
+    password: HOMEPAGE_TEST3.password,
+    firstName: "Test",
+    lastName: "User3",
+    email: "test3@rhdh.test",
+    groups: ["viewers"],
+  });
+}
+
 /**
  * Flows ported from rhdh e2e-tests/playwright/support/pages/home-page-customization.ts
  * (same locators/behavior, uses overlay UIhelper).
  */
 export class DynamicHomePagePo {
+  private baseURL = "";
+
   constructor(
     private readonly page: Page,
     private readonly ui: UIhelper,
   ) {}
+
+  setBaseURL(url: string): void {
+    this.baseURL = url;
+  }
+
+  private async signOut(): Promise<void> {
+    await this.page.goto(`${this.baseURL}/settings`);
+    await this.page.getByTestId("user-settings-menu").click();
+    await this.page.getByTestId("sign-out").locator("div").click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for sign-out redirect
+    await this.page.waitForTimeout(2000);
+  }
+
+  async reloginAsKeycloakUser(
+    username = "test1",
+    password = "test1@123",
+  ): Promise<void> {
+    await this.signOut();
+    await this.page.context().clearCookies();
+    await this.page.goto(this.baseURL);
+    await new LoginHelper(this.page).loginAsKeycloakUser(username, password);
+  }
+
+  async reloginAsNonGroupUser(): Promise<void> {
+    await this.signOut();
+    await this.page.context().clearCookies();
+    await this.page.goto(this.baseURL);
+    await new LoginHelper(this.page).loginAsKeycloakUser(
+      HOMEPAGE_TEST3.username,
+      HOMEPAGE_TEST3.password,
+    );
+  }
 
   private readonly editButton = () => this.page.getByText("Edit");
   private readonly saveButton = () =>
     this.page.getByText("Save", {
       exact: true,
     });
-  private readonly clearAllButton = () => this.page.getByText("Clear all");
+  private readonly clearAllButton = () =>
+    this.page.getByRole("button", { name: "Clear all" });
   private readonly restoreDefaultsButton = () =>
     this.page.getByText("Restore defaults");
   private readonly addWidgetButton = () =>
@@ -41,7 +140,17 @@ export class DynamicHomePagePo {
 
   async verifyHomePageLoaded(): Promise<void> {
     await this.ui.verifyHeading("Welcome back");
-    await expect(this.greetingText()).toBeVisible();
+    await expect(
+      this.page.locator('[class*="react-grid-item"]').first(),
+    ).toBeVisible({ timeout: 15_000 });
+    await this.dismissQuickstart();
+  }
+
+  private async dismissQuickstart(): Promise<void> {
+    const hideBtn = this.page.getByRole("button", { name: "Hide" });
+    if (await hideBtn.isVisible()) {
+      await hideBtn.click();
+    }
   }
 
   async verifyAllCardsDisplayed(): Promise<void> {
@@ -63,12 +172,12 @@ export class DynamicHomePagePo {
    * Used when tests need a full grid without relying on restore-defaults (skipped / broken).
    */
   async seedHomePageWidgets(): Promise<void> {
-    await this.addWidget("Entity Section");
     await this.enterEditMode();
+    await this.deleteAllCards();
+    await this.addWidget("Entity Section");
     await this.addWidget("Onboarding Section");
     await this.addWidget("Recently visited");
     await this.addWidget("Top visited");
-    await this.addWidget("Random joke");
     await this.exitEditMode();
   }
 
@@ -121,45 +230,48 @@ export class DynamicHomePagePo {
     await this.page.mouse.move(startX + delta, startY + delta, { steps: 12 });
     await this.page.mouse.up();
     // eslint-disable-next-line playwright/no-wait-for-timeout -- layout after resize
-    await this.page.waitForTimeout(600);
+    await this.page.waitForTimeout(500);
   }
 
   async deleteAllCards(): Promise<void> {
+    await this.dismissQuickstart();
     for (let n = 0; n < 50; n++) {
-      const currentButtons = this.deleteButtons();
-      const currentCount = await currentButtons.count();
-      if (currentCount === 0) {
+      if ((await this.deleteButtons().count()) === 0) {
         break;
       }
-      await currentButtons.first().click();
-      // eslint-disable-next-line playwright/no-wait-for-timeout -- upstream timing between deletes
-      await this.page.waitForTimeout(1000);
+      await this.deleteButtons().last().click();
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for DOM to stabilize after card removal
+      await this.page.waitForTimeout(2000);
     }
   }
 
   async clearAllCardsWithButton(): Promise<void> {
-    await this.ui.clickButton("Clear all");
+    await expect(this.clearAllButton()).toBeVisible({ timeout: 5_000 });
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for edit mode to stabilize
+    await this.page.waitForTimeout(500);
+    await this.clearAllButton().click();
   }
 
   async verifyCardsDeleted(): Promise<void> {
-    await expect(this.clearAllButton()).toBeHidden();
-    await expect(this.saveButton()).toBeHidden();
+    const gridItems = this.page.locator('[class*="react-grid-item"]');
+    await expect(gridItems).toHaveCount(0, { timeout: 10_000 });
     await expect(this.restoreDefaultsButton()).toBeVisible();
     await expect(this.addWidgetButton()).toBeVisible();
-
-    for (const card of EXPECTED_CARD_TEXTS) {
-      if (card.startsWith("Good")) {
-        await expect(this.greetingText()).toBeHidden();
-      } else {
-        await expect(this.page.getByText(card)).toBeHidden();
-      }
-    }
   }
 
   async restoreDefaultCards(): Promise<void> {
     await this.ui.clickButton("Restore defaults");
     // eslint-disable-next-line playwright/no-wait-for-timeout -- upstream wait for layout
     await this.page.waitForTimeout(2000);
+  }
+
+  async resetToDefaults(): Promise<void> {
+    await this.dismissQuickstart();
+    await this.enterEditMode();
+    await this.clearAllCardsWithButton();
+    await expect(this.restoreDefaultsButton()).toBeVisible({ timeout: 5_000 });
+    await this.restoreDefaultCards();
+    await this.exitEditMode();
   }
 
   async verifyCardsRestored(): Promise<void> {
@@ -174,5 +286,50 @@ export class DynamicHomePagePo {
     await this.page.getByRole("button", { name: widgetType }).click();
     // eslint-disable-next-line playwright/no-wait-for-timeout -- widget mount
     await this.page.waitForTimeout(1000);
+  }
+
+  /** Returns count of visible widget cards on the homepage grid. */
+  async getVisibleCardCount(): Promise<number> {
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for layout to stabilize
+    await this.page.waitForTimeout(500);
+    return this.page.locator('[class*="react-grid-item"]').count();
+  }
+
+  /** Verifies that exactly the given widget titles are visible on the homepage. */
+  async verifySpecificCardsDisplayed(cardTexts: string[]): Promise<void> {
+    for (const text of cardTexts) {
+      await expect(
+        this.page.getByText(text, { exact: true }).first(),
+      ).toBeVisible({ timeout: 10_000 });
+    }
+  }
+
+  /** Verifies a specific card text is NOT visible on the homepage. */
+  async verifyCardNotDisplayed(cardText: string): Promise<void> {
+    await expect(this.page.getByText(cardText, { exact: true })).toBeHidden();
+  }
+
+  /** Verifies the "Add widget" dialog lists all expected widget options. */
+  async verifyAllWidgetsAvailableInDialog(): Promise<void> {
+    await this.ui.clickButton("Add widget");
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- dialog open
+    await this.page.waitForTimeout(1000);
+    for (const widget of AVAILABLE_WIDGETS) {
+      await expect(
+        this.page.getByRole("button", { name: widget }),
+      ).toBeVisible();
+    }
+    await this.page.keyboard.press("Escape");
+  }
+
+  /** Verifies default widgets from server config are displayed on first load. */
+  async verifyDefaultWidgetsFromConfig(
+    expectedTitles: string[] = [],
+  ): Promise<void> {
+    for (const title of expectedTitles) {
+      await expect(
+        this.page.getByText(title, { exact: true }).first(),
+      ).toBeVisible({ timeout: 15_000 });
+    }
   }
 }

--- a/workspaces/homepage/e2e-tests/tsconfig.json
+++ b/workspaces/homepage/e2e-tests/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "@red-hat-developer-hub/e2e-test-utils/tsconfig",
-  "compilerOptions": {
-    "lib": ["ES2022", "DOM"]
-  },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
E2E test for homepage RBAC enhancements 

[RHIDP-13158](https://redhat.atlassian.net/browse/RHIDP-13158)

Note: CI test will fail on the current default chart as the homepage frontend plugin `v1.13.1` and backend `v0.1.1` (DynamicCustomizableHomePage + defaultWidgets) are not bundled in RHDH `1.10-114-CI`; tests require newer chart versions.