### PR TITLE
chore: add cost-management plugins to rhdh-supported-packages.txt

### DIFF
--- a/rhdh-supported-packages.txt
+++ b/rhdh-supported-packages.txt
@@ -95,3 +95,7 @@ backstage/plugins/events-backend-module-github
 # Lightspeed plugins - Dev Preview in 1.9, planned to GA in 1.10
 lightspeed/plugins/lightspeed
 lightspeed/plugins/lightspeed-backend
+
+# Cost Management plugins - Dev Preview in 1.9, heading to GA in 1.10
+cost-management/plugins/cost-management
+cost-management/plugins/cost-management-backend


### PR DESCRIPTION
### Description

Added cost-management plugins to rhdh-supported-packages.txt

Add cost-management and cost-management-backend to the supported packages list to onboard the Cost Management plugin to the Konflux build pipeline as per [Konflux onboarding documentation](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog/-/blob/rhdh-1-rhel-9/docs/ONBOARD_KONFLUX.adoc?ref_type=heads).