### PR TITLE
fix(smoketest): fail early on unhealthy RHDH startup

### DIFF
--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -117,6 +117,27 @@ jobs:
           echo "RHDH did not become ready in time."
           exit 1
 
+      - name: Verify RHDH startup logs
+        run: |
+          set -euo pipefail
+          LOGS=$(docker logs rhdh 2>&1 || true)
+
+          STARTUP_SUCCESS_PATTERN="Starting Developer Hub backend|rootHttpRouter.*Listening on :7007|Plugin initialization started"
+          if ! echo "$LOGS" | grep -qiE "$STARTUP_SUCCESS_PATTERN"; then
+            echo "RHDH startup logs do not contain expected startup markers."
+            echo "Expected one of: $STARTUP_SUCCESS_PATTERN"
+            exit 1
+          fi
+
+          STARTUP_ERROR_PATTERN="InstallException|Error while adding OCI plugin|Failed to load dynamic plugin|dynamic plugin.*error|threw an error during startup|Missing required config value|ConfigReader.*(error|missing)|Invalid app-config|UnhandledPromiseRejection|uncaughtException"
+          if echo "$LOGS" | grep -qiE "$STARTUP_ERROR_PATTERN"; then
+            echo "Detected startup errors in RHDH logs:"
+            echo "$LOGS" | grep -iE -B 2 -A 2 "$STARTUP_ERROR_PATTERN" | grep -v "^--$" | tail -n 120 || true
+            exit 1
+          fi
+
+          echo "RHDH startup logs look healthy."
+
       - name: List installed plugins
         run: docker exec rhdh ls -l /opt/app-root/src/dynamic-plugins-root
 
@@ -126,7 +147,7 @@ jobs:
       - name: Verify plugin loading
         id: collect-results
         run: |
-          set -e
+          set -euo pipefail
           PLUGINS=$(grep -Eo '!([^[:space:]]+)' ./artifacts/dynamic-plugins.test.yaml | sed -e 's/^!//' -e 's/"$//' | sort -u)
           if [ -z "$PLUGINS" ]; then
             echo "No plugins found in dynamic-plugins.test.yaml"
@@ -137,6 +158,7 @@ jobs:
             exit 0
           fi
           LOGS=$(docker logs rhdh || true)
+          SHARED_HARD_ERROR_PATTERN="InstallException|Error while adding OCI plugin|Failed to load dynamic plugin|dynamic plugin.*error|threw an error during startup|Missing required config value|ConfigReader.*(error|missing)|Invalid app-config|UnhandledPromiseRejection|uncaughtException"
           failures=()
           echo "===== Checking logs for plugin loaded messages"
           for plugin in $PLUGINS; do
@@ -149,8 +171,8 @@ jobs:
               failures+=("$plugin")
             fi
           done
-          if echo "$LOGS" | grep -E "(InstallException|Error while adding OCI plugin|Failed to load dynamic plugin|dynamic plugin.*error)" >/dev/null; then
-            echo "Detected dynamic plugin loading errors in logs"
+          if echo "$LOGS" | grep -qiE "$SHARED_HARD_ERROR_PATTERN"; then
+            echo "Detected dynamic plugin loading/startup hard errors in logs"
             failures+=("(log-errors)")
           fi
           if [ ${#failures[@]} -eq 0 ]; then

--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -117,34 +117,13 @@ jobs:
           echo "RHDH did not become ready in time."
           exit 1
 
-      - name: Verify RHDH startup logs
-        run: |
-          set -euo pipefail
-          LOGS=$(docker logs rhdh 2>&1 || true)
-
-          STARTUP_SUCCESS_PATTERN="Plugin initialization complete"
-          if ! echo "$LOGS" | grep -qiE "$STARTUP_SUCCESS_PATTERN"; then
-            echo "RHDH startup logs do not contain expected startup markers."
-            echo "Expected one of: $STARTUP_SUCCESS_PATTERN"
-            exit 1
-          fi
-
-          STARTUP_ERROR_PATTERN="InstallException|Error while adding OCI plugin|Failed to load dynamic plugin|dynamic plugin.*error|threw an error during startup|Missing required config value|ConfigReader.*(error|missing)|Invalid app-config|UnhandledPromiseRejection|uncaughtException"
-          if echo "$LOGS" | grep -qiE "$STARTUP_ERROR_PATTERN"; then
-            echo "Detected startup errors in RHDH logs:"
-            echo "$LOGS" | grep -iE -B 2 -A 2 "$STARTUP_ERROR_PATTERN" | grep -v "^--$" | tail -n 120 || true
-            exit 1
-          fi
-
-          echo "RHDH startup logs look healthy."
-
       - name: List installed plugins
         run: docker exec rhdh ls -l /opt/app-root/src/dynamic-plugins-root
 
       - name: Print generated dynamic plugins config
         run: docker exec rhdh cat /opt/app-root/src/dynamic-plugins-root/app-config.dynamic-plugins.yaml
 
-      - name: Verify plugin loading
+      - name: Validate RHDH startup and plugin loading
         id: collect-results
         run: |
           set -euo pipefail
@@ -158,8 +137,21 @@ jobs:
             exit 0
           fi
           LOGS=$(docker logs rhdh || true)
+          STARTUP_SUCCESS_PATTERN="Plugin initialization complete"
           SHARED_HARD_ERROR_PATTERN="InstallException|Error while adding OCI plugin|Failed to load dynamic plugin|dynamic plugin.*error|threw an error during startup|Missing required config value|ConfigReader.*(error|missing)|Invalid app-config|UnhandledPromiseRejection|uncaughtException"
           failures=()
+
+          echo "===== Checking startup markers"
+          if ! echo "$LOGS" | grep -qiE "$STARTUP_SUCCESS_PATTERN"; then
+            echo "Startup marker missing: $STARTUP_SUCCESS_PATTERN"
+            failures+=("(startup-marker-missing)")
+          fi
+
+          if echo "$LOGS" | grep -qiE "$SHARED_HARD_ERROR_PATTERN"; then
+            echo "Detected startup/plugin hard errors in logs"
+            failures+=("(log-errors)")
+          fi
+
           echo "===== Checking logs for plugin loaded messages"
           for plugin in $PLUGINS; do
             echo "Asserting plugin loaded: $plugin"
@@ -171,10 +163,6 @@ jobs:
               failures+=("$plugin")
             fi
           done
-          if echo "$LOGS" | grep -qiE "$SHARED_HARD_ERROR_PATTERN"; then
-            echo "Detected dynamic plugin loading/startup hard errors in logs"
-            failures+=("(log-errors)")
-          fi
           if [ ${#failures[@]} -eq 0 ]; then
             echo "success=true" >> "$GITHUB_OUTPUT"
             echo "failed-plugins<<EOF" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -122,7 +122,7 @@ jobs:
           set -euo pipefail
           LOGS=$(docker logs rhdh 2>&1 || true)
 
-          STARTUP_SUCCESS_PATTERN="Starting Developer Hub backend|rootHttpRouter.*Listening on :7007|Plugin initialization started"
+          STARTUP_SUCCESS_PATTERN="Plugin initialization complete"
           if ! echo "$LOGS" | grep -qiE "$STARTUP_SUCCESS_PATTERN"; then
             echo "RHDH startup logs do not contain expected startup markers."
             echo "Expected one of: $STARTUP_SUCCESS_PATTERN"


### PR DESCRIPTION
Add a startup log gate after health checks so smoke tests fail on backend boot/config errors instead of only plugin load symptoms. This makes overlay smoke failures clearer and diagnostics easier.