### PR TITLE
chore(e2e): add scorecard custom severity e2e

### DIFF
--- a/workspaces/scorecard/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/scorecard/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -62,6 +62,20 @@ plugins:
                   minutes: 15
                 initialDelay:
                   seconds: 5
+              thresholds:
+                rules:
+                  - key: ideal
+                    expression: "<30"
+                    icon: star
+                    color: "rgb(180, 211, 178)"
+                  - key: warning
+                    expression: 30-70
+                    icon: scorecardWarningStatusIcon
+                    color: "#FAD5A5"
+                  - key: critical
+                    expression: ">70"
+                    icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" style="color:#FAA0A0"><rect x="4" y="4" width="16" height="16" rx="2" stroke="#FAA0A0" stroke-width="2"/><path d="M9 9l6 6M15 9l-6 6" stroke="#FAA0A0" stroke-width="2" stroke-linecap="round"/></svg>
+                    color: "#faa0a0"
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.49.4__2.7.4!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira
     disabled: false
     pluginConfig:

--- a/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
+++ b/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
@@ -88,6 +88,13 @@ test.describe.serial("Scorecard Plugin Tests", () => {
       () => scorecard.navigateToHome(),
       githubMetric,
       "github.open_prs",
+      {
+        thresholdRules: [
+          { key: "ideal", color: "rgb(180, 211, 178)" },
+          { key: "warning", color: "rgb(250, 213, 165)" },
+          { key: "critical", color: "rgb(250, 160, 160)" },
+        ],
+      },
     );
   });
 
@@ -106,6 +113,12 @@ test.describe.serial("Scorecard Plugin Tests", () => {
       () => scorecard.navigateToHome(),
       FILECHECK_METRICS.readme,
       "filecheck.readme",
+      {
+        thresholdRules: [
+          { key: "exist", color: "rgb(46, 125, 50)" },
+          { key: "missing", color: "rgb(211, 47, 47)" },
+        ],
+      },
     );
   });
 
@@ -175,6 +188,20 @@ test.describe.serial("Scorecard Plugin Tests", () => {
       await scorecard.expectScorecardVisible(jiraMetric.title);
       await scorecard.expectErrorHeading("Invalid thresholds");
       await scorecard.validateScorecardAriaFor(jiraMetric);
+    });
+
+    test("Display custom severity keys with custom threshold expressions, colors and icon", async () => {
+      await catalog.go();
+      await catalog.goToByName("github-scorecard-only");
+      await scorecard.openTab();
+
+      const [githubMetric] = SCORECARD_METRICS;
+      await scorecard.validateThresholdLegend(githubMetric, [
+        { key: "ideal", expression: "<30", color: "rgb(180, 211, 178)" },
+        { key: "warning", expression: "30-70", color: "rgb(250, 213, 165)" },
+        { key: "critical", expression: ">70", color: "rgb(250, 160, 160)" },
+      ]);
+      await scorecard.expectScorecardValue(githubMetric.title, "StarIcon");
     });
 
     // Re-enable once https://issues.redhat.com/browse/RHIDP-12130 is fixed

--- a/workspaces/scorecard/e2e-tests/tests/utils/aggregated-scorecard.ts
+++ b/workspaces/scorecard/e2e-tests/tests/utils/aggregated-scorecard.ts
@@ -1,11 +1,6 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
-import { DEFAULT_THRESHOLD_LABELS } from "./constants";
-
-export type AggregatedScorecardMetric = {
-  readonly title: string;
-  readonly description: string;
-  readonly thresholdLabels?: readonly string[];
-};
+import { DEFAULT_THRESHOLD_LABELS, DEFAULT_THRESHOLD_RULES } from "./constants";
+import type { ScorecardMetric, ThresholdRule } from "./types";
 
 /** URL pattern for `/scorecard/aggregations/:id/metrics/:id` (matches `metricId` from dynamic-plugins). */
 export function drilldownUrlPattern(metricId: string): RegExp {
@@ -29,21 +24,22 @@ export function aggregatedScorecardHelpers(page: Page) {
 
     async expectHomepageCardDisplaysMetric(
       card: Locator,
-      metric: AggregatedScorecardMetric,
+      metric: ScorecardMetric,
     ) {
       const labels = metric.thresholdLabels ?? DEFAULT_THRESHOLD_LABELS;
       await expect(card.getByText(metric.title, { exact: true })).toBeVisible();
       await expect(card).toContainText(metric.description);
-      await expect(card.getByText(labels[0], { exact: true })).toBeVisible({
-        timeout: 60_000,
-      });
+      for (const thresholdLabel of labels) {
+        await expect(
+          card.getByText(thresholdLabel, { exact: true }),
+        ).toBeVisible({
+          timeout: 60_000,
+        });
+      }
     },
 
     /** Hovers each visible threshold color swatch and checks the chart tooltip text. */
-    async expectChartThresholdTooltips(
-      card: Locator,
-      metric: AggregatedScorecardMetric,
-    ) {
+    async expectChartThresholdTooltips(card: Locator, metric: ScorecardMetric) {
       const labels = metric.thresholdLabels ?? DEFAULT_THRESHOLD_LABELS;
       const chart = page.locator(".v5-MuiBox-root");
 
@@ -93,7 +89,7 @@ export function aggregatedScorecardHelpers(page: Page) {
 
     async expectDrilldownCardAriaSnapshot(
       metricId: string,
-      metric: AggregatedScorecardMetric,
+      metric: ScorecardMetric,
     ) {
       const card = homepageCard(metricId);
       await expect(card).toBeVisible({ timeout: 120_000 });
@@ -142,6 +138,26 @@ ${thresholdLabelSnapshots}
       await expect(page.getByText(/\d-\d+ of \d+/)).toBeVisible();
     },
 
+    async expectDrilldownThresholdLegend(
+      metricId: string,
+      rules: readonly Pick<ThresholdRule, "key" | "color">[],
+    ) {
+      const card = homepageCard(metricId);
+      await expect(card).toBeVisible({ timeout: 120_000 });
+      for (const rule of rules) {
+        await expect(card).toContainText(
+          rule.key.charAt(0).toUpperCase() + rule.key.slice(1),
+        );
+        const swatch = card.getByTestId(
+          `legend-colorbox-${rule.key.toLowerCase()}`,
+        );
+        await expect(swatch).toBeVisible({ timeout: 60_000 });
+        if (rule.color) {
+          await expect(swatch).toHaveCSS("background-color", rule.color);
+        }
+      }
+    },
+
     /**
      * Homepage card when aggregation `total === 0`: {@link EmptyStatePanel} shows
      * "No data found", helper copy, and **no** `/scorecard/aggregations/...` drill-down link.
@@ -151,7 +167,7 @@ ${thresholdLabelSnapshots}
      */
     async runAggregatedScorecardNoDataHomepageScenario(
       navigateToHome: () => Promise<void>,
-      metric: AggregatedScorecardMetric,
+      metric: ScorecardMetric,
       metricId: string,
       options?: { skipIfHasDrilldown?: boolean },
     ) {
@@ -186,8 +202,11 @@ ${thresholdLabelSnapshots}
 
     async runAggregatedScorecardDrilldownScenario(
       navigateToHome: () => Promise<void>,
-      metric: AggregatedScorecardMetric,
+      metric: ScorecardMetric,
       metricId: string,
+      options?: {
+        thresholdRules?: readonly Pick<ThresholdRule, "key" | "color">[];
+      },
     ) {
       await navigateToHome();
       await page.reload();
@@ -214,6 +233,13 @@ ${thresholdLabelSnapshots}
 
       await test.step("Drill-down page scorecard card snapshot", async () => {
         await impl.expectDrilldownCardAriaSnapshot(metricId, metric);
+      });
+
+      await test.step("Drill-down threshold legend", async () => {
+        await impl.expectDrilldownThresholdLegend(
+          metricId,
+          options?.thresholdRules ?? DEFAULT_THRESHOLD_RULES,
+        );
       });
 
       await test.step("Drill-down entity table columns and rows", async () => {

--- a/workspaces/scorecard/e2e-tests/tests/utils/constants.ts
+++ b/workspaces/scorecard/e2e-tests/tests/utils/constants.ts
@@ -1,1 +1,6 @@
 export const DEFAULT_THRESHOLD_LABELS = ["Success", "Warning", "Error"];
+export const DEFAULT_THRESHOLD_RULES = [
+  { key: "success", color: "rgb(46, 125, 50)" },
+  { key: "warning", color: "rgb(237, 108, 2)" },
+  { key: "error", color: "rgb(211, 47, 47)" },
+];

--- a/workspaces/scorecard/e2e-tests/tests/utils/scorecard.ts
+++ b/workspaces/scorecard/e2e-tests/tests/utils/scorecard.ts
@@ -1,5 +1,7 @@
 import { expect, type Page } from "@playwright/test";
 import type { UIhelper } from "@red-hat-developer-hub/e2e-test-utils/helpers";
+import type { ScorecardMetric, ThresholdRule } from "./types";
+import { DEFAULT_THRESHOLD_LABELS } from "./constants";
 
 export const FILECHECK_METRICS = {
   readme: {
@@ -19,6 +21,7 @@ export const SCORECARD_METRICS = [
     title: "GitHub open PRs",
     description:
       "Current count of open Pull Requests for a given GitHub repository.",
+    thresholdLabels: ["Ideal", "Warning", "Critical"],
   },
   {
     title: "Jira open blocking tickets",
@@ -28,7 +31,13 @@ export const SCORECARD_METRICS = [
 ] as const;
 
 export function scorecardHelpers(page: Page, uiHelper: UIhelper) {
+  const getScorecardCard = (metric: ScorecardMetric) =>
+    page
+      .locator("article")
+      .filter({ has: page.locator(`[aria-label="${metric.title}"]`) });
+
   return {
+    getScorecardCard,
     async openTab() {
       const tab = page.getByRole("tab", { name: "Scorecard" });
       await expect(tab).toBeVisible();
@@ -43,19 +52,38 @@ export function scorecardHelpers(page: Page, uiHelper: UIhelper) {
         page.getByRole("link", { name: "View documentation" }),
       ).toBeVisible();
     },
-    async validateScorecardAriaFor(scorecard: {
-      title: string;
-      description: string;
-    }) {
-      const section = page
-        .locator("article")
-        .filter({ hasText: scorecard.title });
-      await expect(section).toBeVisible();
-      await expect(section).toContainText(scorecard.title);
-      await expect(section).toContainText(scorecard.description);
-      await expect(section).toContainText(/Success/);
-      await expect(section).toContainText(/Warning/);
-      await expect(section).toContainText(/Error/);
+    async validateScorecardAriaFor(scorecard: ScorecardMetric) {
+      const scorecardCard = getScorecardCard(scorecard);
+      await expect(scorecardCard).toBeVisible();
+      await expect(scorecardCard).toContainText(scorecard.title);
+      await expect(scorecardCard).toContainText(scorecard.description);
+      const thresholdLegendLabels =
+        scorecard.thresholdLabels ?? DEFAULT_THRESHOLD_LABELS;
+      for (const label of thresholdLegendLabels) {
+        await expect(scorecardCard).toContainText(label);
+      }
+    },
+    async validateThresholdLegend(
+      metric: ScorecardMetric,
+      rules: readonly ThresholdRule[],
+    ) {
+      const scorecardCard = getScorecardCard(metric);
+      await expect(scorecardCard).toBeVisible();
+
+      for (const rule of rules) {
+        const label = rule.key.charAt(0).toUpperCase() + rule.key.slice(1);
+        const legendText = scorecardCard.getByText(
+          `${label} ${rule.expression}`,
+          { exact: true },
+        );
+        await expect(legendText).toBeVisible();
+        const swatch = scorecardCard.getByTestId(
+          `legend-colorbox-${rule.key.toLowerCase()}`,
+        );
+        if (rule.color) {
+          await expect(swatch).toHaveCSS("background-color", rule.color);
+        }
+      }
     },
     async expectScorecardVisible(title: string) {
       await expect(page.getByText(title, { exact: true })).toBeVisible();
@@ -139,23 +167,23 @@ export function scorecardHelpers(page: Page, uiHelper: UIhelper) {
     ) {
       await navigate();
       await this.openTab();
-      await this.expectFilecheckValue(metricTitle, expectedStatus);
+      const iconTestId =
+        expectedStatus === "exist"
+          ? "CheckCircleOutlineIcon"
+          : "DangerousOutlinedIcon";
+      await this.expectScorecardValue(metricTitle, iconTestId);
     },
-    async expectFilecheckValue(
+    async expectScorecardValue(
       metricTitle: string,
-      expectedStatus: "exist" | "missing",
+      expectedIconTestId: string,
     ) {
       const section = page.locator("article").filter({ hasText: metricTitle });
       await expect(section).toBeVisible({ timeout: 60_000 });
       await expect(section.getByRole("progressbar")).toHaveCount(0, {
         timeout: 60_000,
       });
-      const iconTestId =
-        expectedStatus === "exist"
-          ? "CheckCircleOutlineIcon"
-          : "DangerousOutlinedIcon";
       await expect(
-        section.locator(`[data-testid="${iconTestId}"]`),
+        section.locator(`[data-testid="${expectedIconTestId}"]`),
       ).toBeVisible({ timeout: 90_000 });
     },
   };

--- a/workspaces/scorecard/e2e-tests/tests/utils/types.ts
+++ b/workspaces/scorecard/e2e-tests/tests/utils/types.ts
@@ -1,0 +1,11 @@
+export type ScorecardMetric = {
+  readonly title: string;
+  readonly description: string;
+  readonly thresholdLabels?: readonly string[];
+};
+
+export type ThresholdRule = {
+  readonly key: string;
+  readonly expression: string;
+  readonly color?: string;
+};


### PR DESCRIPTION
Add e2e scorecard tests for custom severity keys with custom threshold expressions, colors and icon.
Additionally, tests that custom threshold expressions are displayed in entity threshold legend.

#### Fixes
Fixes https://redhat.atlassian.net/browse/RHIDP-12067