### PR TITLE
Update `lightspeed` workspace to commit `ec4dc09` for backstage 1.49.3 on branch main

### DIFF
--- a/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed-backend.yaml
+++ b/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed-backend.yaml
@@ -16,11 +16,11 @@ metadata:
   tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-lightspeed-backend"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.8.2!red-hat-developer-hub-backstage-plugin-lightspeed-backend
-  version: 2.8.2
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.49.4__2.8.4!red-hat-developer-hub-backstage-plugin-lightspeed-backend
+  version: 2.8.4
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.2
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
+++ b/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
@@ -16,11 +16,11 @@ metadata:
   tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-lightspeed"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.8.2!red-hat-developer-hub-backstage-plugin-lightspeed
-  version: 2.8.2
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.49.4__2.8.4!red-hat-developer-hub-backstage-plugin-lightspeed
+  version: 2.8.4
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.2
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/lightspeed/source.json
+++ b/workspaces/lightspeed/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"145ef2e09eefb7f4028444257eb1b4cd3dccc0ef","repo-flat":false,"repo-backstage-version":"1.49.2"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"b1a7b95eda72ce7a797d6606007948ab918c4715","repo-flat":false,"repo-backstage-version":"1.49.2"}


### PR DESCRIPTION

Bumps lightspeed plugin to include the latest translations. https://github.com/redhat-developer/rhdh-plugins/pull/3170