### PR TITLE
fix: Remove cost management packages from rhdh-supported-packages.txt

### DIFF
--- a/rhdh-supported-packages.txt
+++ b/rhdh-supported-packages.txt
@@ -95,7 +95,3 @@ backstage/plugins/events-backend-module-github
 # Lightspeed plugins - Dev Preview in 1.9, planned to GA in 1.10
 lightspeed/plugins/lightspeed
 lightspeed/plugins/lightspeed-backend
-
-# Cost Management plugins - Dev Preview in 1.9, heading to GA in 1.10
-cost-management/plugins/cost-management
-cost-management/plugins/cost-management-backend


### PR DESCRIPTION


Revert this [commit](https://github.com/redhat-developer/rhdh-plugin-export-overlays/commit/58b16fc884c40c6b293acb76ba7fc49fb86b99b0) as it is blocking 1.10 branching