### PR TITLE
Add scalprum-config.json for backstage auth plugin

### DIFF
--- a/workspaces/backstage/e2e-tests/playwright.config.ts
+++ b/workspaces/backstage/e2e-tests/playwright.config.ts
@@ -46,5 +46,9 @@ export default playwrightDefineConfig({
       name: "backstage-techdocs",
       testMatch: /tests\/specs\/techdocs\.spec\.ts/,
     },
+    {
+      name: "backstage-auth",
+      testMatch: /tests\/specs\/auth\.spec\.ts/,
+    },
   ],
 });

--- a/workspaces/backstage/e2e-tests/tests/config/auth/app-config-rhdh.yaml
+++ b/workspaces/backstage/e2e-tests/tests/config/auth/app-config-rhdh.yaml
@@ -1,0 +1,5 @@
+auth:
+  experimentalClientIdMetadataDocuments:
+    enabled: true
+  experimentalRefreshToken:
+    enabled: true

--- a/workspaces/backstage/e2e-tests/tests/config/auth/dynamic-plugins.yaml
+++ b/workspaces/backstage/e2e-tests/tests/config/auth/dynamic-plugins.yaml
@@ -1,0 +1,13 @@
+# Explicit config is required — without it, all 28 backstage workspace plugins
+# are auto-loaded from metadata, and most require provider config (github, gitlab,
+# kubernetes, ldap, etc.) that this test doesn't supply, crashing RHDH on startup.
+plugins:
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth:bs_1.49.4__0.1.6!backstage-plugin-auth
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage.plugin-auth:
+            dynamicRoutes:
+              - path: /oauth2/*
+                importName: Router

--- a/workspaces/backstage/e2e-tests/tests/specs/auth.spec.ts
+++ b/workspaces/backstage/e2e-tests/tests/specs/auth.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@red-hat-developer-hub/e2e-test-utils/test";
+
+test.describe("Auth plugin", () => {
+  test.beforeAll(async ({ rhdh }) => {
+    await rhdh.configure({
+      auth: "guest",
+      appConfig: "tests/config/auth/app-config-rhdh.yaml",
+      dynamicPlugins: "tests/config/auth/dynamic-plugins.yaml",
+    });
+    await rhdh.deploy();
+  });
+
+  test.beforeEach(async ({ loginHelper }) => {
+    await loginHelper.loginAsGuest();
+  });
+
+  test("Verify auth plugin renders on /oauth2 route", async ({ page }) => {
+    await page.goto("/oauth2/authorize/test-session");
+    // 400 is expected — we don't have a real OAuth token, but the error
+    // confirms the auth plugin loaded and the backend rejected the session.
+    await expect(page.getByText("Authorization Error")).toBeVisible();
+    await expect(page.getByText("HTTP 400: Bad Request")).toBeVisible();
+  });
+});

--- a/workspaces/backstage/metadata/backstage-plugin-auth.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-auth.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-auth
+  namespace: rhdh
+  title: "Auth Frontend"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/master/plugins/auth
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/plugins/auth
+  tags: []
+spec:
+  packageName: "@backstage/plugin-auth"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth:bs_1.49.4__0.1.6!backstage-plugin-auth
+  version: 0.1.6
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.48.3
+  author: Red Hat
+  support: community
+  lifecycle: active
+  partOf:
+    - auth
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        dynamicPlugins:
+          frontend:
+            backstage.plugin-auth:
+              dynamicRoutes:
+                - path: /oauth2/*
+                  importName: Router

--- a/workspaces/backstage/plugins/auth/scalprum-config.json
+++ b/workspaces/backstage/plugins/auth/scalprum-config.json
@@ -1,0 +1,6 @@
+{
+  "name": "backstage.plugin-auth",
+  "exposedModules": {
+    "PluginRoot": "./src/components/Router"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `scalprum-config.json` for `@backstage/plugin-auth` to enable dynamic plugin loading via Scalprum
- Entry point set to `./src/components/Router`

## TODO
- [x] Verify entry point path matches upstream plugin structure
- [x] Add `app-config.dynamic.yaml` if wiring configuration is required
- [ ] Add e2e tests
- [x] Test with `/publish`