### PR TITLE
fix(tech-radar): skip new frontend test in nightly

### DIFF
--- a/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
+++ b/workspaces/tech-radar/e2e-tests/tests/specs/tech-radar.spec.ts
@@ -10,6 +10,12 @@ const setupScript = path.join(
 test.describe("Test tech-radar plugin", () => {
   test.beforeAll(async ({ rhdh }) => {
     const project = rhdh.deploymentConfig.namespace;
+    // This skip can be removed once the tech-radar wrapper is removed
+    test.skip(
+      project === "tech-radar-app-next" &&
+        process.env.E2E_NIGHTLY_MODE === "true",
+      "app-next not ready for nightly",
+    );
     await rhdh.configure({
       auth: "keycloak",
     });


### PR DESCRIPTION
This change skips the new frontend system version of the tech-radar e2e test in the nightly run, this can be removed once the tech-radar wrapper is removed from the RHDH container.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED