### PR TITLE
chore: add metadata for mssv workspace

### DIFF
--- a/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer-backend.yaml
+++ b/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer-backend.yaml
@@ -14,8 +14,8 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage-community/plugin-multi-source-security-viewer-backend"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-multi-source-security-viewer-backend:bs_1.49.4__0.5.0!backstage-community-plugin-multi-source-security-viewer-backend
-  version: 0.5.0
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-multi-source-security-viewer-backend:bs_1.49.4__0.4.1!backstage-community-plugin-multi-source-security-viewer-backend
+  version: 0.4.1
   backstage:
     role: backend-plugin
     supportedVersions: 1.49.4

--- a/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer-backend.yaml
+++ b/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer-backend.yaml
@@ -1,0 +1,26 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-multi-source-security-viewer-backend
+  namespace: community
+  title: Multi Source Security Viewer Backend
+  links:
+    - url: https://github.com/backstage/community-plugins/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/multi-source-security-viewer
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/multi-source-security-viewer
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-multi-source-security-viewer-backend"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-multi-source-security-viewer-backend:bs_1.49.4__0.5.0!backstage-community-plugin-multi-source-security-viewer-backend
+  version: 0.5.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.49.4
+  author: Backstage Community
+  support: community
+  lifecycle: active
+  appConfigNotRequired: true
+  appConfigExamples: []

--- a/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer.yaml
+++ b/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-multi-source-security-viewer
+  namespace: community
+  title: Multi Source Security Viewer
+  links:
+    - url: https://github.com/backstage/community-plugins/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/multi-source-security-viewer
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/multi-source-security-viewer
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-multi-source-security-viewer"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-multi-source-security-viewer:bs_1.49.4__0.16.0!backstage-community-plugin-multi-source-security-viewer
+  version: 0.16.0
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.49.4
+  author: Backstage Community
+  support: community
+  lifecycle: active
+  appConfigExamples: []

--- a/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer.yaml
+++ b/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer.yaml
@@ -14,8 +14,8 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage-community/plugin-multi-source-security-viewer"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-multi-source-security-viewer:bs_1.49.4__0.16.0!backstage-community-plugin-multi-source-security-viewer
-  version: 0.16.0
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-multi-source-security-viewer:bs_1.49.4__0.15.2!backstage-community-plugin-multi-source-security-viewer
+  version: 0.15.2
   backstage:
     role: frontend-plugin
     supportedVersions: 1.49.4

--- a/workspaces/multi-source-security-viewer/plugins-list.yaml
+++ b/workspaces/multi-source-security-viewer/plugins-list.yaml
@@ -1,0 +1,2 @@
+plugins/multi-source-security-viewer:
+plugins/multi-source-security-viewer-backend:

--- a/workspaces/multi-source-security-viewer/source.json
+++ b/workspaces/multi-source-security-viewer/source.json
@@ -1,0 +1,1 @@
+{"repo":"https://github.com/backstage/community-plugins","repo-ref":"84cb56f5b65681951bf0618e7114e8f6d48b7e92","repo-flat":false,"repo-backstage-version":"1.49.2"}


### PR DESCRIPTION
The multi-source-security-viewer workspace was missing metadata files, causing github workflows to fail during PRs.