### PR TITLE
chore: add homepage-backend to default.packages.yaml for catalog index DPDY

### DIFF
--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -53,6 +53,7 @@ packages:
   - package: '@backstage/plugin-signals-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-bulk-import' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-homepage-backend' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki' # tech-preview


### PR DESCRIPTION
Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3190

Fixes missing `@red-hat-developer-hub/backstage-plugin-homepage-backend` in `dynamic-plugins.default.yaml`. Mirrors rhdh PR #4828 / RHIDP-13581. Requires catalog index image rebuild for 1.10 after merge.