### PR TITLE
chore(e2e): adopt e2e-test-utils 1.1.43 with nightly registry fix for ghcr.io community plugins

### DIFF
--- a/workspaces/acr/e2e-tests/package.json
+++ b/workspaces/acr/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/acr/e2e-tests/yarn.lock
+++ b/workspaces/acr/e2e-tests/yarn.lock
@@ -282,9 +282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -307,7 +307,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -551,7 +551,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/adoption-insights/e2e-tests/package.json
+++ b/workspaces/adoption-insights/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "1.57.0",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/adoption-insights/e2e-tests/yarn.lock
+++ b/workspaces/adoption-insights/e2e-tests/yarn.lock
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -379,7 +379,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -765,7 +765,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:1.57.0"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/analytics/e2e-tests/package.json
+++ b/workspaces/analytics/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/analytics/e2e-tests/yarn.lock
+++ b/workspaces/analytics/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -577,7 +577,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/argocd/e2e-tests/package.json
+++ b/workspaces/argocd/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/argocd/e2e-tests/yarn.lock
+++ b/workspaces/argocd/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -572,7 +572,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/backstage/e2e-tests/package.json
+++ b/workspaces/backstage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/backstage/e2e-tests/yarn.lock
+++ b/workspaces/backstage/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -626,7 +626,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/extensions/e2e-tests/package.json
+++ b/workspaces/extensions/e2e-tests/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "dotenv": "17.4.1",
     "eslint": "10.2.0",

--- a/workspaces/extensions/e2e-tests/yarn.lock
+++ b/workspaces/extensions/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1021,7 +1021,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:17.4.1"
     eslint: "npm:10.2.0"

--- a/workspaces/github/e2e-tests/package.json
+++ b/workspaces/github/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/github/e2e-tests/yarn.lock
+++ b/workspaces/github/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1187,7 +1187,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/global-header/e2e-tests/package.json
+++ b/workspaces/global-header/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/global-header/e2e-tests/yarn.lock
+++ b/workspaces/global-header/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1246,7 +1246,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/homepage/e2e-tests/package.json
+++ b/workspaces/homepage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
+++ b/workspaces/homepage/e2e-tests/tests/specs/dynamic-home-page.spec.ts
@@ -26,6 +26,11 @@ test.describe.serial("Dynamic home page customization", () => {
   let baseURL: string;
   let test1Count: number;
 
+  test.skip(
+    process.env.E2E_NIGHTLY_MODE === "true",
+    "homepage-backend absent from DPDY in catalog index image (RHDHBUGS-3190)",
+  );
+
   test.beforeAll(async ({ browser, rhdh }) => {
     test.setTimeout(10 * 60 * 1000);
 

--- a/workspaces/homepage/e2e-tests/yarn.lock
+++ b/workspaces/homepage/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1312,7 +1312,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/keycloak/e2e-tests/package.json
+++ b/workspaces/keycloak/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/keycloak/e2e-tests/yarn.lock
+++ b/workspaces/keycloak/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1482,7 +1482,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/orchestrator/e2e-tests/package.json
+++ b/workspaces/orchestrator/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.36",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "dotenv": "16.6.1",
     "eslint": "10.2.0",

--- a/workspaces/orchestrator/e2e-tests/yarn.lock
+++ b/workspaces/orchestrator/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.36":
-  version: 1.1.36
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.36"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/87c381f59723726b2e1ed7b98496b2c361f796e57e12960fa1c88a8dcd2d0a11f3c9d10065846d3aea9d0bcef22427c5bb37409d59c2af756fd7aa8e1ff3949d
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1771,7 +1771,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.36"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:16.6.1"
     eslint: "npm:10.2.0"

--- a/workspaces/quay/e2e-tests/package.json
+++ b/workspaces/quay/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
+++ b/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
@@ -6,6 +6,16 @@ test.describe("Test Quay.io plugin", () => {
   const quayRepository = "rhdh-community/rhdh";
 
   test.beforeAll(async ({ rhdh }) => {
+    // Community plugins publish to ghcr.io; nightly mode resolves {{inherit}} to RHEC by default.
+    // Remove when these community packages are no longer in default.packages.yaml in the rhdh repo.
+    const ghcrRegistry = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays";
+    process.env.NIGHTLY_DPDY_OCI_REGISTRY_MAP = JSON.stringify({
+      [ghcrRegistry]: [
+        "@backstage-community/plugin-quay",
+        "@backstage-community/plugin-quay-backend",
+        "@backstage-community/plugin-scaffolder-backend-module-quay",
+      ],
+    });
     await rhdh.configure({ auth: "guest" });
     await rhdh.deploy();
   });

--- a/workspaces/quay/e2e-tests/yarn.lock
+++ b/workspaces/quay/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/quickstart/e2e-tests/package.json
+++ b/workspaces/quickstart/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quickstart/e2e-tests/yarn.lock
+++ b/workspaces/quickstart/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1955,7 +1955,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/rbac/e2e-tests/package.json
+++ b/workspaces/rbac/e2e-tests/package.json
@@ -26,7 +26,7 @@
     "@backstage-community/plugin-rbac-common": "1.26.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/rbac/e2e-tests/yarn.lock
+++ b/workspaces/rbac/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1933,7 +1933,7 @@ __metadata:
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scorecard/e2e-tests/package.json
+++ b/workspaces/scorecard/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scorecard/e2e-tests/yarn.lock
+++ b/workspaces/scorecard/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.41",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.41":
-  version: 1.1.41
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.41"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/906713b3fb1ecce4b95cdca7620fbf69be22518fe47be131454f9e310fb80b4059e11cc8008ed127d22792e7d876ebdf00e6d4d2a437a1eb777eacb2d6cadd78
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.41"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tekton/e2e-tests/package.json
+++ b/workspaces/tekton/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
+++ b/workspaces/tekton/e2e-tests/tests/specs/tekton.spec.ts
@@ -4,6 +4,12 @@ import { TektonSupportHelper } from "../support/tekton-support-helper";
 
 test.describe("Test Tekton plugin", () => {
   test.beforeAll(async ({ rhdh }) => {
+    // Community plugin publishes to ghcr.io; nightly mode resolves {{inherit}} to RHEC by default.
+    // Remove when this community package is no longer in default.packages.yaml in the rhdh repo.
+    const ghcrRegistry = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays";
+    process.env.NIGHTLY_DPDY_OCI_REGISTRY_MAP = JSON.stringify({
+      [ghcrRegistry]: ["@backstage-community/plugin-tekton"],
+    });
     await rhdh.configure({
       auth: "keycloak",
     });

--- a/workspaces/tekton/e2e-tests/yarn.lock
+++ b/workspaces/tekton/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -2097,7 +2097,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/theme/e2e-tests/package.json
+++ b/workspaces/theme/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/theme/e2e-tests/yarn.lock
+++ b/workspaces/theme/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -2106,7 +2106,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/topology/e2e-tests/package.json
+++ b/workspaces/topology/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.39",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/topology/e2e-tests/yarn.lock
+++ b/workspaces/topology/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.39":
-  version: 1.1.39
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.39"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
+  version: 1.1.43
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32c3386aadf23b4450c642bab93daab4aabd933043fa3332e9fe26cb7b56da23476d26a673bd8336b29b03b03ccb70c4692418cbabbc28c371f0be733b2a5598
+  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
   languageName: node
   linkType: hard
 
@@ -2133,7 +2133,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.39"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
## Summary

Backport of #2480 to `release-1.10`.

- Bumps `@red-hat-developer-hub/e2e-test-utils` to `1.1.43` across all e2e workspaces
- Sets `NIGHTLY_DPDY_OCI_REGISTRY_MAP` in `quay` and `tekton` specs so their community plugins (published to `ghcr.io`) resolve `{{inherit}}` to the correct registry in nightly mode — broken by [rhdh-e2e-test-utils#104](https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/104) which defaults to RHEC
- Skips homepage nightly tests until `homepage-backend` appears in the DPDY ([RHDHBUGS-3190](https://issues.redhat.com/browse/RHDHBUGS-3190))

Assisted-by: Claude Code