### PR TITLE
fix(argocd): Add roadie frontend

### DIFF
--- a/catalog-entities/extensions/plugins/roadie-argocd.yaml
+++ b/catalog-entities/extensions/plugins/roadie-argocd.yaml
@@ -32,6 +32,7 @@ spec:
     - CI/CD
 
   packages:
+    - roadiehq-backstage-plugin-argo-cd
     - roadiehq-backstage-plugin-argo-cd-backend
 
   assets:


### PR DESCRIPTION
Adds Roadie frontend explicitly to Roadie plugin packages.
Roadie frontend plugin [is already declared as part of ](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd.yaml#L28) Roadie plugin roadie-argocd, this update is to stay consistent and mention it also from the plugin's side.