### PR TITLE
[WIP] [release-1.10] fix(homepage): update homepage frontend and backend

### DIFF
--- a/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-dynamic-home-page.yaml
+++ b/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-dynamic-home-page.yaml
@@ -17,10 +17,10 @@ metadata:
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-dynamic-home-page'
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
-  version: 1.13.1
+  version: 1.13.4
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.3
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-homepage-backend.yaml
+++ b/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-homepage-backend.yaml
@@ -16,8 +16,8 @@ metadata:
   tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-homepage-backend"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.49.4__0.1.1!red-hat-developer-hub-backstage-plugin-homepage-backend
-  version: 0.1.1
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.49.4__0.1.3!red-hat-developer-hub-backstage-plugin-homepage-backend
+  version: 0.1.3
   backstage:
     role: backend-plugin
     supportedVersions: 1.49.4

--- a/workspaces/homepage/source.json
+++ b/workspaces/homepage/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"61b7b31a3a37454599058c4799012d30a98959b9","repo-flat":false,"repo-backstage-version":"1.49.3"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"b2110290c8af66dece1dd421f3c34956ba81779d","repo-flat":false,"repo-backstage-version":"1.49.3"}


### PR DESCRIPTION
Update homepage plugin to https://github.com/redhat-developer/rhdh-plugins/pull/3240, manual backport of #2525 for 1.10.

Mark it as WIP to confims this first on a cluster and by a release-manager.

# Releases

## @red-hat-developer-hub/backstage-plugin-dynamic-home-page@1.13.4

### Patch Changes

-   ab8323b: Fix issue that defaul widget props are ignored when customization is enabled.

## @red-hat-developer-hub/backstage-plugin-homepage-backend@0.1.3

### Patch Changes

-   ab8323b: Fix conditional permission checks.
