### PR TITLE
chore: set Backstage supportedVersions to overlays target 1.49.4

### DIFF
--- a/workspaces/3scale/metadata/backstage-community-plugin-3scale-backend.yaml
+++ b/workspaces/3scale/metadata/backstage-community-plugin-3scale-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 3.13.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/acr/metadata/backstage-community-plugin-acr.yaml
+++ b/workspaces/acr/metadata/backstage-community-plugin-acr.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.24.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights-backend.yaml
+++ b/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.8.2
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights.yaml
+++ b/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.8.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/adoption-insights/metadata/rhdh-bsp-analytics-mod-adoption-insights.yaml
+++ b/workspaces/adoption-insights/metadata/rhdh-bsp-analytics-mod-adoption-insights.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.8.2
   backstage:
     role: frontend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/adr/metadata/backstage-community-plugin-adr-backend.yaml
+++ b/workspaces/adr/metadata/backstage-community-plugin-adr-backend.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.20.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/adr/metadata/backstage-community-plugin-adr.yaml
+++ b/workspaces/adr/metadata/backstage-community-plugin-adr.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.23.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/adr/metadata/backstage-community-search-backend-module-adr.yaml
+++ b/workspaces/adr/metadata/backstage-community-search-backend-module-adr.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.17.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/ai-integrations/metadata/rhdh-bs-plugin-catalog-backend-module-model-catalog.yaml
+++ b/workspaces/ai-integrations/metadata/rhdh-bs-plugin-catalog-backend-module-model-catalog.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.9.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Backstage
   support: dev-preview
   lifecycle: active

--- a/workspaces/ai-integrations/metadata/rhdh-bs-plugin-catalog-techdoc-url-reader-backend.yaml
+++ b/workspaces/ai-integrations/metadata/rhdh-bs-plugin-catalog-techdoc-url-reader-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.5.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Backstage
   support: dev-preview
   lifecycle: active

--- a/workspaces/analytics/metadata/backstage-community-plugin-analytics-module-ga4.yaml
+++ b/workspaces/analytics/metadata/backstage-community-plugin-analytics-module-ga4.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.18.0
   backstage:
     role: frontend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: The Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/analytics/metadata/backstage-community-plugin-analytics-module-matomo.yaml
+++ b/workspaces/analytics/metadata/backstage-community-plugin-analytics-module-matomo.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.27.0
   backstage:
     role: frontend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: The Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/analytics/metadata/backstage-community-plugin-analytics-module-newrelic-browser.yaml
+++ b/workspaces/analytics/metadata/backstage-community-plugin-analytics-module-newrelic-browser.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.18.0
   backstage:
     role: frontend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: The Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/analytics/metadata/backstage-community-plugin-analytics-provider-segment.yaml
+++ b/workspaces/analytics/metadata/backstage-community-plugin-analytics-provider-segment.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.27.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/announcements/metadata/backstage-community-plugin-announcements-backend.yaml
+++ b/workspaces/announcements/metadata/backstage-community-plugin-announcements-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.23.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/announcements/metadata/backstage-community-plugin-announcements.yaml
+++ b/workspaces/announcements/metadata/backstage-community-plugin-announcements.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.8.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/announcements/metadata/backstage-community-plugin-search-backend-module-announcements.yaml
+++ b/workspaces/announcements/metadata/backstage-community-plugin-search-backend-module-announcements.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.16.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/app-defaults/metadata/red-hat-developer-hub-backstage-plugin-app-auth.yaml
+++ b/workspaces/app-defaults/metadata/red-hat-developer-hub-backstage-plugin-app-auth.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.0.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/app-defaults/metadata/red-hat-developer-hub-backstage-plugin-app-integrations.yaml
+++ b/workspaces/app-defaults/metadata/red-hat-developer-hub-backstage-plugin-app-integrations.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.0.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/argocd/metadata/backstage-community-plugin-argocd-backend.yaml
+++ b/workspaces/argocd/metadata/backstage-community-plugin-argocd-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.4.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/argocd/metadata/backstage-community-plugin-argocd.yaml
+++ b/workspaces/argocd/metadata/backstage-community-plugin-argocd.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.8.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/azure-devops/metadata/backstage-community-plugin-azure-devops-backend.yaml
+++ b/workspaces/azure-devops/metadata/backstage-community-plugin-azure-devops-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.27.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/azure-devops/metadata/backstage-community-plugin-azure-devops.yaml
+++ b/workspaces/azure-devops/metadata/backstage-community-plugin-azure-devops.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.29.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/azure-devops/metadata/backstage-community-plugin-catalog-backend-module-azure-devops-annotator-processor.yaml
+++ b/workspaces/azure-devops/metadata/backstage-community-plugin-catalog-backend-module-azure-devops-annotator-processor.yaml
@@ -22,7 +22,7 @@ spec:
   version: 0.18.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/azure-devops/metadata/backstage-community-plugin-scaffolder-backend-module-azure-devops.yaml
+++ b/workspaces/azure-devops/metadata/backstage-community-plugin-scaffolder-backend-module-azure-devops.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.23.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/azure-devops/metadata/backstage-community-plugin-scaffolder-backend-module-dotnet.yaml
+++ b/workspaces/azure-devops/metadata/backstage-community-plugin-scaffolder-backend-module-dotnet.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.13.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/azure-devops/metadata/backstage-community-plugin-search-backend-module-azure-devops.yaml
+++ b/workspaces/azure-devops/metadata/backstage-community-plugin-search-backend-module-azure-devops.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.5.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-amazon-ecs-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-amazon-ecs-plugin-for-backstage-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.9.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.43.1
+    supportedVersions: 1.49.4
   author: AWS
   support: community
   lifecycle: active

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-amazon-ecs-plugin-for-backstage.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-amazon-ecs-plugin-for-backstage.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.6.3
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.43.1
+    supportedVersions: 1.49.4
   author: AWS
   support: community
   lifecycle: active

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codebuild-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codebuild-plugin-for-backstage-backend.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.9.2
   backstage:
     role: backend-plugin
-    supportedVersions: 1.43.1
+    supportedVersions: 1.49.4
   author: AWS
   support: community
   lifecycle: active

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codebuild-plugin-for-backstage.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codebuild-plugin-for-backstage.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.7.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.43.1
+    supportedVersions: 1.49.4
   author: AWS
   support: community
   lifecycle: active

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codepipeline-plugin-for-backstage-backend.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codepipeline-plugin-for-backstage-backend.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.10.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.43.1
+    supportedVersions: 1.49.4
   author: AWS
   support: community
   lifecycle: active

--- a/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codepipeline-plugin-for-backstage.yaml
+++ b/workspaces/backstage-plugins-for-aws/metadata/aws-aws-codepipeline-plugin-for-backstage.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.8.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.43.1
+    supportedVersions: 1.49.4
   author: AWS
   support: community
   lifecycle: active

--- a/workspaces/bookmarks/metadata/backstage-community-plugin-bookmarks.yaml
+++ b/workspaces/bookmarks/metadata/backstage-community-plugin-bookmarks.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.9.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml
+++ b/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 7.3.5
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import.yaml
+++ b/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import.yaml
@@ -20,7 +20,7 @@ spec:
   version: 7.3.5
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/config-viewer/metadata/proberaum-backstage-plugin-config-viewer-backend.yaml
+++ b/workspaces/config-viewer/metadata/proberaum-backstage-plugin-config-viewer-backend.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.13.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.48.3
+    supportedVersions: 1.49.4
   author: Proberaum
   support: community
   lifecycle: active

--- a/workspaces/config-viewer/metadata/proberaum-backstage-plugin-config-viewer.yaml
+++ b/workspaces/config-viewer/metadata/proberaum-backstage-plugin-config-viewer.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.13.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.48.3
+    supportedVersions: 1.49.4
   author: Proberaum
   support: community
   lifecycle: active

--- a/workspaces/dynatrace-dql/metadata/dynatrace-backstage-plugin-dql-backend.yaml
+++ b/workspaces/dynatrace-dql/metadata/dynatrace-backstage-plugin-dql-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.7.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.47.3
+    supportedVersions: 1.49.4
   author: Dynatrace
   support: generally-available
   lifecycle: active

--- a/workspaces/dynatrace-dql/metadata/dynatrace-backstage-plugin-dql.yaml
+++ b/workspaces/dynatrace-dql/metadata/dynatrace-backstage-plugin-dql.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.7.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.47.3
+    supportedVersions: 1.49.4
   author: Dynatrace
   support: generally-available
   lifecycle: active

--- a/workspaces/dynatrace/metadata/backstage-community-plugin-dynatrace.yaml
+++ b/workspaces/dynatrace/metadata/backstage-community-plugin-dynatrace.yaml
@@ -20,7 +20,7 @@ spec:
   version: 10.17.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Dynatrace
   support: community
   lifecycle: active

--- a/workspaces/env-viewer/metadata/proberaum-backstage-plugin-env-viewer-backend.yaml
+++ b/workspaces/env-viewer/metadata/proberaum-backstage-plugin-env-viewer-backend.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.3.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.48.3
+    supportedVersions: 1.49.4
   author: Proberaum
   support: community
   lifecycle: active

--- a/workspaces/env-viewer/metadata/proberaum-backstage-plugin-env-viewer.yaml
+++ b/workspaces/env-viewer/metadata/proberaum-backstage-plugin-env-viewer.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.3.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.48.3
+    supportedVersions: 1.49.4
   author: Proberaum
   support: community
   lifecycle: active

--- a/workspaces/extensions/metadata/rhdh-bsp-ctlg-backend-mod-extensions.yaml
+++ b/workspaces/extensions/metadata/rhdh-bsp-ctlg-backend-mod-extensions.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.17.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/extensions/metadata/rhdh-bsp-extensions-backend.yaml
+++ b/workspaces/extensions/metadata/rhdh-bsp-extensions-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.17.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/extensions/metadata/rhdh-bsp-extensions.yaml
+++ b/workspaces/extensions/metadata/rhdh-bsp-extensions.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.17.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/github-notifications/metadata/proberaum-backstage-plugin-github-notifications-backend.yaml
+++ b/workspaces/github-notifications/metadata/proberaum-backstage-plugin-github-notifications-backend.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.12.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.48.5
+    supportedVersions: 1.49.4
   author: Proberaum
   support: community
   lifecycle: active

--- a/workspaces/github/metadata/backstage-community-plugin-github-actions.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-actions.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.22.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/github/metadata/backstage-community-plugin-github-deployments.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-deployments.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.18.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/github/metadata/backstage-community-plugin-github-discussions.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-discussions.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.10.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/github/metadata/backstage-community-plugin-github-issues.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-issues.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.21.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/github/metadata/backstage-community-plugin-github-pull-requests-board.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-github-pull-requests-board.yaml
@@ -19,7 +19,7 @@ spec:
   version: 0.16.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: DAZN
   support: community
   lifecycle: active

--- a/workspaces/github/metadata/backstage-community-plugin-search-backend-module-github-discussions.yaml
+++ b/workspaces/github/metadata/backstage-community-plugin-search-backend-module-github-discussions.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.11.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/gitlab/metadata/immobiliarelabs-backstage-plugin-gitlab-backend.yaml
+++ b/workspaces/gitlab/metadata/immobiliarelabs-backstage-plugin-gitlab-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 7.0.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.48.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/gitlab/metadata/immobiliarelabs-backstage-plugin-gitlab.yaml
+++ b/workspaces/gitlab/metadata/immobiliarelabs-backstage-plugin-gitlab.yaml
@@ -20,7 +20,7 @@ spec:
   version: 7.0.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.48.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/global-floating-action-button/metadata/rhdh-bsp-global-floating-action-button.yaml
+++ b/workspaces/global-floating-action-button/metadata/rhdh-bsp-global-floating-action-button.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.9.3
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/global-header/metadata/red-hat-developer-hub-backstage-plugin-global-header.yaml
+++ b/workspaces/global-header/metadata/red-hat-developer-hub-backstage-plugin-global-header.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.21.5
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-dynamic-home-page.yaml
+++ b/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-dynamic-home-page.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.13.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-homepage-backend.yaml
+++ b/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-homepage-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.1.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/icon-viewer/metadata/proberaum-backstage-plugin-icon-viewer.yaml
+++ b/workspaces/icon-viewer/metadata/proberaum-backstage-plugin-icon-viewer.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.3.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.48.3
+    supportedVersions: 1.49.4
   author: Proberaum
   support: community
   lifecycle: active

--- a/workspaces/jenkins/metadata/backstage-community-plugin-jenkins-backend.yaml
+++ b/workspaces/jenkins/metadata/backstage-community-plugin-jenkins-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.27.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/jenkins/metadata/backstage-community-plugin-jenkins.yaml
+++ b/workspaces/jenkins/metadata/backstage-community-plugin-jenkins.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.30.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/jenkins/metadata/backstage-community-plugin-scaffolder-backend-module-jenkins.yaml
+++ b/workspaces/jenkins/metadata/backstage-community-plugin-scaffolder-backend-module-jenkins.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.20.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/jfrog-artifactory/metadata/backstage-community-plugin-jfrog-artifactory.yaml
+++ b/workspaces/jfrog-artifactory/metadata/backstage-community-plugin-jfrog-artifactory.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.28.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/keycloak/metadata/backstage-community-plugin-catalog-backend-module-keycloak.yaml
+++ b/workspaces/keycloak/metadata/backstage-community-plugin-catalog-backend-module-keycloak.yaml
@@ -21,7 +21,7 @@ spec:
   version: 3.19.2
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/kiali/metadata/backstage-community-plugin-kiali-backend.yaml
+++ b/workspaces/kiali/metadata/backstage-community-plugin-kiali-backend.yaml
@@ -21,7 +21,7 @@ spec:
   version: 1.29.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/kiali/metadata/backstage-community-plugin-kiali.yaml
+++ b/workspaces/kiali/metadata/backstage-community-plugin-kiali.yaml
@@ -21,7 +21,7 @@ spec:
   version: 1.50.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/lighthouse/metadata/backstage-community-plugin-lighthouse-backend.yaml
+++ b/workspaces/lighthouse/metadata/backstage-community-plugin-lighthouse-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.21.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/lighthouse/metadata/backstage-community-plugin-lighthouse.yaml
+++ b/workspaces/lighthouse/metadata/backstage-community-plugin-lighthouse.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.20.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed-backend.yaml
+++ b/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.8.5
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
+++ b/workspaces/lightspeed/metadata/rhdh-bsp-lightspeed.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.8.5
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/mcp-chat/metadata/backstage-community-plugin-mcp-chat-backend.yaml
+++ b/workspaces/mcp-chat/metadata/backstage-community-plugin-mcp-chat-backend.yaml
@@ -24,7 +24,7 @@ spec:
   lifecycle: experimental
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   appConfigExamples:
     - title: Minimal starter
       content:

--- a/workspaces/mcp-chat/metadata/backstage-community-plugin-mcp-chat.yaml
+++ b/workspaces/mcp-chat/metadata/backstage-community-plugin-mcp-chat.yaml
@@ -24,7 +24,7 @@ spec:
   lifecycle: experimental
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   partOf:
     - mcp-chat
   appConfigExamples:

--- a/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer-backend.yaml
+++ b/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer-backend.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.4.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer.yaml
+++ b/workspaces/multi-source-security-viewer/metadata/backstage-community-plugin-multi-source-security-viewer.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.15.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/nexus-repository-manager/metadata/backstage-community-plugin-nexus-repository-manager.yaml
+++ b/workspaces/nexus-repository-manager/metadata/backstage-community-plugin-nexus-repository-manager.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.23.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/npm/metadata/backstage-community-plugin-npm-backend.yaml
+++ b/workspaces/npm/metadata/backstage-community-plugin-npm-backend.yaml
@@ -18,7 +18,7 @@ spec:
   version: 1.20.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/npm/metadata/backstage-community-plugin-npm.yaml
+++ b/workspaces/npm/metadata/backstage-community-plugin-npm.yaml
@@ -18,7 +18,7 @@ spec:
   version: 1.20.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend-mod-loki.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend-mod-loki.yaml
@@ -21,7 +21,7 @@ spec:
   version: 1.2.6
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend.yaml
@@ -21,7 +21,7 @@ spec:
   version: 8.9.4
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-form-widgets.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-form-widgets.yaml
@@ -21,7 +21,7 @@ spec:
   version: 1.10.7
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
@@ -22,7 +22,7 @@ spec:
   version: 5.7.12
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/orchestrator/metadata/rhdh-bsp-scaffolder-backend-mod-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-scaffolder-backend-mod-orchestrator.yaml
@@ -22,7 +22,7 @@ spec:
   version: 1.5.4
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/pagerduty/metadata/pagerduty-backstage-plugin-backend.yaml
+++ b/workspaces/pagerduty/metadata/pagerduty-backstage-plugin-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.12.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.47.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/pagerduty/metadata/pagerduty-backstage-plugin-entity-processor.yaml
+++ b/workspaces/pagerduty/metadata/pagerduty-backstage-plugin-entity-processor.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.3.10
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.47.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/pagerduty/metadata/pagerduty-backstage-plugin-scaffolder-actions.yaml
+++ b/workspaces/pagerduty/metadata/pagerduty-backstage-plugin-scaffolder-actions.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.2.9
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.47.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/pagerduty/metadata/pagerduty-backstage-plugin.yaml
+++ b/workspaces/pagerduty/metadata/pagerduty-backstage-plugin.yaml
@@ -20,7 +20,7 @@ spec:
   version: 0.19.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.47.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/pingidentity/metadata/backstage-community-plugin-catalog-backend-module-pingidentity.yaml
+++ b/workspaces/pingidentity/metadata/backstage-community-plugin-catalog-backend-module-pingidentity.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.11.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/quay/metadata/backstage-community-plugin-quay-backend.yaml
+++ b/workspaces/quay/metadata/backstage-community-plugin-quay-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.14.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/quay/metadata/backstage-community-plugin-quay.yaml
+++ b/workspaces/quay/metadata/backstage-community-plugin-quay.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.32.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/quay/metadata/backstage-community-plugin-scaffolder-backend-module-quay.yaml
+++ b/workspaces/quay/metadata/backstage-community-plugin-scaffolder-backend-module-quay.yaml
@@ -22,7 +22,7 @@ spec:
   version: 2.18.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/quickstart/metadata/rhdh-bsp-quickstart.yaml
+++ b/workspaces/quickstart/metadata/rhdh-bsp-quickstart.yaml
@@ -19,7 +19,7 @@ spec:
   version: 1.9.6
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/rbac/metadata/backstage-community-plugin-rbac.yaml
+++ b/workspaces/rbac/metadata/backstage-community-plugin-rbac.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.52.4
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd-backend.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 4.8.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.12.5
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-datadog.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-datadog.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.7.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-github-insights.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-github-insights.yaml
@@ -20,7 +20,7 @@ spec:
   version: 3.5.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-github-pull-requests.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-github-pull-requests.yaml
@@ -20,7 +20,7 @@ spec:
   version: 3.7.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-jira.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-jira.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.14.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-security-insights.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-security-insights.yaml
@@ -20,7 +20,7 @@ spec:
   version: 3.3.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-argocd.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-argocd.yaml
@@ -21,7 +21,7 @@ spec:
   version: 1.8.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-module-aws.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-module-aws.yaml
@@ -22,7 +22,7 @@ spec:
   version: 2.8.2
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-module-http-request.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-module-http-request.yaml
@@ -21,7 +21,7 @@ spec:
   version: 5.6.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
     author: Roadie
   support: generally-available
   lifecycle: active

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-module-utils.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-scaffolder-backend-module-utils.yaml
@@ -21,7 +21,7 @@ spec:
   version: 4.1.2
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.44.2
+    supportedVersions: 1.49.4
   author: Roadie
   support: community
   lifecycle: active

--- a/workspaces/scaffolder-backend-module-kubernetes/metadata/backstage-community-plugin-scaffolder-backend-module-kubernetes.yaml
+++ b/workspaces/scaffolder-backend-module-kubernetes/metadata/backstage-community-plugin-scaffolder-backend-module-kubernetes.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.17.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/scaffolder-backend-module-regex/metadata/backstage-community-plugin-scaffolder-backend-module-regex.yaml
+++ b/workspaces/scaffolder-backend-module-regex/metadata/backstage-community-plugin-scaffolder-backend-module-regex.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.15.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/scaffolder-backend-module-servicenow/metadata/backstage-community-plugin-scaffolder-backend-module-servicenow.yaml
+++ b/workspaces/scaffolder-backend-module-servicenow/metadata/backstage-community-plugin-scaffolder-backend-module-servicenow.yaml
@@ -22,7 +22,7 @@ spec:
   version: 2.15.1
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/scaffolder-backend-module-sonarqube/metadata/backstage-community-plugin-scaffolder-backend-module-sonarqube.yaml
+++ b/workspaces/scaffolder-backend-module-sonarqube/metadata/backstage-community-plugin-scaffolder-backend-module-sonarqube.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.15.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/scaffolder-relation-processor/metadata/bcp-ctlg-backend-mod-scaffolder-relation-processor.yaml
+++ b/workspaces/scaffolder-relation-processor/metadata/bcp-ctlg-backend-mod-scaffolder-relation-processor.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.14.2
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-dependabot.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-dependabot.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.2.11
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-filecheck.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-filecheck.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.1.8
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.7.7
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.7.7
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-openssf.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-openssf.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.2.11
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-sonarqube.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-sonarqube.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.1.6
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.7.7
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.7.7
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: dev-preview
   lifecycle: active

--- a/workspaces/servicenow/metadata/backstage-community-plugin-servicenow-backend.yaml
+++ b/workspaces/servicenow/metadata/backstage-community-plugin-servicenow-backend.yaml
@@ -21,7 +21,7 @@ spec:
   version: 1.10.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/servicenow/metadata/backstage-community-plugin-servicenow.yaml
+++ b/workspaces/servicenow/metadata/backstage-community-plugin-servicenow.yaml
@@ -21,7 +21,7 @@ spec:
   version: 1.10.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/sonarqube/metadata/backstage-community-plugin-sonarqube-backend.yaml
+++ b/workspaces/sonarqube/metadata/backstage-community-plugin-sonarqube-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.1.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/sonarqube/metadata/backstage-community-plugin-sonarqube.yaml
+++ b/workspaces/sonarqube/metadata/backstage-community-plugin-sonarqube.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.1.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/tech-insights/metadata/backstage-community-plugin-tech-insights-backend-module-jsonfc.yaml
+++ b/workspaces/tech-insights/metadata/backstage-community-plugin-tech-insights-backend-module-jsonfc.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.7.2
   backstage:
     role: backend-plugin
-    supportedVersions: 1.47.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/tech-insights/metadata/backstage-community-plugin-tech-insights-maturity.yaml
+++ b/workspaces/tech-insights/metadata/backstage-community-plugin-tech-insights-maturity.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.6.5
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.47.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/tech-insights/metadata/backstage-community-plugin-tech-insights.yaml
+++ b/workspaces/tech-insights/metadata/backstage-community-plugin-tech-insights.yaml
@@ -18,7 +18,7 @@ spec:
   version: 1.2.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.47.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/tech-radar/metadata/backstage-community-plugin-tech-radar-backend.yaml
+++ b/workspaces/tech-radar/metadata/backstage-community-plugin-tech-radar-backend.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.16.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/tech-radar/metadata/backstage-community-plugin-tech-radar.yaml
+++ b/workspaces/tech-radar/metadata/backstage-community-plugin-tech-radar.yaml
@@ -20,7 +20,7 @@ spec:
   version: 1.17.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/tekton/metadata/backstage-community-plugin-tekton.yaml
+++ b/workspaces/tekton/metadata/backstage-community-plugin-tekton.yaml
@@ -20,7 +20,7 @@ spec:
   version: 3.37.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/theme/metadata/red-hat-developer-hub-backstage-plugin-qe-theme.yaml
+++ b/workspaces/theme/metadata/red-hat-developer-hub-backstage-plugin-qe-theme.yaml
@@ -16,7 +16,7 @@ spec:
   version: 0.11.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/theme/metadata/red-hat-developer-hub-backstage-plugin-theme.yaml
+++ b/workspaces/theme/metadata/red-hat-developer-hub-backstage-plugin-theme.yaml
@@ -16,7 +16,7 @@ spec:
   version: 0.14.5
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/todo/metadata/backstage-community-plugin-todo-backend.yaml
+++ b/workspaces/todo/metadata/backstage-community-plugin-todo-backend.yaml
@@ -19,7 +19,7 @@ spec:
   version: 0.19.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/todo/metadata/backstage-community-plugin-todo.yaml
+++ b/workspaces/todo/metadata/backstage-community-plugin-todo.yaml
@@ -19,7 +19,7 @@ spec:
   version: 0.18.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Backstage Community
   support: community
   lifecycle: active

--- a/workspaces/topology/metadata/backstage-community-plugin-topology.yaml
+++ b/workspaces/topology/metadata/backstage-community-plugin-topology.yaml
@@ -20,7 +20,7 @@ spec:
   version: 2.12.3
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.2
+    supportedVersions: 1.49.4
   author: Red Hat
   support: generally-available
   lifecycle: active

--- a/workspaces/translations/metadata/red-hat-developer-hub-backstage-plugin-translations-backend.yaml
+++ b/workspaces/translations/metadata/red-hat-developer-hub-backstage-plugin-translations-backend.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.3.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/translations/metadata/red-hat-developer-hub-backstage-plugin-translations.yaml
+++ b/workspaces/translations/metadata/red-hat-developer-hub-backstage-plugin-translations.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.3.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.49.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a.yaml
+++ b/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.3.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-backend.yaml
+++ b/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-backend.yaml
@@ -18,7 +18,7 @@ spec:
   version: 1.4.2
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-dcr.yaml
+++ b/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-dcr.yaml
@@ -22,3 +22,5 @@ spec:
   author: Red Hat
   support: community
   lifecycle: active
+  appConfigNotRequired: true
+  appConfigExamples: []

--- a/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-dcr.yaml
+++ b/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-dcr.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.2.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras.yaml
+++ b/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras.yaml
@@ -22,3 +22,5 @@ spec:
   author: Red Hat
   support: community
   lifecycle: active
+  appConfigNotRequired: true
+  appConfigExamples: []

--- a/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras.yaml
+++ b/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras.yaml
@@ -18,7 +18,7 @@ spec:
   version: 0.2.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active

--- a/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a.yaml
+++ b/workspaces/x2a/metadata/red-hat-developer-hub-backstage-plugin-x2a.yaml
@@ -18,7 +18,7 @@ spec:
   version: 1.2.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.45.3
+    supportedVersions: 1.49.4
   author: Red Hat
   support: community
   lifecycle: active


### PR DESCRIPTION
Follow-up to #2538. Use versions.json Backstage target for all Package metadata so Extensions catalog shows RHDH platform compatibility. Replaces per-workspace source.json values that understated compatibility (e.g. 1.49.3, 1.43.1) per review feedback.