### PR TITLE
[WIP] feat(auth): add scalprum overlay to expose Router component for DCR OAuth2 consent page

### DIFF
--- a/workspaces/backstage/plugins/auth/app-config.dynamic.yaml
+++ b/workspaces/backstage/plugins/auth/app-config.dynamic.yaml
@@ -1,0 +1,7 @@
+dynamicPlugins:
+  frontend:
+    backstage.plugin-auth:
+      dynamicRoutes:
+        - path: /oauth2
+          importName: Router
+          module: PluginRoot

--- a/workspaces/backstage/plugins/auth/overlay/src/exposed.ts
+++ b/workspaces/backstage/plugins/auth/overlay/src/exposed.ts
@@ -1,0 +1,1 @@
+export { Router } from './components/Router';

--- a/workspaces/backstage/plugins/auth/scalprum-config.json
+++ b/workspaces/backstage/plugins/auth/scalprum-config.json
@@ -1,0 +1,6 @@
+{
+  "name": "backstage.plugin-auth",
+  "exposedModules": {
+    "PluginRoot": "./src/exposed.ts"
+  }
+}


### PR DESCRIPTION
## Summary

The `@backstage/plugin-auth` frontend plugin (introduced in [backstage/backstage#31092](https://github.com/backstage/backstage/pull/31092)) provides the OAuth2 consent page at `/oauth2/authorize/:sessionId`, which is required for [Dynamic Client Registration (DCR)](https://backstage.io/docs/auth/service-to-service-auth/#dynamic-client-registration) in MCP servers.

Currently, the exported OCI image uses `registrationMethod: "callback"` with no `exposedModules`, because the plugin is built with the new Backstage frontend system (`createFrontendPlugin` + `PageBlueprint`). This means RHDH's `dynamicRoutes` system cannot render it — attempting to mount the default export gives React error 130 (element type is invalid: expected a component but got an object).

This PR adds a scalprum overlay that explicitly exports the `Router` component via module federation, making the image compatible with RHDH's existing `dynamicRoutes` wiring. This follows the same pattern used by [`api-docs-module-protoc-gen-doc`](https://github.com/redhat-developer/rhdh-plugin-export-overlays/tree/main/workspaces/backstage/plugins/api-docs-module-protoc-gen-doc), which also provides a `scalprum-config.json` + overlay source entry point to control what is exposed via module federation.

## Changes

- **`scalprum-config.json`** — Forces `exposedModules: { "PluginRoot": "./src/exposed.ts" }` instead of auto-detected callback registration
- **`overlay/src/exposed.ts`** — Custom entry point that re-exports `Router` from `./components/Router`
- **`app-config.dynamic.yaml`** — Default frontend wiring config for users of this image

## Usage

```yaml
- package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth:<tag>
  disabled: false
  pluginConfig:
    dynamicPlugins:
      frontend:
        backstage.plugin-auth:
          dynamicRoutes:
            - path: /oauth2
              importName: Router
              module: PluginRoot