### PR TITLE
chore: add tag fallback to use outdated tags for best effort catalog index

### DIFF
--- a/.github/workflows/generate-catalog-index.yaml
+++ b/.github/workflows/generate-catalog-index.yaml
@@ -32,7 +32,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY: 'quay.io/rhdh'
   COMMUNITY_REGISTRY: 'ghcr.io/redhat-developer/rhdh-plugin-export-overlays'
   COMMUNITY_CATALOG_INDEX: 'ghcr.io/redhat-developer/rhdh-plugin-export-overlays/plugin-catalog-index'
   SUPPORTED_CATALOG_INDEX: 'quay.io/rhdh-community/plugin-catalog-index'
@@ -141,18 +140,15 @@ jobs:
             RHDH_VERSION_ARG="--rhdh-version $RHDH_VERSION"
           fi
 
-          COMMUNITY_ARG="--community-registry $COMMUNITY_REGISTRY"
-
           # shellcheck disable=SC2086
           if scripts/update-index.sh \
             --overlays-dir . \
-            --registry "$REGISTRY" \
+            --registry "$COMMUNITY_REGISTRY" \
             --output-dir catalog-index/supported \
             --plugin-builds-dir plugin_builds/supported \
             --packages-file default.packages.yaml \
             --packages-file rhdh-supported-packages.txt \
             --report-file catalog-index/supported/build-report.json \
-            $COMMUNITY_ARG \
             $RHDH_VERSION_ARG; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
@@ -175,23 +171,16 @@ jobs:
 
       - name: Generate community catalog
         id: gen-community
-        env:
-          RHDH_VERSION: ${{ steps.versions.outputs.rhdh-version }}
         run: |
-          RHDH_VERSION_ARG=""
-          if [[ -n "$RHDH_VERSION" ]]; then
-            RHDH_VERSION_ARG="--rhdh-version $RHDH_VERSION"
-          fi
 
-          # shellcheck disable=SC2086
+
           if scripts/update-index.sh \
             --overlays-dir . \
-            --registry "$REGISTRY" \
+            --registry "$COMMUNITY_REGISTRY" \
             --output-dir catalog-index/community \
             --plugin-builds-dir plugin_builds/community \
             --packages-file rhdh-community-packages.txt \
-            --report-file catalog-index/community/build-report.json \
-            $RHDH_VERSION_ARG; then
+            --report-file catalog-index/community/build-report.json; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::Community catalog generation failed"

--- a/.github/workflows/generate-catalog-index.yaml
+++ b/.github/workflows/generate-catalog-index.yaml
@@ -46,6 +46,8 @@ jobs:
     outputs:
       supported-ok: ${{ steps.gen-supported.outputs.ok }}
       community-ok: ${{ steps.gen-community.outputs.ok }}
+      supported-clean: ${{ steps.gen-supported.outputs.clean }}
+      community-clean: ${{ steps.gen-community.outputs.clean }}
       backstage-version: ${{ steps.versions.outputs.backstage-version }}
       rhdh-version: ${{ steps.versions.outputs.rhdh-version }}
       source-branch: ${{ steps.branches.outputs.source-branch }}
@@ -156,6 +158,19 @@ jobs:
           else
             echo "::warning::Supported catalog generation failed"
             echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if the catalog is clean (no fallbacks or missing plugins)
+          REPORT="catalog-index/supported/build-report.json"
+          if [[ -f "$REPORT" ]]; then
+            FAILED=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACKS=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+            if [[ "$FAILED" -eq 0 && "$FALLBACKS" -eq 0 ]]; then
+              echo "clean=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "clean=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Generate community catalog
@@ -181,6 +196,19 @@ jobs:
           else
             echo "::warning::Community catalog generation failed"
             echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if the catalog is clean (no fallbacks or missing plugins)
+          REPORT="catalog-index/community/build-report.json"
+          if [[ -f "$REPORT" ]]; then
+            FAILED=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACKS=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+            if [[ "$FAILED" -eq 0 && "$FALLBACKS" -eq 0 ]]; then
+              echo "clean=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "clean=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Write build-info.json
@@ -250,10 +278,37 @@ jobs:
         env:
           SUPPORTED_OK: ${{ steps.gen-supported.outputs.ok }}
           COMMUNITY_OK: ${{ steps.gen-community.outputs.ok }}
+          SUPPORTED_CLEAN: ${{ steps.gen-supported.outputs.clean }}
+          COMMUNITY_CLEAN: ${{ steps.gen-community.outputs.clean }}
         run: |
           if [[ "${SUPPORTED_OK}" != "true" || "${COMMUNITY_OK}" != "true" ]]; then
             echo "::error::Catalog generation failed (supported=$SUPPORTED_OK, community=$COMMUNITY_OK)"
             exit 1
+          fi
+
+          # Surface fallbacks and missing plugins as warnings
+          HAS_ISSUES=false
+          for TIER in supported community; do
+            REPORT="catalog-index/$TIER/build-report.json"
+            if [[ ! -f "$REPORT" ]]; then continue; fi
+
+            FAILED_COUNT=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACK_COUNT=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+
+            if [[ "$FAILED_COUNT" -gt 0 ]]; then
+              FAILED_PLUGINS=$(jq -r '[.plugins | to_entries[] | select(.value.overall == "fail") | .key] | join(", ")' "$REPORT" 2>/dev/null || echo "")
+              echo "::warning::$TIER catalog: $FAILED_COUNT plugin(s) missing from registry: $FAILED_PLUGINS"
+              HAS_ISSUES=true
+            fi
+            if [[ "$FALLBACK_COUNT" -gt 0 ]]; then
+              FALLBACK_PLUGINS=$(jq -r '[.plugins | to_entries[] | select(.value.stages["registry-enrich"].fallback == true) | .key] | join(", ")' "$REPORT" 2>/dev/null || echo "")
+              echo "::warning::$TIER catalog: $FALLBACK_COUNT plugin(s) using fallback tags: $FALLBACK_PLUGINS"
+              HAS_ISSUES=true
+            fi
+          done
+
+          if [[ "$HAS_ISSUES" == "true" ]]; then
+            echo "::warning::Catalog published with issues — last-successful-publish not updated"
           fi
 
   publish-supported:
@@ -389,6 +444,8 @@ jobs:
         env:
           PUBLISH_SUPPORTED_RESULT: ${{ needs.publish-supported.result }}
           PUBLISH_COMMUNITY_RESULT: ${{ needs.publish-community.result }}
+          SUPPORTED_CLEAN: ${{ needs.generate.outputs.supported-clean }}
+          COMMUNITY_CLEAN: ${{ needs.generate.outputs.community-clean }}
           BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
           RHDH_VERSION: ${{ needs.generate.outputs.rhdh-version }}
         run: |
@@ -404,9 +461,11 @@ jobs:
 
             if [[ "$TIER" == "supported" ]]; then
               RESULT="${PUBLISH_SUPPORTED_RESULT}"
+              CLEAN="${SUPPORTED_CLEAN}"
               IMAGE="${SUPPORTED_CATALOG_INDEX}:${TAG}"
             else
               RESULT="${PUBLISH_COMMUNITY_RESULT}"
+              CLEAN="${COMMUNITY_CLEAN}"
               IMAGE="${COMMUNITY_CATALOG_INDEX}:${TAG}"
             fi
 
@@ -414,12 +473,16 @@ jobs:
               '.metadata["catalog-index-image"] = $image' \
               "$REPORT" > "${REPORT}.tmp" && mv "${REPORT}.tmp" "$REPORT"
 
-            if [[ "$RESULT" == "success" ]]; then
+            # Only mark as last-successful-publish when publish succeeded AND catalog is clean
+            # (no fallback tags, no missing plugins)
+            if [[ "$RESULT" == "success" && "$CLEAN" == "true" ]]; then
               jq --arg sha "$GITHUB_SHA" \
                 '.metadata["last-successful-publish"] = $sha' \
                 "$REPORT" > "${REPORT}.tmp" && mv "${REPORT}.tmp" "$REPORT"
+              echo "Updated $TIER report: publish=$RESULT, clean=$CLEAN, image=$IMAGE (last-successful-publish updated)"
+            else
+              echo "Updated $TIER report: publish=$RESULT, clean=$CLEAN, image=$IMAGE (last-successful-publish NOT updated)"
             fi
-            echo "Updated $TIER report: publish=$RESULT, image=$IMAGE"
           done
 
       - name: Render catalog status page

--- a/.github/workflows/validate-catalog-scripts.yaml
+++ b/.github/workflows/validate-catalog-scripts.yaml
@@ -1,0 +1,40 @@
+name: Validate catalog index scripts
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
+    paths:
+      - 'scripts/*.py'
+      - 'scripts/tests/**'
+      - 'scripts/requirements-dev.txt'
+      - '.github/workflows/validate-catalog-scripts.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: validate-catalog-scripts-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r scripts/requirements-dev.txt
+
+      - name: Run tests
+        working-directory: scripts
+        run: python -m pytest tests/ -v

--- a/scripts/bootstrapPluginBuilds.py
+++ b/scripts/bootstrapPluginBuilds.py
@@ -24,8 +24,7 @@ from plugin_utils import (
     log_warn,
     log_error,
     set_debug,
-    read_plugins_list,
-    match_metadata_to_plugin_path,
+    build_workspace_mappings,
     load_and_resolve_to_npm_names,
 )
 
@@ -216,6 +215,9 @@ Examples:
 
     print(f"\n{Colors.GREEN}=== Bootstrap plugin_builds from workspace metadata ==={Colors.NORM}\n")
 
+    # Build workspace mappings upfront for stem → workspace path resolution
+    ws_mappings = build_workspace_mappings(overlays_dir)
+
     # Find all workspace directories with metadata
     workspace_dirs = sorted([
         d for d in workspaces_dir.iterdir()
@@ -230,7 +232,6 @@ Examples:
     for workspace_dir in workspace_dirs:
         workspace_name = workspace_dir.name
         metadata_dir = workspace_dir / "metadata"
-        plugin_paths = read_plugins_list(workspace_dir)
 
         yaml_files = sorted(metadata_dir.glob("*.yaml"))
         if not yaml_files:
@@ -252,14 +253,6 @@ Examples:
                 package_name = spec.get('packageName', '')
                 support_level = spec.get('support', '')
 
-                # Derive workspacePath
-                matched_path = match_metadata_to_plugin_path(stem, plugin_paths)
-                if matched_path:
-                    workspace_path = f"{workspace_name}/{matched_path}"
-                else:
-                    workspace_path = f"{workspace_name}/{stem}"
-                    log_debug(f"No plugins-list match for {stem}, using fallback: {workspace_path}")
-
                 # Check packages filter (by npm package name)
                 if packages_set is not None and package_name not in packages_set:
                     skipped_count += 1
@@ -267,6 +260,15 @@ Examples:
 
                 # Construct registryReference
                 image_name = package_name_to_image_name(package_name) if package_name else stem
+
+                # Look up workspacePath from pre-built mappings (uses scored matching
+                # + process-of-elimination to handle divergent folder/package names)
+                workspace_path = ws_mappings.ws_path_to_npm and next(
+                    (wp for wp, npm in ws_mappings.ws_path_to_npm.items() if npm == package_name), None
+                )
+                if not workspace_path:
+                    workspace_path = f"{workspace_name}/{stem}"
+                    log_debug(f"No workspace mapping for {package_name}, using fallback: {workspace_path}")
                 effective_registry = registry_base
                 if support_level == 'community' and community_registry != registry_base:
                     effective_registry = community_registry

--- a/scripts/generateCatalogIndex.py
+++ b/scripts/generateCatalogIndex.py
@@ -1044,11 +1044,10 @@ Examples:
 
     if missing_references:
         print("\n========")
-        log_warn(f"Could not find {Colors.RED}{len(missing_references)}{Colors.NORM} plugins listed in plugin_builds/ folder! Remember to export and publish them, then re-run this script.")
+        log_warn(f"Could not find {Colors.YELLOW}{len(missing_references)}{Colors.NORM} plugins listed in plugin_builds/ folder! Remember to export and publish them, then re-run this script.")
         for json_file, _plugin_name, reference in missing_references:
-            print(f"  - {json_file} > {Colors.RED}https://{reference}{Colors.NORM}")
-        log_error(f"{len(missing_references)} plugin(s) missing from registry — catalog is incomplete")
-        sys.exit(1)
+            print(f"  - {json_file} > {Colors.YELLOW}https://{reference}{Colors.NORM}")
+        log_warn(f"{len(missing_references)} plugin(s) missing from registry — catalog published without them")
 
 
 if __name__ == "__main__":

--- a/scripts/generateCatalogIndex.py
+++ b/scripts/generateCatalogIndex.py
@@ -39,7 +39,7 @@ REGISTRY_BASE = ""
 
 
 def is_registry_rarc() -> bool:
-    """Check if the registry is registry.access.redhat.com (downstream GA registry)"""
+    """Check if REGISTRY_BASE is registry.access.redhat.com. Used to determine if queries should be routed through quay.io for unauthenticated access."""
     return REGISTRY_BASE.startswith("registry.access.redhat.com")
 
 
@@ -86,6 +86,31 @@ def get_ghcr_token(repository: str) -> str | None:
 
 
 def parse_image_reference(registry_reference: str) -> tuple[str, str, str]:
+    """Split a container image reference into its name, tag, and digest components.
+
+    Handles all combinations of tag and digest presence, including references
+    with both (tag + digest), tag only, digest only, or empty string input.
+    Tag separators vary by registry: ghcr.io uses ``bs_{bsver}__{pluginver}``
+    while quay.io/rhdh uses ``{rhdhver}--{pluginver}``.
+
+    Args:
+        registry_reference: A container image reference string, e.g.
+            ``"quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123"``.
+
+    Returns:
+        A 3-tuple of ``(image_name, tag, digest)`` where any component may
+        be an empty string if not present in the input.
+
+    Examples:
+        >>> parse_image_reference("quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123")
+        ('quay.io/rhdh/plugin', '1.11--1.5.4', 'sha256:abc123')
+        >>> parse_image_reference("quay.io/rhdh/plugin:1.11--1.5.4")
+        ('quay.io/rhdh/plugin', '1.11--1.5.4', '')
+        >>> parse_image_reference("quay.io/rhdh/plugin@sha256:abc123")
+        ('quay.io/rhdh/plugin', '', 'sha256:abc123')
+        >>> parse_image_reference("")
+        ('', '', '')
+    """
     if not registry_reference:
         return "", "", ""
 
@@ -110,6 +135,31 @@ MIGRATION_HINT_RE = re.compile(
 
 
 def tag_comment_for_plugin(plugin_data: dict) -> str | None:
+    """Build a tag/build-date comment string from plugin build data.
+
+    Constructs a YAML comment line summarizing the image tag and build date
+    for a plugin. These comments are inserted above OCI package lines in
+    package YAML files and dynamic-plugins.default.yaml to provide
+    human-readable provenance.
+
+    Args:
+        plugin_data: A dict from plugin_builds JSON containing at minimum
+            ``'build-date'``, ``'registryReference'``, and optionally
+            ``'imageTag'``. The tag is taken from ``'imageTag'`` if present,
+            otherwise extracted from the registryReference.
+
+    Returns:
+        A comment string like ``"# Tag: 1.11--1.5.4, Build date: 2025-05-01"``,
+        or ``None`` if any of tag, build_date, or digest is missing.
+
+    Example:
+        >>> tag_comment_for_plugin({
+        ...     'build-date': '2025-05-01',
+        ...     'registryReference': 'quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc',
+        ...     'imageTag': '1.11--1.5.4',
+        ... })
+        '# Tag: 1.11--1.5.4, Build date: 2025-05-01'
+    """
     build_date = plugin_data.get('build-date') or ''
     tag = plugin_data.get('imageTag') or ''
     _, fallback_tag, digest = parse_image_reference(plugin_data.get('registryReference', ''))
@@ -120,19 +170,23 @@ def tag_comment_for_plugin(plugin_data: dict) -> str | None:
 
 
 def is_tag_comment_line(line: str) -> bool:
+    """Check if a line matches the ``# Tag: ..., Build date: ...`` pattern."""
     return bool(TAG_COMMENT_RE.match(line))
 
 
 def tag_comment_line_text(comment: str) -> str:
+    """Wrap a tag comment string with 2-space indentation and trailing newline."""
     return f"  {comment}\n"
 
 
 def pop_trailing_tag_comments(new_lines: list[str]) -> None:
+    """Remove trailing tag comment lines from the end of a line buffer."""
     while new_lines and is_tag_comment_line(new_lines[-1]):
         new_lines.pop()
 
 
 def trailing_tag_comment_matches(new_lines: list[str], expected_comment: str | None) -> bool:
+    """Check if the last non-blank line in the buffer matches the expected tag comment."""
     if not expected_comment:
         return False
     for line in reversed(new_lines):
@@ -145,11 +199,13 @@ def trailing_tag_comment_matches(new_lines: list[str], expected_comment: str | N
 
 
 def digest_from_oci_package_line(line: str) -> str | None:
+    """Extract the sha256 digest from an OCI package line, or None if not matched."""
     m = OCI_PACKAGE_DIGEST_RE.match(line)
     return m.group(2) if m else None
 
 
 def peek_digest_after(lines: list[str], idx: int) -> str | None:
+    """Look ahead in lines starting after idx to find the next OCI package digest."""
     j = idx + 1
     while j < len(lines):
         nl = lines[j]
@@ -167,7 +223,7 @@ def peek_digest_after(lines: list[str], idx: int) -> str | None:
 
 
 def inject_dpdy_tag_comments(output_dir: Path, plugin_builds_dir: Path) -> None:
-    """Ensure Tag/Build date comments on commented oci:// lines and wrapper package lines."""
+    """Delegate to injectDpdyTagComments.py to add Tag/Build date comments to dynamic-plugins.default.yaml."""
     dpdy = output_dir / "dynamic-plugins.default.yaml"
     script = Path(__file__).resolve().parent / "injectDpdyTagComments.py"
     if not dpdy.is_file() or not script.is_file():
@@ -182,6 +238,31 @@ def inject_dpdy_tag_comments(output_dir: Path, plugin_builds_dir: Path) -> None:
 
 
 def build_digest_comment_map(index_data: dict[str, dict]) -> dict[str, str]:
+    """Build a mapping from sha256 digests to their tag comment strings.
+
+    Iterates over index data and creates a lookup dict so that OCI package
+    lines containing a digest can be matched to their corresponding
+    human-readable tag comment.
+
+    Args:
+        index_data: The combined index dict mapping plugin names to their
+            plugin data dicts (as produced by ``generate_index_json``).
+
+    Returns:
+        A dict mapping digest strings to comment strings, e.g.
+        ``{"sha256:abc123": "# Tag: 1.11--1.5.4, Build date: 2025-05-01"}``.
+        Only entries with a valid tag comment and digest are included.
+
+    Example:
+        >>> build_digest_comment_map({
+        ...     "my-plugin": {
+        ...         "registryReference": "quay.io/rhdh/plugin@sha256:abc123",
+        ...         "imageTag": "1.11--1.5.4",
+        ...         "build-date": "2025-05-01",
+        ...     }
+        ... })
+        {'sha256:abc123': '# Tag: 1.11--1.5.4, Build date: 2025-05-01'}
+    """
     digest_comment_map: dict[str, str] = {}
     for pdata in index_data.values():
         comment = tag_comment_for_plugin(pdata)
@@ -193,7 +274,7 @@ def build_digest_comment_map(index_data: dict[str, dict]) -> dict[str, str]:
     return digest_comment_map
 
 def copy_catalog_entities_extensions(source_dir: Path, output_dir: Path) -> None:
-    """Copy content from catalog-entities/extensions source to output catalog-entities/extensions."""
+    """Copy the catalog-entities/extensions/ source directory to the output directory."""
     target_dir = output_dir / "catalog-entities" / "extensions"
 
     if not source_dir.exists():
@@ -223,11 +304,25 @@ def copy_catalog_entities_extensions(source_dir: Path, output_dir: Path) -> None
 
 
 def copy_workspace_metadata_files(overlays_dir: Path, output_dir: Path) -> tuple[set, dict[str, str]]:
-    """
-    Task 2: Find all *.yaml files in workspaces/*/metadata/ and copy them to
-    output catalog-entities/extensions/packages/
+    """Copy workspace metadata YAML files to the output packages directory.
 
-    Returns: (set of YAML file base names, dict mapping base names to full relative paths)
+    Finds all ``workspaces/*/metadata/*.yaml`` files in the overlays directory
+    and copies them to ``<output_dir>/catalog-entities/extensions/packages/``.
+    These are ``kind: Package`` entity files that describe each built plugin
+    artifact (version, OCI reference, appConfigExamples).
+
+    Args:
+        overlays_dir: Root of the overlays repository containing the
+            ``workspaces/`` directory.
+        output_dir: Output directory where the catalog index is being
+            assembled.
+
+    Returns:
+        A 2-tuple of:
+        - A set of YAML file base names (stems without extension), e.g.
+          ``{"backstage-plugin-techdocs", "backstage-plugin-catalog"}``.
+        - A dict mapping each base name to its relative source path, e.g.
+          ``{"backstage-plugin-techdocs": "workspaces/backstage/metadata/backstage-plugin-techdocs.yaml"}``.
     """
     overlay_workspaces = overlays_dir / "workspaces"
     target_packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
@@ -260,7 +355,7 @@ def copy_workspace_metadata_files(overlays_dir: Path, output_dir: Path) -> tuple
 
 
 def check_image_exists(registry_reference: str) -> bool:
-    """Check if a container image exists using Docker Registry HTTP API v2"""
+    """Check if a container image exists in the registry using a Docker Registry HTTP API v2 HEAD request."""
     try:
         parts = registry_reference.split('/', 1)
         if len(parts) < 2:
@@ -321,12 +416,42 @@ def check_image_exists(registry_reference: str) -> bool:
 
 
 def generate_index_json(plugin_builds_dir: Path, output_dir: Path, report: BuildReport | None = None) -> tuple[dict[str, dict], list[str], list[tuple[str, str, str]], dict[str, str], dict[str, dict]]:
-    """
-    Read *.json files in plugin_builds/ and check if registryReference exists.
-    Combine valid ones into index.json.
-    No filtering — plugin_builds/ is already pre-filtered by bootstrapPluginBuilds.py.
+    """Generate the catalog index.json from plugin_builds/ metadata.
 
-    Returns: (combined_index, found_plugins, missing_references, plugin_workspace_paths, all_plugin_data)
+    This is the core pipeline of the catalog index generator. It reads each
+    JSON file in ``plugin_builds/``, where each file is a dict mapping
+    plugin image names (e.g. ``"red-hat-developer-hub-backstage-plugin-foo"``)
+    to plugin data dicts containing fields like ``registryReference``,
+    ``digest``, ``build-date``, ``vcs-ref``, ``workspacePath``, and
+    ``support``. For each plugin, it verifies the OCI image exists in the
+    registry (swapping registry.access.redhat.com queries to quay.io for
+    unauthenticated access), then writes all valid entries into an ordered
+    ``index.json``.
+
+    The ``plugin_builds/`` directory is pre-filtered by
+    ``bootstrapPluginBuilds.py`` to the appropriate tier (supported,
+    community, etc.), so no additional filtering is performed here.
+
+    Args:
+        plugin_builds_dir: Path to the ``plugin_builds/`` directory
+            containing ``<workspace>/*.json`` files.
+        output_dir: Output directory where ``index.json`` will be written.
+        report: Optional ``BuildReport`` instance for tracking per-plugin
+            pass/fail status of the catalog-index stage.
+
+    Returns:
+        A 5-tuple of:
+        - ``combined_index``: Dict mapping plugin names to their plugin data
+          dicts for all plugins whose OCI images were found.
+        - ``found_plugins``: List of plugin names with valid OCI images,
+          in processing order.
+        - ``missing_references``: List of 3-tuples
+          ``(json_file_path, plugin_name, reason)`` for plugins that could
+          not be resolved.
+        - ``plugin_workspace_paths``: Dict mapping plugin names to their
+          workspace paths (e.g. ``"workspaces/backstage"``).
+        - ``all_plugin_data``: Dict of all plugin data regardless of OCI
+          image existence, used for diagnostic reporting.
     """
     catalog_index_json = output_dir / "index.json"
 
@@ -454,7 +579,37 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path, report: Build
 
 
 def update_package_files(output_dir: Path, index_data: dict[str, dict], found_plugins: list[str], plugin_builds_dir: Path) -> None:
-    """Add OCI reference entries alongside existing file path entries"""
+    """Add or update OCI reference entries in package YAML files and dynamic-plugins.default.yaml.
+
+    Performs line-by-line editing on package YAML files and
+    ``dynamic-plugins.default.yaml`` to inject OCI image references. Handles
+    two distinct patterns:
+
+    1. **Replacing existing OCI lines**: When a ``- package: oci://...`` line
+       already exists for the plugin, it is replaced with the current digest
+       reference and its tag comment is updated.
+    2. **Adding commented OCI blocks**: When only a file-path entry exists
+       (``- package: ./dynamic-plugins/dist/...``), a commented-out OCI
+       block is added above it with migration hints, preserving the original
+       file-path entry.
+
+    Plugin name matching accounts for alternatives: the
+    ``red-hat-developer-hub-`` vs ``rhdh-`` prefix, and with/without the
+    ``-dynamic`` suffix.
+
+    Also delegates to ``inject_dpdy_tag_comments`` to handle tag comments
+    on lines that were not matched by the main loop (e.g., wrapper package
+    lines in dynamic-plugins.default.yaml).
+
+    Args:
+        output_dir: Output directory containing the catalog index being
+            assembled.
+        index_data: Combined index dict mapping plugin names to plugin data
+            (from ``generate_index_json``).
+        found_plugins: List of plugin names with valid OCI images.
+        plugin_builds_dir: Path to ``plugin_builds/`` directory, passed
+            through to ``inject_dpdy_tag_comments``.
+    """
     packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
     dynamic_plugins_yaml = output_dir / "dynamic-plugins.default.yaml"
 
@@ -672,7 +827,19 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
 
 
 def prune_packages_dir(output_dir: Path, found_plugins: list[str]) -> None:
-    """Remove package YAML files from the output that don't correspond to plugins in the index."""
+    """Remove package YAML files that don't correspond to plugins in the index.
+
+    Iterates over ``catalog-entities/extensions/packages/*.yaml`` and deletes
+    any file whose image name (derived via ``get_image_name_from_package_yaml``)
+    is not present in the ``found_plugins`` list. This ensures the output
+    catalog only contains Package entities for plugins whose OCI images were
+    successfully resolved.
+
+    Args:
+        output_dir: Output directory containing the assembled catalog index.
+        found_plugins: List of plugin image names that have valid OCI images
+            in the registry (from ``generate_index_json``).
+    """
     packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
     if not packages_dir.exists():
         return
@@ -741,12 +908,30 @@ def _support_label_color(label: str) -> str:
 
 
 def scrub_plugin_entity_file(yaml_file: Path, filtered_stems: set[str]) -> str:
-    """Scrub a single Plugin entity YAML file.
-    - If no packages match the filter: delete the file
-    - If all packages match the filter: keep as-is
-    - If mixed: use line-based editing to remove excluded package refs
+    """Scrub a single Plugin entity YAML file based on a package filter.
 
-    Returns: 'removed' | 'stripped' | 'kept' | 'skipped'
+    Examines the ``spec.packages`` list of a ``kind: Plugin`` entity and
+    determines how to handle it relative to the allowed package stems:
+
+    - If **no** packages match the filter, the file is deleted entirely.
+    - If **all** packages match, the file is kept unchanged.
+    - If the match is **mixed**, line-based editing removes only the
+      excluded package references while preserving the rest of the file.
+
+    Non-Plugin entities (wrong ``kind`` or unparseable) are skipped.
+
+    Args:
+        yaml_file: Path to a Plugin entity YAML file in the
+            ``catalog-entities/extensions/plugins/`` directory.
+        filtered_stems: Set of allowed package entity names (metadata.name
+            values) derived from the package filter files.
+
+    Returns:
+        One of four status strings:
+        - ``'removed'``: File was deleted (no packages matched the filter).
+        - ``'stripped'``: File was edited to remove excluded package refs.
+        - ``'kept'``: File was left unchanged (all packages matched).
+        - ``'skipped'``: File was not a Plugin entity or could not be parsed.
     """
     try:
         with open(yaml_file, 'r', encoding='utf-8') as f:
@@ -817,7 +1002,25 @@ def scrub_plugin_entity_file(yaml_file: Path, filtered_stems: set[str]) -> str:
 
 
 def scrub_catalog_entities(output_dir: Path, overlays_dir: Path, packages_files: list[str]) -> None:
-    """Scrub catalog entities to only retain plugins/packages from the provided package files."""
+    """Scrub both plugins/ and packages/ directories to only retain entities from the package filter files.
+
+    Resolves the union of package stems from all provided filter files
+    (YAML and/or txt format), then:
+
+    1. Scrubs ``plugins/`` by delegating each Plugin entity YAML to
+       ``scrub_plugin_entity_file`` (removes, strips, or keeps).
+    2. Scrubs ``packages/`` by removing any Package metadata YAML whose
+       ``metadata.name`` is not in the resolved filter set.
+
+    Args:
+        output_dir: Output directory containing the assembled catalog index
+            with ``catalog-entities/extensions/plugins/`` and ``packages/``.
+        overlays_dir: Root of the overlays repository, used for resolving
+            workspace paths in txt-format filter files.
+        packages_files: List of paths to package filter files. Accepts YAML
+            (``default.packages.yaml`` with npm names) or txt (workspace
+            paths, one per line). Stems from all files are unioned.
+    """
     filtered_stems = load_and_resolve_to_stems(packages_files, overlays_dir)
     log_info(f"Resolved {len(filtered_stems)} filtered package stems from {len(packages_files)} file(s)")
 

--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -15,13 +15,14 @@
 # - midstream: from container env MIDSTREAM_REPO
 
 import argparse
+import hashlib
 import json
 import os
+import re
 import sys
 from pathlib import Path
 import requests
 import yaml
-import hashlib
 
 from plugin_utils import (
     BuildReport,
@@ -43,24 +44,27 @@ RARC_RHDH_PREFIX = RARC_DOMAIN + "/rhdh/"
 
 DYNAMIC_PACKAGES_ANNOTATION = "io.backstage.dynamic-packages"
 
+# Matches a clean version suffix: "2.18.0", "1.5", but NOT ".att", ".sbom", bare SHAs, etc.
+VERSION_SUFFIX_RE = re.compile(r'^\d+\.\d+(\.\d+)?$')
+
 
 def is_downstream_quay_rhdh() -> bool:
-    """Check if we're in downstream mode (quay.io/rhdh — NOT quay.io/rhdh-community)"""
+    """Check if REGISTRY_BASE is quay.io/rhdh (downstream supported, NOT quay.io/rhdh-community)."""
     return REGISTRY_BASE + "/" == QUAY_RHDH_PREFIX
 
 
 def is_downstream_rarc() -> bool:
-    """Check if the user requested registry.access.redhat.com output via -r"""
+    """Check if the user explicitly requested registry.access.redhat.com output via the ``-r`` flag."""
     return REGISTRY_BASE.startswith(RARC_DOMAIN)
 
 
 def _is_quay_rhdh_ref(registry_reference: str) -> bool:
-    """Check if a registry reference targets quay.io/rhdh/ (not quay.io/rhdh-community/)."""
+    """Per-reference check if a specific ref targets quay.io/rhdh/ (not quay.io/rhdh-community/)."""
     return registry_reference.startswith(QUAY_RHDH_PREFIX)
 
 
 def get_ghcr_token(repository: str) -> str | None:
-    """Get anonymous bearer token for ghcr.io"""
+    """Get an anonymous bearer token for ghcr.io"""
     try:
         url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
         response = requests.get(url, timeout=10)
@@ -72,10 +76,10 @@ def get_ghcr_token(repository: str) -> str | None:
 
 
 def get_registry_auth(registry: str, repository: str):
-    """
-    Get authentication for a registry.
-    Returns (auth_tuple, headers_dict) where auth_tuple is for basic auth
-    and headers_dict contains bearer token if applicable.
+    """Return auth tuple and headers for a given registry.
+
+    ghcr.io uses an anonymous bearer token; all other registries fall back to
+    basic auth via ``REGISTRY_USERNAME`` / ``REGISTRY_PASSWORD`` env vars.
     """
     auth = None
     extra_headers = {}
@@ -94,10 +98,9 @@ def get_registry_auth(registry: str, repository: str):
 
 
 def get_query_registry_reference(registry_reference: str) -> str:
-    """
-    Get the registry reference to use for querying.
-    For registry.access.redhat.com refs, swap to quay.io for unauthenticated verification.
-    Per-reference check — works with mixed-registry plugin_builds.
+    """Swap r.a.r.c refs to quay.io/rhdh for unauthenticated querying; leave other refs unchanged.
+
+    Per-reference check, so it works correctly with mixed-registry plugin_builds.
     """
     if registry_reference.startswith(RARC_RHDH_PREFIX):
         return registry_reference.replace(RARC_RHDH_PREFIX, QUAY_RHDH_PREFIX)
@@ -105,10 +108,9 @@ def get_query_registry_reference(registry_reference: str) -> str:
 
 
 def get_output_registry_reference(registry_reference: str) -> str:
-    """
-    Get the registry reference to use for output/storage.
-    Only swap quay.io/rhdh/ → registry.access.redhat.com/rhdh/ when the user
-    explicitly requested r.a.r.c output via -r registry.access.redhat.com/rhdh.
+    """Reverse swap: quay.io/rhdh → r.a.r.c, but ONLY when the user requested r.a.r.c output via ``-r``.
+
+    Leaves non-quay.io/rhdh refs (e.g., ghcr.io, quay.io/rhdh-community) unchanged.
     """
     if is_downstream_rarc() and _is_quay_rhdh_ref(registry_reference):
         return registry_reference.replace(QUAY_RHDH_PREFIX, RARC_RHDH_PREFIX)
@@ -116,7 +118,36 @@ def get_output_registry_reference(registry_reference: str) -> str:
 
 
 def parse_registry_reference(registry_reference: str) -> tuple[str, str, str] | None:
-    """Parse 'registry/repository:tag' into (registry, repository, tag). Returns None on failure."""
+    """Parse a container image reference into its (registry, repository, tag_or_digest) parts.
+
+    Accepts ``registry/repository:tag`` or ``registry/repository@sha256:...``
+    formats. References targeting registry.access.redhat.com are transparently
+    swapped to quay.io/rhdh before parsing via ``get_query_registry_reference``.
+
+    Args:
+        registry_reference: Full image reference string, e.g.
+            ``"ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"`` or
+            ``"quay.io/rhdh/plugin:1.11--1.5.4"`` or
+            ``"registry.access.redhat.com/rhdh/plugin@sha256:abc123"``.
+
+    Returns:
+        A tuple ``(registry, repository, tag_or_digest)`` on success, or
+        ``None`` if the reference cannot be parsed (e.g. missing ``/``,
+        missing both ``:`` and ``@``).
+
+    Example:
+        >>> parse_registry_reference("ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0")
+        ('ghcr.io', 'org/repo/plugin', 'bs_1.45.3__1.2.0')
+
+        >>> parse_registry_reference("quay.io/rhdh/plugin:1.11--1.5.4")
+        ('quay.io', 'rhdh/plugin', '1.11--1.5.4')
+
+        >>> parse_registry_reference("registry.access.redhat.com/rhdh/plugin@sha256:abc123")
+        ('quay.io', 'rhdh/plugin', 'sha256:abc123')
+
+        >>> parse_registry_reference("invalid-no-slash")
+        None
+    """
     query_ref = get_query_registry_reference(registry_reference)
     parts = query_ref.split('/', 1)
     if len(parts) < 2:
@@ -135,7 +166,47 @@ def parse_registry_reference(registry_reference: str) -> tuple[str, str, str] | 
 
 
 def list_tags_with_prefix(registry: str, repository: str, prefix: str, auth, headers: dict) -> list[str]:
-    """List all tags matching a prefix from the registry (paginated), sorted by version."""
+    """List all tags matching a prefix from the registry, filtered to clean versions, sorted ascending.
+
+    Queries the Docker Registry HTTP API v2 with pagination to collect all tags,
+    then filters to only those starting with ``prefix`` whose suffix is a clean
+    version number (e.g. ``2.18.0``, ``1.5``).  This rejects Konflux/Tekton
+    build artifacts such as ``.att``, ``.sbom``, ``.sig``, ``.prefetch``, ``.git``,
+    ``.src``, ``.dockerfile``, bare SHA tags, ``on-pr-*``, ``rhdh-bsp-*``, etc.
+
+    Args:
+        registry: Registry hostname, e.g. ``"ghcr.io"`` or ``"quay.io"``.
+        repository: Image repository path, e.g. ``"rhdh/plugin-foo"``.
+        prefix: Tag prefix to match, e.g. ``"bs_1.49.4__"`` or ``"1.11--"``.
+        auth: Basic-auth tuple ``(username, password)`` or ``None``.
+        headers: Request headers dict (must include Accept and any Bearer token).
+
+    Returns:
+        Tags sorted in ascending version order.  The last element is the
+        latest version.  Empty list if no matching tags are found.
+
+    Example:
+        Given these tags in the registry for ``quay.io/rhdh/plugin-foo``::
+
+            "1.11--1.5.4"           # valid
+            "1.11--1.3.0"           # valid
+            "sha256-abc123.att"     # rejected (doesn't match prefix)
+            "on-pr-abc123.prefetch" # rejected (doesn't match prefix)
+
+        With ``prefix="1.11--"``, returns::
+
+            ["1.11--1.3.0", "1.11--1.5.4"]
+
+        Given these tags for ``ghcr.io/org/repo/plugin``::
+
+            "bs_1.49.4__2.14.0"    # valid
+            "bs_1.49.4__2.18.0"    # valid
+            "sha256:d054dbee..."    # rejected (doesn't match prefix)
+
+        With ``prefix="bs_1.49.4__"``, returns::
+
+            ["bs_1.49.4__2.14.0", "bs_1.49.4__2.18.0"]
+    """
     matched = []
     n = 500
     last = ""
@@ -149,7 +220,9 @@ def list_tags_with_prefix(registry: str, repository: str, prefix: str, auth, hea
                 break
             data = resp.json()
             tags = data.get("tags") or []
-            matched.extend(t for t in tags if t.startswith(prefix))
+            for t in tags:
+                if t.startswith(prefix) and VERSION_SUFFIX_RE.match(t[len(prefix):]):
+                    matched.append(t)
             if len(tags) < n:
                 break
             last = tags[-1] if tags else ""
@@ -173,9 +246,43 @@ def list_tags_with_prefix(registry: str, repository: str, prefix: str, auth, hea
 
 
 def resolve_fallback_tag(registry_reference: str) -> str | None:
-    """
-    When the exact tag doesn't exist, find the latest published tag with the same prefix.
-    Returns the full resolved registryReference, or None if no fallback found.
+    """Find the latest published tag sharing the same version prefix when the exact tag doesn't exist.
+
+    Constructs a prefix by splitting the tag on the registry-appropriate
+    separator (``"__"`` for ghcr.io, ``"--"`` for quay.io/rhdh) and keeping
+    everything up to and including the separator. Then queries the registry
+    for all tags with that prefix and returns the highest version.
+
+    Args:
+        registry_reference: Full image reference with the requested tag, e.g.
+            ``"quay.io/rhdh/plugin:1.11--1.6.0"`` or
+            ``"ghcr.io/org/repo/plugin:bs_1.45.3__2.18.0"``.
+
+    Returns:
+        The full registry reference with the fallback tag substituted, e.g.
+        ``"quay.io/rhdh/plugin:1.11--1.5.4"``. Returns ``None`` if no tags
+        match the prefix, if the reference cannot be parsed, or if the best
+        matching tag equals the originally requested tag (no fallback needed).
+
+    Example:
+        If ``quay.io/rhdh/plugin:1.11--1.6.0`` does not exist but
+        ``1.11--1.5.4`` and ``1.11--1.3.0`` do::
+
+            >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.11--1.6.0")
+            'quay.io/rhdh/plugin:1.11--1.5.4'
+
+        For ghcr.io with prefix ``bs_1.45.3__``::
+
+            >>> resolve_fallback_tag("ghcr.io/org/repo/plugin:bs_1.45.3__2.18.0")
+            'ghcr.io/org/repo/plugin:bs_1.45.3__2.14.0'
+
+        When the requested prefix has no tags at all — even if older prefixes
+        exist in the registry — the fallback returns ``None``.  For example,
+        if the registry has ``1.11--1.5.4`` and ``1.10--1.5.4`` but nothing
+        with prefix ``1.12--``::
+
+            >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.12--1.5.4")
+            None  # no tags match prefix "1.12--", older prefixes are ignored
     """
     parsed = parse_registry_reference(registry_reference)
     if not parsed:
@@ -207,9 +314,41 @@ def resolve_fallback_tag(registry_reference: str) -> str | None:
 
 
 def _fetch_image_metadata(registry_reference: str) -> dict[str, str] | None:
-    """
-    Fetch container image metadata from Docker Registry HTTP API v2.
-    Returns: dict with 'digest', 'build-date', 'vcs-ref', 'upstream', 'midstream' or None if failed.
+    """Fetch container image metadata via Docker Registry HTTP API v2.
+
+    Retrieves the image manifest to obtain the digest, then fetches the config
+    blob to extract build labels and environment variables. References targeting
+    registry.access.redhat.com are transparently swapped to quay.io/rhdh for
+    querying, since r.a.r.c requires authentication that may not be available.
+
+    Args:
+        registry_reference: Full image reference, e.g.
+            ``"ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"`` or
+            ``"quay.io/rhdh/plugin:1.11--1.5.4"``.
+
+    Returns:
+        A dict of metadata fields on success, or ``None`` on any failure
+        (timeout, HTTP error, invalid reference). The returned dict looks like::
+
+            {
+                'digest': 'sha256:a1b2c3d4...',
+                'build-date': '2025-05-01',
+                'vcs-ref': 'abc123def456',
+                'upstream': 'https://github.com/org/upstream-repo',
+                'midstream': 'https://github.com/org/midstream-repo',
+            }
+
+        Not all fields are guaranteed to be present; only ``'digest'`` is
+        always included on success. Labels (``build-date``, ``vcs-ref``) and
+        env vars (``upstream``, ``midstream``) depend on how the image was
+        built.
+
+    Example:
+        >>> _fetch_image_metadata("ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0")
+        {'digest': 'sha256:a1b2c3...', 'build-date': '2025-05-01', 'vcs-ref': 'abc123'}
+
+        >>> _fetch_image_metadata("quay.io/rhdh/plugin:nonexistent-tag")
+        None
     """
     try:
         # Swap r.a.r.c → quay.io for queries as r.a.r.c is not always accessible without authentication
@@ -306,16 +445,47 @@ def _fetch_image_metadata(registry_reference: str) -> dict[str, str] | None:
 
 
 def get_image_metadata(registry_reference: str) -> dict | None:
-    """
-    Get container image metadata, with automatic fallback to the latest published
-    tag when the exact tag doesn't exist.
+    """Fetch container image metadata, with automatic fallback to the latest published tag.
 
-    Returns dict with 'digest', 'build-date', etc. and optionally:
-    - 'registryReference': resolved reference (only set when fallback changed it)
-    - 'fallback': True (only when fallback was used)
-    - 'requestedTag': original tag string (only when fallback was used)
+    Wraps ``_fetch_image_metadata`` with a two-step strategy: first tries the
+    exact tag, and if that fails, calls ``resolve_fallback_tag`` to find the
+    latest published tag with the same version prefix.
 
-    Returns None if metadata could not be fetched even after fallback.
+    Args:
+        registry_reference: Full image reference, e.g.
+            ``"quay.io/rhdh/plugin:1.11--1.6.0"``.
+
+    Returns:
+        A metadata dict on success, or ``None`` if metadata could not be
+        fetched even after fallback.
+
+        On a **direct hit** (exact tag exists), the dict contains only the
+        fields from ``_fetch_image_metadata``::
+
+            {'digest': 'sha256:...', 'build-date': '2025-05-01', ...}
+
+        On a **fallback hit** (exact tag missing, older tag used), the dict
+        includes three extra fields::
+
+            {
+                'digest': 'sha256:...',
+                'build-date': '2025-05-01',
+                'registryReference': 'quay.io/rhdh/plugin:1.11--1.5.4',
+                'fallback': True,
+                'requestedTag': '1.11--1.6.0',
+            }
+
+    Example:
+        Direct hit (tag ``1.11--1.5.4`` exists)::
+
+            >>> get_image_metadata("quay.io/rhdh/plugin:1.11--1.5.4")
+            {'digest': 'sha256:a1b2c3...', 'build-date': '2025-05-01'}
+
+        Fallback hit (tag ``1.11--1.6.0`` missing, ``1.11--1.5.4`` used)::
+
+            >>> get_image_metadata("quay.io/rhdh/plugin:1.11--1.6.0")
+            {'digest': 'sha256:a1b2c3...', 'registryReference': 'quay.io/rhdh/plugin:1.11--1.5.4',
+             'fallback': True, 'requestedTag': '1.11--1.6.0'}
     """
     metadata = _fetch_image_metadata(registry_reference)
     if metadata is not None:
@@ -346,9 +516,32 @@ def get_image_metadata(registry_reference: str) -> dict | None:
 
 
 def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, report: BuildReport | None = None) -> tuple[int, int, list[str], int, int]:
-    """
-    Update all plugin_builds/*.json files with image metadata
-    Returns: (updated_count, error_count, missing_refs, overlays_metadata_changes, fallback_count)
+    """Enrich plugin_builds JSON files with container image metadata from the registry.
+
+    The main enrichment pipeline. For each ``plugin_builds/*/*.json`` file,
+    fetches image metadata (digest, build-date, vcs-ref, upstream, midstream)
+    from the Docker Registry HTTP API v2 and writes the results back into the
+    JSON. Also updates the corresponding ``workspaces/*/metadata/*.yaml``
+    overlay files with the resolved ``dynamicArtifact`` OCI reference
+    (including digest).
+
+    Args:
+        plugin_builds_dir: Path to the ``plugin_builds/`` directory containing
+            per-workspace subdirectories with JSON files.
+        overlays_dir: Path to the overlays repository root (containing
+            ``workspaces/``). Used to locate and update metadata YAML files.
+        report: Optional ``BuildReport`` instance for tracking per-plugin
+            stage results (pass/fail with digest and fallback info).
+
+    Returns:
+        A 5-tuple of ``(updated_count, error_count, missing_refs,
+        overlays_metadata_changes, fallback_count)`` where:
+
+        - ``updated_count``: Number of JSON files successfully enriched.
+        - ``error_count``: Number of JSON files that failed to parse or process.
+        - ``missing_refs``: List of registry references where no image was found.
+        - ``overlays_metadata_changes``: Number of metadata YAML files updated.
+        - ``fallback_count``: Number of plugins that used a fallback tag.
     """
     if not plugin_builds_dir.exists():
         log_error(f"Plugin builds directory {plugin_builds_dir} does not exist")

--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -19,7 +19,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
 import requests
 import yaml
 import hashlib
@@ -60,7 +59,7 @@ def _is_quay_rhdh_ref(registry_reference: str) -> bool:
     return registry_reference.startswith(QUAY_RHDH_PREFIX)
 
 
-def get_ghcr_token(repository: str) -> Optional[str]:
+def get_ghcr_token(repository: str) -> str | None:
     """Get anonymous bearer token for ghcr.io"""
     try:
         url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
@@ -116,12 +115,104 @@ def get_output_registry_reference(registry_reference: str) -> str:
     return registry_reference
 
 
-def get_image_metadata(registry_reference: str) -> Optional[Dict[str, str]]:
+def parse_registry_reference(registry_reference: str) -> tuple[str, str, str] | None:
+    """Parse 'registry/repository:tag' into (registry, repository, tag). Returns None on failure."""
+    query_ref = get_query_registry_reference(registry_reference)
+    parts = query_ref.split('/', 1)
+    if len(parts) < 2:
+        return None
+    registry = parts[0]
+    image_and_tag = parts[1]
+    if '@' in image_and_tag:
+        name_part = image_and_tag.split('@', 1)[0]
+        repository = name_part.rsplit(':', 1)[0] if ':' in name_part else name_part
+        tag = image_and_tag.split('@', 1)[1]
+    elif ':' in image_and_tag:
+        repository, tag = image_and_tag.rsplit(':', 1)
+    else:
+        return None
+    return registry, repository, tag
+
+
+def list_tags_with_prefix(registry: str, repository: str, prefix: str, auth, headers: dict) -> list[str]:
+    """List all tags matching a prefix from the registry (paginated), sorted by version."""
+    matched = []
+    n = 500
+    last = ""
+    while True:
+        url = f"https://{registry}/v2/{repository}/tags/list?n={n}"
+        if last:
+            url += f"&last={requests.utils.quote(last)}"
+        try:
+            resp = requests.get(url, headers=headers, auth=auth, timeout=60)
+            if resp.status_code != 200:
+                break
+            data = resp.json()
+            tags = data.get("tags") or []
+            matched.extend(t for t in tags if t.startswith(prefix))
+            if len(tags) < n:
+                break
+            last = tags[-1] if tags else ""
+            if not last:
+                break
+        except Exception as e:
+            log_debug(f"Error listing tags for {registry}/{repository}: {e}")
+            break
+
+    def version_key(tag: str):
+        suffix = tag[len(prefix):]
+        parts = []
+        for p in suffix.split('.'):
+            try:
+                parts.append((0, int(p)))
+            except ValueError:
+                parts.append((1, p))
+        return parts
+
+    return sorted(matched, key=version_key)
+
+
+def resolve_fallback_tag(registry_reference: str) -> str | None:
     """
-    Get container image metadata from Docker Registry HTTP API v2
-    Returns: dict with 'digest', 'build-date', 'vcs-ref', 'upstream', 'midstream' or None if failed
+    When the exact tag doesn't exist, find the latest published tag with the same prefix.
+    Returns the full resolved registryReference, or None if no fallback found.
+    """
+    parsed = parse_registry_reference(registry_reference)
+    if not parsed:
+        return None
+
+    registry, repository, tag = parsed
+
+    # Detect prefix: ghcr.io uses "__", others use "--"
+    separator = "__" if registry == "ghcr.io" else "--"
+    if separator not in tag:
+        return None
+    prefix = tag.rsplit(separator, 1)[0] + separator
+
+    auth, extra_headers = get_registry_auth(registry, repository)
+    headers = {'Accept': 'application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'}
+    headers.update(extra_headers)
+
+    tags = list_tags_with_prefix(registry, repository, prefix, auth, headers)
+    if not tags:
+        return None
+
+    best_tag = tags[-1]
+    if best_tag == tag:
+        return None
+
+    # Reconstruct the reference with the fallback tag (using original registry, not query registry)
+    original_ref_base = registry_reference.rsplit(':', 1)[0]
+    return f"{original_ref_base}:{best_tag}"
+
+
+def _fetch_image_metadata(registry_reference: str) -> dict[str, str] | None:
+    """
+    Fetch container image metadata from Docker Registry HTTP API v2.
+    Returns: dict with 'digest', 'build-date', 'vcs-ref', 'upstream', 'midstream' or None if failed.
     """
     try:
+        # Swap r.a.r.c → quay.io for queries as r.a.r.c is not always accessible without authentication
         query_ref = get_query_registry_reference(registry_reference)
 
         # Parse the registry reference: registry.io/repo/image:tag
@@ -214,10 +305,50 @@ def get_image_metadata(registry_reference: str) -> Optional[Dict[str, str]]:
         return None
 
 
-def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, report: BuildReport | None = None) -> Tuple[int, int, List[str], int]:
+def get_image_metadata(registry_reference: str) -> dict | None:
+    """
+    Get container image metadata, with automatic fallback to the latest published
+    tag when the exact tag doesn't exist.
+
+    Returns dict with 'digest', 'build-date', etc. and optionally:
+    - 'registryReference': resolved reference (only set when fallback changed it)
+    - 'fallback': True (only when fallback was used)
+    - 'requestedTag': original tag string (only when fallback was used)
+
+    Returns None if metadata could not be fetched even after fallback.
+    """
+    metadata = _fetch_image_metadata(registry_reference)
+    if metadata is not None:
+        return metadata
+    
+    original_tag = registry_reference.rsplit(':', 1)[-1] if ':' in registry_reference else ""
+
+    fallback_ref = resolve_fallback_tag(registry_reference)
+    if fallback_ref is None:
+        log_warn(f"Requested tag {Colors.YELLOW}{original_tag}{Colors.NORM} not found, no fallback available")
+        return None
+
+    fallback_tag = fallback_ref.rsplit(':', 1)[-1] if ':' in fallback_ref else ""
+    
+    log_warn(
+        f"[FALLBACK] requested tag {Colors.YELLOW}{original_tag}{Colors.NORM} but tag not found,"
+        f" using latest published tag {Colors.GREEN}{fallback_tag}{Colors.NORM} instead"
+    )
+
+    metadata = _fetch_image_metadata(fallback_ref)
+    if metadata is None:
+        return None
+
+    metadata['registryReference'] = fallback_ref
+    metadata['fallback'] = True
+    metadata['requestedTag'] = original_tag
+    return metadata
+
+
+def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, report: BuildReport | None = None) -> tuple[int, int, list[str], int, int]:
     """
     Update all plugin_builds/*.json files with image metadata
-    Returns: (updated_count, error_count, missing_refs, overlays_metadata_changes)
+    Returns: (updated_count, error_count, missing_refs, overlays_metadata_changes, fallback_count)
     """
     if not plugin_builds_dir.exists():
         log_error(f"Plugin builds directory {plugin_builds_dir} does not exist")
@@ -233,6 +364,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
     error_count = 0
     missing_refs = []
     overlays_metadata_changes = 0
+    fallback_count = 0
 
     for i, json_file in enumerate(json_files, 1):
         relative_path = json_file.relative_to(plugin_builds_dir)
@@ -253,30 +385,25 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                     metadata = get_image_metadata(registry_reference)
 
                     if metadata:
-                        if 'digest' in metadata:
-                            plugin_data['digest'] = metadata['digest']
-                            modified = True
+                        if 'registryReference' in metadata:
+                            registry_reference = metadata['registryReference']
 
-                        if 'build-date' in metadata:
-                            plugin_data['build-date'] = metadata['build-date']
-                            modified = True
+                        if metadata.get('fallback'):
+                            fallback_count += 1
 
-                        if 'vcs-ref' in metadata:
-                            plugin_data['vcs-ref'] = metadata['vcs-ref']
-                            modified = True
+                        for key, value in metadata.items():
+                            if plugin_data.get(key) != value:
+                                plugin_data[key] = value
+                                modified = True
 
-                        if 'upstream' in metadata:
-                            plugin_data['upstream'] = metadata['upstream']
-                            modified = True
+                        # Clean up stale fallback fields from a previous run
+                        if 'fallback' not in metadata:
+                            for stale_key in ('fallback', 'requestedTag'):
+                                if stale_key in plugin_data:
+                                    del plugin_data[stale_key]
+                                    modified = True
 
-                        if 'midstream' in metadata:
-                            plugin_data['midstream'] = metadata['midstream']
-                            modified = True
-
-                        if DYNAMIC_PACKAGES_ANNOTATION in metadata:
-                            plugin_data[DYNAMIC_PACKAGES_ANNOTATION] = metadata[DYNAMIC_PACKAGES_ANNOTATION]
-                            modified = True
-
+                        # Output ref swap back from quay.io to registry.access.redhat.com if registry is set as r.a.r.c
                         output_ref = get_output_registry_reference(registry_reference)
                         if output_ref != registry_reference:
                             log_debug(f"registry_reference switched to: {output_ref}")
@@ -294,7 +421,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                             )
                 else:
                     fields_removed = []
-                    for field in ['digest', 'build-date', 'vcs-ref', 'upstream', 'midstream', DYNAMIC_PACKAGES_ANNOTATION]:
+                    for field in ['digest', 'build-date', 'vcs-ref', 'upstream', 'midstream', DYNAMIC_PACKAGES_ANNOTATION, 'fallback', 'requestedTag']:
                         if field in plugin_data:
                             del plugin_data[field]
                             fields_removed.append(field)
@@ -302,7 +429,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
 
             if modified:
                 ordered_data = {}
-                key_order = ['workspacePath', 'registryReference', 'digest', 'build-date', 'upstream', 'midstream', 'vcs-ref']
+                key_order = ['workspacePath', 'registryReference', 'fallback', 'requestedTag', 'digest', 'build-date', 'upstream', 'midstream', 'vcs-ref']
 
                 for plugin_name, plugin_data in data.items():
                     ordered_plugin = {}
@@ -328,85 +455,86 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                     for pname, pdata in data.items():
                         digest = pdata.get('digest', '')
                         if digest:
+                            stage_kwargs = {"digest": digest}
+                            if pdata.get('fallback'):
+                                ref_tag = pdata.get('registryReference', '').rsplit(':', 1)[-1]
+                                stage_kwargs["fallback"] = True
+                                stage_kwargs["requestedTag"] = pdata.get('requestedTag', '')
+                                stage_kwargs["resolvedTag"] = ref_tag
                             report.set_stage(
                                 pname, "registry-enrich", "pass",
-                                digest=digest,
+                                **stage_kwargs,
                             )
 
                 # Update the equivalent metadata.yaml file in the overlays directory
-                # Skip metadata write-back for ghcr.io — those images use tagged dynamicArtifacts
-                # and don't include build-date labels (per-reference check)
-                if registry_reference.startswith("ghcr.io/"):
-                    log_debug(f"Skipping metadata write-back for ghcr.io plugin: {relative_path}")
-                else:
-                    metadata_dir = overlays_dir / "workspaces" / relative_path.parent / "metadata"
-                    if metadata_dir.exists():
-                        for plugin_name, plugin_data in data.items():
-                            registry_reference_tag = plugin_data.get('registryReference', '')
-                            if not registry_reference_tag:
+                metadata_dir = overlays_dir / "workspaces" / relative_path.parent / "metadata"
+                if metadata_dir.exists():
+                    for plugin_name, plugin_data in data.items():
+                        registry_reference_tag = plugin_data.get('registryReference', '')
+                        if not registry_reference_tag:
+                            continue
+                        digest = plugin_data.get("digest")
+                        registry_reference_digest = registry_reference_tag
+                        if digest:
+                            ref_base = (registry_reference_tag.split("@")[0] if "@" in registry_reference_tag
+                                        else registry_reference_tag.rsplit(":", 1)[0])
+                            registry_reference_digest = f"{ref_base}@{digest}"
+                        registry_reference_digest = get_output_registry_reference(registry_reference_digest)
+                        metadata_file = None
+                        for f in metadata_dir.glob("*.yaml"):
+                            try:
+                                with open(f, "r", encoding='utf-8') as fp:
+                                    meta = yaml.safe_load(fp)
+                                spec = (meta or {}).get("spec") or {}
+                                pkg = spec.get("packageName") or ""
+                                da = spec.get("dynamicArtifact") or ""
+                                log_debug(f"pkg: {pkg}; f.stem: {f.stem}; plugin_name: {plugin_name}")
+                                image_in_artifact = ("/" + plugin_name + ":" in da or "/" + plugin_name + "@" in da)
+                                stem_matches = f.stem.replace("redhat-backstage-plugin-", "red-hat-developer-hub-backstage-plugin-") == plugin_name
+                                if image_in_artifact or stem_matches or f.stem == plugin_name:
+                                    metadata_file = f
+                                    break
+                            except Exception:
                                 continue
-                            digest = plugin_data.get("digest")
-                            registry_reference_digest = registry_reference_tag
-                            if digest:
-                                ref_base = (registry_reference_tag.split("@")[0] if "@" in registry_reference_tag
-                                            else registry_reference_tag.rsplit(":", 1)[0])
-                                registry_reference_digest = f"{ref_base}@{digest}"
-                            registry_reference_digest = get_output_registry_reference(registry_reference_digest)
-                            metadata_file = None
-                            for f in metadata_dir.glob("*.yaml"):
-                                try:
-                                    with open(f, "r", encoding='utf-8') as fp:
-                                        meta = yaml.safe_load(fp)
-                                    spec = (meta or {}).get("spec") or {}
-                                    pkg = spec.get("packageName") or ""
-                                    da = spec.get("dynamicArtifact") or ""
-                                    log_debug(f"pkg: {pkg}; f.stem: {f.stem}; plugin_name: {plugin_name}")
-                                    image_in_artifact = ("/" + plugin_name + ":" in da or "/" + plugin_name + "@" in da)
-                                    stem_matches = f.stem.replace("redhat-backstage-plugin-", "red-hat-developer-hub-backstage-plugin-") == plugin_name
-                                    if image_in_artifact or stem_matches or f.stem == plugin_name:
-                                        metadata_file = f
-                                        break
-                                except Exception:
-                                    continue
-                            if metadata_file is not None:
-                                with open(metadata_file, "r", encoding='utf-8') as f:
-                                    content = f.read()
-                                try:
-                                    meta = yaml.safe_load(content)
-                                    da = ((meta or {}).get("spec") or {}).get("dynamicArtifact") or ""
-                                except Exception:
-                                    da = ""
-                                if da.startswith("oci://"):
-                                    new_oci = f"oci://{registry_reference_digest}"
-                                    lines = content.splitlines()
-                                    out = []
-                                    for line in lines:
-                                        stripped = line.lstrip()
-                                        if stripped.startswith("dynamicArtifact:") and ("oci://" in line or "quay.io" in line or "registry.access" in line):
-                                            indent = line[: len(line) - len(stripped)]
-                                            tag_parts = registry_reference_tag.split(":")
-                                            tag = tag_parts[1] if len(tag_parts) > 1 else ""
-                                            build_date = plugin_data.get("build-date")
-                                            while out and out[-1].lstrip().startswith("# Tag:"):
-                                                out.pop()
-                                            if build_date:
-                                                out.append(f'{indent}# Tag: {tag}, Build date: {build_date}')
-                                            else:
-                                                out.append(f'{indent}# Tag: {tag}')
-                                            out.append(f'{indent}dynamicArtifact: "{new_oci}"')
+                        if metadata_file is not None:
+                            with open(metadata_file, "r", encoding='utf-8') as f:
+                                content = f.read()
+                            try:
+                                meta = yaml.safe_load(content)
+                                da = ((meta or {}).get("spec") or {}).get("dynamicArtifact") or ""
+                            except Exception:
+                                da = ""
+                            if da.startswith("oci://"):
+                                new_oci = f"oci://{registry_reference_digest}"
+                                lines = content.splitlines()
+                                out = []
+                                for line in lines:
+                                    stripped = line.lstrip()
+                                    if stripped.startswith("dynamicArtifact:") and ("oci://" in line or "quay.io" in line or "registry.access" in line or "ghcr.io" in line):
+                                        indent = line[: len(line) - len(stripped)]
+                                        tag_parts = registry_reference_tag.split(":")
+                                        tag = tag_parts[1] if len(tag_parts) > 1 else ""
+                                        build_date = plugin_data.get("build-date")
+                                        while out and out[-1].lstrip().startswith("# Tag:"):
+                                            out.pop()
+                                        if build_date:
+                                            out.append(f'{indent}# Tag: {tag}, Build date: {build_date}')
                                         else:
-                                            out.append(line)
-                                    with open(metadata_file, "w", encoding='utf-8') as f:
-                                        f.write("\n".join(out))
-                                        f.write("\n")
-                                    overlays_metadata_changes += 1
-                                    log_debug(f"Set 'dynamicArtifact: oci://{registry_reference_digest}'")
-                                    log_debug(f" in {metadata_file}")
-                                    print(
-                                        f"[{i}/{len(json_files)}]   >> https://{Colors.GREEN}"
-                                        f"{registry_reference_digest.replace('@', ' @')}"
-                                        f"{Colors.NORM}\n"
-                                    )
+                                            out.append(f'{indent}# Tag: {tag}')
+                                        out.append(f'{indent}dynamicArtifact: "{new_oci}"')
+                                    else:
+                                        out.append(line)
+                                with open(metadata_file, "w", encoding='utf-8') as f:
+                                    f.write("\n".join(out))
+                                    f.write("\n")
+                                overlays_metadata_changes += 1
+                                log_debug(f"Set 'dynamicArtifact: oci://{registry_reference_digest}'")
+                                log_debug(f" in {metadata_file}")
+                                print(
+                                    f"[{i}/{len(json_files)}]   >> https://{Colors.GREEN}"
+                                    f"{registry_reference_digest.replace('@', ' @')}"
+                                    f"{Colors.NORM}\n"
+                                )
 
         except json.JSONDecodeError as e:
             log_error(f"Error parsing JSON file {json_file}: {e}")
@@ -415,7 +543,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
             log_error(f"Error processing {json_file}: {e}")
             error_count += 1
 
-    return updated_count, error_count, missing_refs, overlays_metadata_changes
+    return updated_count, error_count, missing_refs, overlays_metadata_changes, fallback_count
 
 
 def main():
@@ -491,11 +619,13 @@ Examples:
         sys.exit(1)
 
     log_info("\n=== Update plugin_builds/*.json files with container metadata ===")
-    updated_count, error_count, missing_refs, overlays_metadata_changes = update_plugin_build_files(plugin_builds_dir, overlays_dir, report)
+    updated_count, error_count, missing_refs, overlays_metadata_changes, fallback_count = update_plugin_build_files(plugin_builds_dir, overlays_dir, report)
     total = updated_count + error_count + len(missing_refs)
 
     log_info("\n=== Results ===")
     log_info(f"Updated: {Colors.GREEN}{updated_count}{Colors.NORM} of {total}")
+    if fallback_count > 0:
+        log_warn(f"Fallback Tags: {Colors.YELLOW}{fallback_count}{Colors.NORM} plugin(s) using older published tags")
     if len(missing_refs) > 0:
         log_warn(f"Missing Tags: {Colors.YELLOW}{len(missing_refs)}{Colors.NORM}")
         for ref in missing_refs:

--- a/scripts/injectDpdyTagComments.py
+++ b/scripts/injectDpdyTagComments.py
@@ -18,6 +18,29 @@ TAG_LINE_RE = re.compile(r"^\s*# Tag:")
 
 
 def load_tag_by_key(plugin_builds_dir: Path) -> dict[str, tuple[str, str]]:
+    """Read all plugin_builds/*/*.json and build a lookup dict from image name to (tag, build_date).
+
+    Each JSON file maps plugin image names to their registry references and
+    build dates. For every entry, an alias is also added so that both the
+    ``red-hat-developer-hub-`` and ``rhdh-`` prefixed forms resolve to the
+    same tag info.
+
+    Args:
+        plugin_builds_dir: Path to the plugin_builds/ directory. Each
+            subdirectory contains JSON files with plugin build metadata.
+
+    Returns:
+        A dict mapping image name (str) to a (tag, build_date) tuple.
+        Returns an empty dict if the directory does not exist.
+
+    Example::
+
+        >>> load_tag_by_key(Path("plugin_builds"))
+        {
+            "red-hat-developer-hub-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+            "rhdh-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+        }
+    """
     tag_by_key: dict[str, tuple[str, str]] = {}
     if not plugin_builds_dir.is_dir():
         return tag_by_key
@@ -40,6 +63,26 @@ def load_tag_by_key(plugin_builds_dir: Path) -> dict[str, tuple[str, str]]:
 
 
 def keys_for_package(pkg: str) -> list[str]:
+    """Generate all lookup keys for a package name to try against tag_by_key.
+
+    Produces the original name, a variant with the ``-dynamic`` suffix
+    stripped, and a variant with the ``rhdh-`` prefix expanded to
+    ``red-hat-developer-hub-``.
+
+    Args:
+        pkg: The package name to generate keys for (e.g.
+            ``"rhdh-backstage-plugin-foo-dynamic"``).
+
+    Returns:
+        A list of candidate keys, ordered from most specific to least.
+
+    Example::
+
+        >>> keys_for_package("rhdh-backstage-plugin-foo-dynamic")
+        ["rhdh-backstage-plugin-foo-dynamic",
+         "rhdh-backstage-plugin-foo",
+         "red-hat-developer-hub-backstage-plugin-foo-dynamic"]
+    """
     keys = [pkg]
     if pkg.endswith("-dynamic"):
         keys.append(pkg[: -len("-dynamic")])
@@ -49,6 +92,25 @@ def keys_for_package(pkg: str) -> list[str]:
 
 
 def comment_for_package(pkg: str, tag_by_key: dict[str, tuple[str, str]]) -> str | None:
+    """Look up the tag comment string for a package name.
+
+    Tries each key from ``keys_for_package`` against ``tag_by_key`` and
+    returns the formatted YAML comment for the first match.
+
+    Args:
+        pkg: The package name to look up.
+        tag_by_key: The lookup dict built by ``load_tag_by_key``.
+
+    Returns:
+        A formatted comment string (e.g.
+        ``"  # Tag: 1.11--1.5.4, Build date: 2025-05-01\\n"``), or None
+        if no matching tag info was found.
+
+    Example::
+
+        >>> comment_for_package("rhdh-backstage-plugin-foo", tag_by_key)
+        "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\\n"
+    """
     for key in keys_for_package(pkg):
         if key in tag_by_key:
             tag, bd = tag_by_key[key]
@@ -57,6 +119,11 @@ def comment_for_package(pkg: str, tag_by_key: dict[str, tuple[str, str]]) -> str
 
 
 def package_name_from_oci_comment(line: str) -> str | None:
+    """Extract the image name from a commented OCI package line.
+
+    Parses lines like ``# - package: oci://registry/image-name@sha256:...``
+    and returns the image name portion.
+    """
     m = re.search(r"oci://[^/]+/([^@\s!]+)", line)
     if not m:
         return None
@@ -64,13 +131,18 @@ def package_name_from_oci_comment(line: str) -> str | None:
 
 
 def package_name_from_package_value(val: str) -> str:
+    """Extract the package name from a package value string.
+
+    Handles both local paths (``./dynamic-plugins/dist/foo`` returns
+    ``foo``) and OCI references (returns the image name before ``@``).
+    """
     if val.startswith("./"):
         return val.rsplit("/", 1)[-1]
     return val.split("/")[-1].split("@")[0]
 
 
 def recent_has_tag(result: list[str]) -> bool:
-    """Check if a Tag comment exists between the current position and the previous package line."""
+    """Check if a Tag comment already exists between the current position and the previous package line."""
     for line in reversed(result):
         if TAG_LINE_RE.match(line):
             return True
@@ -80,6 +152,36 @@ def recent_has_tag(result: list[str]) -> bool:
 
 
 def inject(dpdy_path: Path, plugin_builds_dir: Path) -> bool:
+    """Insert ``# Tag: ..., Build date: ...`` comments into dynamic-plugins.default.yaml.
+
+    Reads the DPDY file and plugin build metadata, then inserts tag/build-date
+    comments in two positions:
+
+    - After ``# - package: oci://...`` lines (commented-out migration blocks)
+    - Before ``- package: ./dynamic-plugins/dist/...`` lines (wrapper package
+      entries), only when no Tag comment already exists nearby
+
+    Args:
+        dpdy_path: Path to the dynamic-plugins.default.yaml file.
+        plugin_builds_dir: Path to the plugin_builds/ directory containing
+            workspace subdirectories with JSON build metadata files.
+
+    Returns:
+        True if the file was modified and written back, False otherwise.
+
+    Example:
+
+        Before::
+
+            # - package: oci://quay.io/rhdh/plugin-foo@sha256:abc123
+            - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic
+
+        After::
+
+            # - package: oci://quay.io/rhdh/plugin-foo@sha256:abc123
+            # Tag: 1.11--1.5.4, Build date: 2025-05-01
+            - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic
+    """
     tag_by_key = load_tag_by_key(plugin_builds_dir)
     lines = dpdy_path.read_text(encoding="utf-8").splitlines(keepends=True)
     result: list[str] = []

--- a/scripts/plugin_utils.py
+++ b/scripts/plugin_utils.py
@@ -65,26 +65,6 @@ def read_plugins_list(workspace_dir: Path) -> list[str]:
                 paths.append(path)
     return paths
 
-
-def match_metadata_to_plugin_path(metadata_name: str, plugin_paths: list[str]) -> str | None:
-    """
-    Match a metadata file stem to a plugins-list.yaml entry.
-    metadata_name: e.g., 'backstage-community-plugin-acr'
-    plugin_paths:  e.g., ['plugins/acr']
-    Returns the matching path or None.
-    """
-    sorted_paths = sorted(plugin_paths, key=lambda p: -len(p.split('/')[-1]))
-    for path in sorted_paths:
-        last_segment = path.split('/')[-1]
-        if metadata_name == last_segment:
-            return path
-        if metadata_name.endswith('-' + last_segment):
-            return path
-        if metadata_name.endswith(last_segment):
-            return path
-    return None
-
-
 def detect_file_format(file_path: str) -> str:
     """Returns 'yaml' or 'txt' based on file extension."""
     p = Path(file_path)

--- a/scripts/plugin_utils.py
+++ b/scripts/plugin_utils.py
@@ -74,8 +74,30 @@ def detect_file_format(file_path: str) -> str:
 
 
 def load_filtered_packages_from_yaml(packages_file: str) -> set[str]:
-    """Load filtered package names from default.packages.yaml.
-    Returns set of npm package names from both enabled and disabled sections."""
+    """Load npm package names from a packages YAML file.
+
+    Reads a YAML file in the ``default.packages.yaml`` format and returns
+    the union of npm package names from both the ``enabled`` and ``disabled``
+    sections under the top-level ``packages`` key.
+
+    Args:
+        packages_file: Path to the packages YAML file.
+
+    Returns:
+        Set of npm package name strings.
+
+    Example:
+        Given a YAML file with::
+
+            packages:
+              enabled:
+                - package: "@backstage-community/plugin-techdocs"
+              disabled:
+                - package: "@backstage-community/plugin-foo"
+
+        >>> load_filtered_packages_from_yaml("default.packages.yaml")
+        {"@backstage-community/plugin-techdocs", "@backstage-community/plugin-foo"}
+    """
     path = Path(packages_file)
     if not path.exists():
         log_error(f"Packages file not found: {packages_file}")
@@ -95,8 +117,22 @@ def load_filtered_packages_from_yaml(packages_file: str) -> set[str]:
 
 
 def load_packages_from_txt(txt_file: str) -> list[str]:
-    """Load workspace paths from a txt file (e.g., rhdh-supported-packages.txt).
-    Returns list of workspace paths like 'backstage/plugins/techdocs'."""
+    """Load workspace paths from a plain-text package list file.
+
+    Reads a text file with one workspace path per line. Blank lines and
+    lines starting with ``#`` are ignored.
+
+    Args:
+        txt_file: Path to the text file (e.g.,
+            ``rhdh-supported-packages.txt``).
+
+    Returns:
+        List of workspace path strings, in file order.
+
+    Example:
+        >>> load_packages_from_txt("rhdh-supported-packages.txt")
+        ["backstage/plugins/techdocs", "backstage/plugins/catalog"]
+    """
     path = Path(txt_file)
     if not path.exists():
         log_error(f"Packages txt file not found: {txt_file}")
@@ -113,6 +149,31 @@ def load_packages_from_txt(txt_file: str) -> list[str]:
 
 @dataclass
 class WorkspaceMappings:
+    """Bidirectional lookup maps connecting workspace paths, npm names, and stems.
+
+    These four dictionaries allow resolution between the three identifier formats
+    used across the repo:
+
+    - **Workspace paths** (``ws_path``): slash-separated paths like
+      ``"backstage/plugins/techdocs"`` drawn from ``plugins-list.yaml``.
+    - **npm names**: scoped package names like
+      ``"@backstage-community/plugin-techdocs"`` from ``spec.packageName``
+      in Package entity YAMLs.
+    - **Stems**: the ``metadata.name`` field from Package entity YAMLs, e.g.
+      ``"backstage-community-plugin-techdocs"``. These are the canonical
+      identifiers used for filtering throughout catalog index generation.
+
+    Attributes:
+        ws_path_to_npm: Maps workspace path to npm package name.
+            Example: ``{"backstage/plugins/techdocs": "@backstage-community/plugin-techdocs"}``
+        ws_path_to_stem: Maps workspace path to metadata entity stem.
+            Example: ``{"backstage/plugins/techdocs": "backstage-community-plugin-techdocs"}``
+        npm_to_stem: Maps npm package name to metadata entity stem.
+            Example: ``{"@backstage-community/plugin-techdocs": "backstage-community-plugin-techdocs"}``
+        stem_to_npm: Maps metadata entity stem to npm package name.
+            Example: ``{"backstage-community-plugin-techdocs": "@backstage-community/plugin-techdocs"}``
+    """
+
     ws_path_to_npm: dict[str, str] = field(default_factory=dict)
     ws_path_to_stem: dict[str, str] = field(default_factory=dict)
     npm_to_stem: dict[str, str] = field(default_factory=dict)
@@ -126,12 +187,47 @@ def _match_workspace_metadata(
 ) -> dict[str, str]:
     """Match metadata entries to plugin paths within a single workspace.
 
-    Uses scored matching to avoid greedy collisions (e.g., two stems matching
-    the same path), then process-of-elimination for remaining unmatched pairs.
+    Resolves which ``plugins-list.yaml`` path corresponds to each Package
+    entity stem, using a two-pass heuristic:
 
-    metadata_entries: list of (stem, npm_name) pairs
-    plugin_paths: list of plugin paths from plugins-list.yaml
-    Returns: dict mapping stem -> workspace_path
+    **Pass 1 -- Scored matching:**
+    Every (stem, path) pair is scored based on how the path's last segment
+    relates to the stem:
+
+    - Exact match (``stem == last_segment``): highest score
+    - Suffix with dash (``stem.endswith("-" + last_segment)``): medium
+    - Plain suffix (``stem.endswith(last_segment)``): lowest
+
+    Scores are weighted by segment length to prefer longer (more specific)
+    matches. Pairs are then assigned greedily in descending score order,
+    ensuring no stem or path is used twice.
+
+    **Pass 2 -- Process of elimination:**
+    Remaining unmatched stems are resolved against remaining paths via:
+
+    1. Substring matching (``last_segment in stem``)
+    2. 1:1 pairing if the count of unmatched stems equals remaining paths
+
+    Any stems still unmatched fall back to ``"{ws_name}/{stem}"``.
+
+    Args:
+        ws_name: Workspace directory name (e.g., ``"backstage"``).
+        metadata_entries: List of ``(stem, npm_name)`` pairs from Package
+            entity YAMLs in ``workspaces/{ws_name}/metadata/``.
+        plugin_paths: Plugin paths from ``plugins-list.yaml`` (e.g.,
+            ``["plugins/techdocs", "plugins/catalog"]``).
+
+    Returns:
+        Dict mapping each stem to its full workspace path
+        (``"{ws_name}/{plugin_path}"``).
+
+    Example:
+        >>> _match_workspace_metadata(
+        ...     "backstage",
+        ...     [("backstage-community-plugin-techdocs", "@backstage-community/plugin-techdocs")],
+        ...     ["plugins/techdocs"],
+        ... )
+        {"backstage-community-plugin-techdocs": "backstage/plugins/techdocs"}
     """
     result: dict[str, str] = {}
 
@@ -204,8 +300,50 @@ def _match_workspace_metadata(
 
 
 def build_workspace_mappings(overlays_dir: Path) -> WorkspaceMappings:
-    """Scan workspaces/*/metadata/*.yaml and plugins-list.yaml to build
-    bidirectional maps between workspace paths, npm names, and stems."""
+    """Scan all workspaces to build bidirectional maps between workspace paths,
+    npm names, and metadata entity stems.
+
+    Iterates over every workspace in ``{overlays_dir}/workspaces/`` and reads:
+
+    - ``workspaces/{ws}/metadata/*.yaml`` -- Package entity YAMLs providing
+      ``metadata.name`` (stem) and ``spec.packageName`` (npm name)
+    - ``workspaces/{ws}/plugins-list.yaml`` -- plugin paths within the
+      upstream source repo
+
+    These are matched via ``_match_workspace_metadata`` to produce the four
+    maps in ``WorkspaceMappings``.
+
+    The directory structure consumed::
+
+        workspaces/
+          backstage/
+            metadata/
+              backstage-community-plugin-techdocs.yaml
+            plugins-list.yaml
+          rhdh/
+            metadata/
+              ...
+            plugins-list.yaml
+
+    Note:
+        This scans ALL workspaces in the repo, not just the ones being
+        filtered for a particular catalog index tier. The full mapping is
+        needed so that any package file (YAML or txt) can be resolved.
+
+    Args:
+        overlays_dir: Root of the overlays repository (the directory
+            containing the ``workspaces/`` subdirectory).
+
+    Returns:
+        A ``WorkspaceMappings`` instance with all four maps populated.
+
+    Example:
+        >>> mappings = build_workspace_mappings(Path("/path/to/rhdh-plugin-export-overlays"))
+        >>> mappings.npm_to_stem["@backstage-community/plugin-techdocs"]
+        'backstage-community-plugin-techdocs'
+        >>> mappings.ws_path_to_npm["backstage/plugins/techdocs"]
+        '@backstage-community/plugin-techdocs'
+    """
     mappings = WorkspaceMappings()
     workspaces_dir = overlays_dir / "workspaces"
     if not workspaces_dir.exists():
@@ -277,9 +415,45 @@ def load_and_resolve_to_stems(
     packages_files: list[str],
     overlays_dir: Path,
 ) -> set[str]:
-    """Takes a list of file paths (YAML or txt), auto-detects format,
-    resolves all to metadata entity stems.
-    Returns union of all resolved stems."""
+    """Load package lists from multiple files and resolve all entries to
+    metadata entity stems.
+
+    Each file is auto-detected as YAML or txt based on extension. YAML files
+    contain npm package names (resolved via ``npm_to_stem``); txt files
+    contain workspace paths (resolved via ``ws_path_to_stem``). The union
+    of all resolved stems across all files is returned.
+
+    Logs warnings for entries that cannot be resolved and debug-level
+    messages for cross-file overlaps.
+
+    Args:
+        packages_files: Paths to package list files. Supports mixed formats
+            (some YAML, some txt) in the same call.
+        overlays_dir: Root of the overlays repository (passed through to
+            ``build_workspace_mappings``).
+
+    Returns:
+        Union of resolved stems from all input files.
+
+    Example:
+        >>> # YAML file containing "@backstage-community/plugin-techdocs"
+        >>> # resolves to stem "backstage-community-plugin-techdocs"
+        >>> stems = load_and_resolve_to_stems(
+        ...     ["default.packages.yaml"],
+        ...     Path("/path/to/overlays"),
+        ... )
+        >>> "backstage-community-plugin-techdocs" in stems
+        True
+
+        >>> # txt file containing "backstage/plugins/techdocs"
+        >>> # resolves to the same stem via workspace mapping
+        >>> stems = load_and_resolve_to_stems(
+        ...     ["rhdh-supported-packages.txt"],
+        ...     Path("/path/to/overlays"),
+        ... )
+        >>> "backstage-community-plugin-techdocs" in stems
+        True
+    """
     if not packages_files:
         return set()
 
@@ -345,9 +519,44 @@ def load_and_resolve_to_npm_names(
     packages_files: list[str],
     overlays_dir: Path,
 ) -> set[str]:
-    """Takes a list of file paths (YAML or txt), auto-detects format,
-    resolves all to npm package names.
-    Returns union of all resolved npm names."""
+    """Load package lists from multiple files and resolve all entries to npm
+    package names.
+
+    Each file is auto-detected as YAML or txt based on extension. YAML files
+    already contain npm names (validated against workspace metadata); txt files
+    contain workspace paths (resolved via ``ws_path_to_npm``). The union of
+    all resolved npm names across all files is returned.
+
+    Logs warnings for entries that cannot be resolved and debug-level
+    messages for cross-file overlaps.
+
+    Args:
+        packages_files: Paths to package list files. Supports mixed formats
+            (some YAML, some txt) in the same call.
+        overlays_dir: Root of the overlays repository (passed through to
+            ``build_workspace_mappings``).
+
+    Returns:
+        Union of resolved npm package names from all input files.
+
+    Example:
+        >>> # txt file containing "backstage/plugins/techdocs"
+        >>> # resolves to npm name "@backstage-community/plugin-techdocs"
+        >>> npms = load_and_resolve_to_npm_names(
+        ...     ["rhdh-supported-packages.txt"],
+        ...     Path("/path/to/overlays"),
+        ... )
+        >>> "@backstage-community/plugin-techdocs" in npms
+        True
+
+        >>> # YAML file entries are validated and passed through directly
+        >>> npms = load_and_resolve_to_npm_names(
+        ...     ["default.packages.yaml"],
+        ...     Path("/path/to/overlays"),
+        ... )
+        >>> "@backstage-community/plugin-techdocs" in npms
+        True
+    """
     if not packages_files:
         return set()
 
@@ -411,11 +620,24 @@ def load_and_resolve_to_npm_names(
 class BuildReport:
     """Manages a build-report.json file for tracking plugin generation stages.
 
-    Usage:
-        report = BuildReport(args.report_file)  # None disables reporting
-        report.add_plugin("image-name", package="@scope/pkg", version="1.0")
-        report.set_stage("image-name", "bootstrap", "pass", oci_ref="quay.io/...")
-        report.save()  # computes overall/summary and writes to disk
+    Tracks per-plugin build progress through named stages (e.g., bootstrap,
+    export, publish), each with a pass/fail/skip status. On ``save()``,
+    computes per-plugin overall status and an aggregate summary.
+
+    Passing ``None`` as the report file disables all operations (methods
+    become no-ops). An ``atexit`` handler is registered to auto-save on
+    process exit when reporting is enabled.
+
+    Args:
+        report_file: Path to the JSON report file, or ``None`` to disable.
+
+    Example:
+        >>> report = BuildReport("build-report.json")
+        >>> report.set_metadata(backstage_version="1.45.1")
+        >>> report.add_plugin("plugin-techdocs", package="@backstage-community/plugin-techdocs")
+        >>> report.set_stage("plugin-techdocs", "bootstrap", "pass", oci_ref="quay.io/...")
+        >>> report.set_stage("plugin-techdocs", "export", "pass")
+        >>> report.save()  # writes JSON with overall="pass", summary counts
     """
 
     def __init__(self, report_file: str | None):
@@ -437,11 +659,13 @@ class BuildReport:
         return self._path is not None
 
     def set_metadata(self, **fields) -> None:
+        """Update top-level metadata fields (e.g., backstage_version, node_version)."""
         if not self.enabled:
             return
         self._data.setdefault("metadata", {}).update(fields)
 
     def add_plugin(self, plugin_name: str, **info) -> None:
+        """Register a plugin in the report with optional info fields (e.g., package, version)."""
         if not self.enabled:
             return
         plugin = self._data.setdefault("plugins", {}).setdefault(
@@ -452,6 +676,7 @@ class BuildReport:
                 plugin[k] = v
 
     def set_stage(self, plugin_name: str, stage: str, status: str, **details) -> None:
+        """Record the outcome of a build stage for a specific plugin."""
         if not self.enabled:
             return
         plugin = self._data.setdefault("plugins", {}).setdefault(
@@ -462,12 +687,14 @@ class BuildReport:
         plugin.setdefault("stages", {})[stage] = stage_data
 
     def set_stage_all(self, stage: str, status: str, **details) -> None:
+        """Apply the same stage outcome to every plugin currently in the report."""
         if not self.enabled:
             return
         for plugin_name in self._data.get("plugins", {}):
             self.set_stage(plugin_name, stage, status, **details)
 
     def save(self) -> None:
+        """Compute per-plugin overall status and summary counts, then write to disk."""
         if not self.enabled:
             return
 

--- a/scripts/renderCatalogStatus.py
+++ b/scripts/renderCatalogStatus.py
@@ -204,7 +204,10 @@ def render_tier(
         return lines
 
     failed = {k: v for k, v in plugins.items() if v.get("overall") == "fail"}
-    passed = {k: v for k, v in plugins.items() if v.get("overall") == "pass"}
+    all_passed = {k: v for k, v in plugins.items() if v.get("overall") == "pass"}
+    fallback = {k: v for k, v in all_passed.items()
+                if v.get("stages", {}).get("registry-enrich", {}).get("fallback")}
+    passed = {k: v for k, v in all_passed.items() if k not in fallback}
 
     lines.append(f"## {tier_name} Catalog")
     lines.append("")
@@ -223,6 +226,27 @@ def render_tier(
             name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
             reason_link = f"[{reason}]({workflow_run_url})" if workflow_run_url else reason
             lines.append(f"| {name_link} | `{pkg}` | {ver} | {stage_label} | {reason_link} |")
+        lines.append("")
+
+    if fallback:
+        lines.append(f"### ⚠️ Outdated ({len(fallback)})")
+        lines.append("")
+        lines.append("> These plugins are using an older published tag because the requested version was not found in the registry.")
+        lines.append("")
+        lines.append("| Plugin | Package | Requested Tag | Resolved Tag | OCI Reference |")
+        lines.append("|--------|---------|---------------|--------------|---------------|")
+        for name in sorted(fallback):
+            p = fallback[name]
+            ws = p.get("workspace", "")
+            pkg = p.get("package", "")
+            stages = p.get("stages", {})
+            enrich = stages.get("registry-enrich", {})
+            requested = enrich.get("requestedTag", "")
+            resolved = enrich.get("resolvedTag", "")
+            oci_ref = stages.get("bootstrap", {}).get("oci_ref", "")
+            name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
+            oci_link = oci_ref_to_link(oci_ref, ghcr_version_ids)
+            lines.append(f"| {name_link} | `{pkg}` | `{requested}` | `{resolved}` | {oci_link} |")
         lines.append("")
 
     if passed:
@@ -252,6 +276,15 @@ def commit_link(sha: str, source_repo: str) -> str:
     if source_repo:
         return f"[{short}]({source_repo}/commit/{sha})"
     return short
+
+
+def count_fallbacks(report: dict) -> int:
+    """Count plugins using fallback tags in a report."""
+    return sum(
+        1 for p in report.get("plugins", {}).values()
+        if p.get("overall") == "pass"
+        and p.get("stages", {}).get("registry-enrich", {}).get("fallback")
+    )
 
 
 def render_last_publish(report: dict, source_repo: str) -> str:
@@ -323,16 +356,18 @@ def render_status_page(
 
     lines.append("## Summary")
     lines.append("")
-    lines.append("| Tier | Total | Passed | Failed | Latest Catalog Index Image | Last Successful Publish |")
-    lines.append("|------|-------|--------|--------|----------------------------|-------------------------|")
+    lines.append("| Tier | Total | Passed | Outdated | Failed | Latest Catalog Index Image | Last Successful Publish |")
+    lines.append("|------|-------|--------|----------|--------|----------------------------|-------------------------|")
     if supported_report:
         sup_img = render_catalog_image(supported_report, ghcr_version_ids)
         sup_pub = render_last_publish(supported_report, source_repo)
-        lines.append(f"| Supported | {sup_summary.get('total', 0)} | {sup_summary.get('succeeded', 0)} | {sup_summary.get('failed', 0)} | {sup_img} | {sup_pub} |")
+        sup_fallback = count_fallbacks(supported_report)
+        lines.append(f"| Supported | {sup_summary.get('total', 0)} | {sup_summary.get('succeeded', 0)} | {sup_fallback} | {sup_summary.get('failed', 0)} | {sup_img} | {sup_pub} |")
     if community_report:
         com_img = render_catalog_image(community_report, ghcr_version_ids)
         com_pub = render_last_publish(community_report, source_repo)
-        lines.append(f"| Community | {com_summary.get('total', 0)} | {com_summary.get('succeeded', 0)} | {com_summary.get('failed', 0)} | {com_img} | {com_pub} |")
+        com_fallback = count_fallbacks(community_report)
+        lines.append(f"| Community | {com_summary.get('total', 0)} | {com_summary.get('succeeded', 0)} | {com_fallback} | {com_summary.get('failed', 0)} | {com_img} | {com_pub} |")
     lines.append("")
 
     # Tier details

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pyyaml
+requests

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,108 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load_fixture_json(filename: str) -> dict:
+    """Load a JSON fixture file from scripts/tests/fixtures/."""
+    with open(FIXTURES_DIR / filename, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _fixture_path(filename: str) -> Path:
+    """Return the absolute path to a fixture file."""
+    return FIXTURES_DIR / filename
+
+
+@pytest.fixture
+def sample_plugin_data():
+    """Real plugin_builds JSON for a downstream quay.io/rhdh build.
+
+    Source: plugin_builds/supported/adoption-insights/
+    Downstream builds include build-date, vcs-ref, upstream, and midstream.
+    """
+    return _load_fixture_json(
+        "red-hat-developer-hub-backstage-plugin-adoption-insights.json"
+    )
+
+
+@pytest.fixture
+def sample_plugin_data_no_digest(sample_plugin_data):
+    """Plugin_builds entry stripped to pre-enrichment state.
+
+    This is what a plugin_builds JSON looks like before generatePluginBuildInfo
+    enriches it with registry metadata — only workspacePath and registryReference.
+    """
+    data = {}
+    for name, fields in sample_plugin_data.items():
+        data[name] = {
+            "workspacePath": fields["workspacePath"],
+            "registryReference": fields["registryReference"],
+        }
+    return data
+
+
+@pytest.fixture
+def sample_plugin_data_ghcr():
+    """Real plugin_builds JSON for a community ghcr.io image.
+
+    Source: plugin_builds/community/3scale/
+    Community builds do NOT have build-date, vcs-ref, upstream, or midstream —
+    those are only present in downstream quay.io/rhdh builds.
+    """
+    return _load_fixture_json(
+        "backstage-community-plugin-3scale-backend.json"
+    )
+
+
+@pytest.fixture
+def sample_package_yaml():
+    """Real Package entity YAML from workspaces/backstage/metadata/.
+
+    Source: backstage-plugin-catalog-backend-module-github.yaml
+    """
+    return _fixture_path("sample-package.yaml")
+
+
+@pytest.fixture
+def sample_packages_yaml():
+    """Trimmed default.packages.yaml with enabled and disabled sections.
+
+    Source: derived from default.packages.yaml
+    """
+    return str(_fixture_path("sample-packages.yaml"))
+
+
+@pytest.fixture
+def sample_packages_txt():
+    """Trimmed community packages txt file.
+
+    Source: derived from rhdh-community-packages.txt
+    """
+    return str(_fixture_path("sample-packages.txt"))
+
+
+@pytest.fixture
+def sample_workspace_dir():
+    """Real workspace directory structure from fixtures/workspaces/.
+
+    Contains::
+
+        workspaces/
+          backstage/
+            plugins-list.yaml
+            metadata/
+              backstage-plugin-catalog-backend-module-github.yaml
+          3scale/
+            plugins-list.yaml
+            metadata/
+              backstage-community-plugin-3scale-backend.yaml
+    """
+    return FIXTURES_DIR

--- a/scripts/tests/fixtures/backstage-community-plugin-3scale-backend.json
+++ b/scripts/tests/fixtures/backstage-community-plugin-3scale-backend.json
@@ -1,0 +1,9 @@
+{
+  "backstage-community-plugin-3scale-backend": {
+    "workspacePath": "3scale/plugins/3scale-backend",
+    "registryReference": "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-3scale-backend:bs_1.49.4__3.13.0",
+    "digest": "sha256:62810995b060834821de573af6228387c4254bc593857e02b39238f4b990b17c",
+    "support": "community",
+    "io.backstage.dynamic-packages": "W3siYmFja3N0YWdlLWNvbW11bml0eS1wbHVnaW4tM3NjYWxlLWJhY2tlbmQiOnsibmFtZSI6IkBiYWNrc3RhZ2UtY29tbXVuaXR5L3BsdWdpbi0zc2NhbGUtYmFja2VuZC1keW5hbWljIiwidmVyc2lvbiI6IjMuMTMuMCIsImJhY2tzdGFnZSI6eyJyb2xlIjoiYmFja2VuZC1wbHVnaW4tbW9kdWxlIiwicGx1Z2luSWQiOiIzc2NhbGUiLCJwbHVnaW5QYWNrYWdlIjoiQGJhY2tzdGFnZS1jb21tdW5pdHkvcGx1Z2luLTNzY2FsZS1iYWNrZW5kIiwic3VwcG9ydGVkLXZlcnNpb25zIjoiMS40OS4yIn0sInJlcG9zaXRvcnkiOnsidHlwZSI6ImdpdCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9iYWNrc3RhZ2UvY29tbXVuaXR5LXBsdWdpbnMiLCJkaXJlY3RvcnkiOiJ3b3Jrc3BhY2VzLzNzY2FsZS9wbHVnaW5zLzNzY2FsZS1iYWNrZW5kIn0sImxpY2Vuc2UiOiJBcGFjaGUtMi4wIiwiYXV0aG9yIjoiUmVkIEhhdCIsImJ1Z3MiOiJodHRwczovL2dpdGh1Yi5jb20vYmFja3N0YWdlL2NvbW11bml0eS1wbHVnaW5zL2lzc3VlcyIsImtleXdvcmRzIjpbImJhY2tzdGFnZSIsInBsdWdpbiJdfX1d"
+  }
+}

--- a/scripts/tests/fixtures/red-hat-developer-hub-backstage-plugin-adoption-insights.json
+++ b/scripts/tests/fixtures/red-hat-developer-hub-backstage-plugin-adoption-insights.json
@@ -1,0 +1,13 @@
+{
+  "red-hat-developer-hub-backstage-plugin-adoption-insights": {
+    "workspacePath": "adoption-insights/plugins/adoption-insights",
+    "registryReference": "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-adoption-insights:1.11--0.8.2",
+    "digest": "sha256:6d534d3bb0c08f0034b00c1398891fb3393b3df87002789efdc50bcd7c0a1177",
+    "build-date": "2026-06-02T17:27:06Z",
+    "upstream": "https://github.com/redhat-developer/rhdh-plugin-export-overlays/tree/main @ 710868b6ee9c4a596c5e3b5b5988193f2b8873ec",
+    "midstream": "https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog/-/commits/rhdh-1-rhel-9",
+    "vcs-ref": "b93b7dcd7aa784d5faa9ef98d753bd9643532ce1",
+    "support": "generally-available",
+    "io.backstage.dynamic-packages": "W3sicmVkLWhhdC1kZXZlbG9wZXItaHViLWJhY2tzdGFnZS1wbHVnaW4tYWRvcHRpb24taW5zaWdodHMiOnsibmFtZSI6IkByZWQtaGF0LWRldmVsb3Blci1odWIvYmFja3N0YWdlLXBsdWdpbi1hZG9wdGlvbi1pbnNpZ2h0cy1keW5hbWljIiwidmVyc2lvbiI6IjAuOC4yIiwiYmFja3N0YWdlIjp7InJvbGUiOiJmcm9udGVuZC1wbHVnaW4iLCJwbHVnaW5JZCI6ImFkb3B0aW9uLWluc2lnaHRzIiwicGx1Z2luUGFja2FnZXMiOlsiQHJlZC1oYXQtZGV2ZWxvcGVyLWh1Yi9iYWNrc3RhZ2UtcGx1Z2luLWFkb3B0aW9uLWluc2lnaHRzIiwiQHJlZC1oYXQtZGV2ZWxvcGVyLWh1Yi9iYWNrc3RhZ2UtcGx1Z2luLWFkb3B0aW9uLWluc2lnaHRzLWJhY2tlbmQiLCJAcmVkLWhhdC1kZXZlbG9wZXItaHViL2JhY2tzdGFnZS1wbHVnaW4tYWRvcHRpb24taW5zaWdodHMtY29tbW9uIl0sInN1cHBvcnRlZC12ZXJzaW9ucyI6IjEuNDkuMyJ9LCJyZXBvc2l0b3J5Ijp7InR5cGUiOiJnaXQiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vcmVkaGF0LWRldmVsb3Blci9yaGRoLXBsdWdpbnMiLCJkaXJlY3RvcnkiOiJ3b3Jrc3BhY2VzL2Fkb3B0aW9uLWluc2lnaHRzL3BsdWdpbnMvYWRvcHRpb24taW5zaWdodHMifSwibGljZW5zZSI6IkFwYWNoZS0yLjAifX1d"
+  }
+}

--- a/scripts/tests/fixtures/sample-package.yaml
+++ b/scripts/tests/fixtures/sample-package.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-catalog-backend-module-github
+  namespace: rhdh
+  title: "Catalog Backend Module GitHub"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-github
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-github
+  tags:
+    - software-catalog
+spec:
+  packageName: "@backstage/plugin-catalog-backend-module-github"
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+  version: 0.13.0
+  backstage:
+    role: backend-plugin-module
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - backstage-plugin-catalog-backend-module-github
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        catalog:
+          providers:
+            github:
+              providerId:
+                organization: ${GITHUB_ORG}

--- a/scripts/tests/fixtures/sample-packages.txt
+++ b/scripts/tests/fixtures/sample-packages.txt
@@ -1,0 +1,3 @@
+# Trimmed from rhdh-community-packages.txt for testing
+3scale/plugins/3scale-backend
+backstage/plugins/catalog-backend-module-github

--- a/scripts/tests/fixtures/sample-packages.yaml
+++ b/scripts/tests/fixtures/sample-packages.yaml
@@ -1,0 +1,7 @@
+# Trimmed from default.packages.yaml for testing
+packages:
+  enabled:
+  - package: '@backstage/plugin-catalog-backend-module-github'
+  - package: '@backstage-community/plugin-analytics-provider-segment'
+  disabled:
+  - package: '@backstage-community/plugin-acr'

--- a/scripts/tests/fixtures/workspaces/3scale/metadata/backstage-community-plugin-3scale-backend.yaml
+++ b/scripts/tests/fixtures/workspaces/3scale/metadata/backstage-community-plugin-3scale-backend.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-3scale-backend
+  namespace: rhdh
+  title: "3Scale"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/community-plugins/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/3scale
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/3scale
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-3scale-backend"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-3scale-backend:bs_1.49.4__3.13.0!backstage-community-plugin-3scale-backend
+  version: 3.13.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: community
+  lifecycle: active
+  partOf:
+    - 3scale
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        catalog:
+          providers:
+            threeScaleApiEntity:
+              default:
+                baseUrl: ${THREESCALE_BASE_URL}
+                accessToken: ${THREESCALE_ACCESS_TOKEN}

--- a/scripts/tests/fixtures/workspaces/3scale/plugins-list.yaml
+++ b/scripts/tests/fixtures/workspaces/3scale/plugins-list.yaml
@@ -1,0 +1,1 @@
+plugins/3scale-backend:

--- a/scripts/tests/fixtures/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-github.yaml
+++ b/scripts/tests/fixtures/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-github.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-catalog-backend-module-github
+  namespace: rhdh
+  title: "Catalog Backend Module GitHub"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-github
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-github
+  tags:
+    - software-catalog
+spec:
+  packageName: "@backstage/plugin-catalog-backend-module-github"
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+  version: 0.13.0
+  backstage:
+    role: backend-plugin-module
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - backstage-plugin-catalog-backend-module-github
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        catalog:
+          providers:
+            github:
+              providerId:
+                organization: ${GITHUB_ORG}

--- a/scripts/tests/fixtures/workspaces/backstage/plugins-list.yaml
+++ b/scripts/tests/fixtures/workspaces/backstage/plugins-list.yaml
@@ -1,0 +1,1 @@
+plugins/catalog-backend-module-github:

--- a/scripts/tests/test_generateCatalogIndex.py
+++ b/scripts/tests/test_generateCatalogIndex.py
@@ -1,0 +1,326 @@
+"""Tests for pure-logic functions in generateCatalogIndex.py."""
+
+import pytest
+
+from generateCatalogIndex import (
+    build_digest_comment_map,
+    digest_from_oci_package_line,
+    get_image_name_from_package_yaml,
+    get_query_registry_reference,
+    is_tag_comment_line,
+    parse_image_reference,
+    peek_digest_after,
+    pop_trailing_tag_comments,
+    tag_comment_for_plugin,
+    trailing_tag_comment_matches,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_image_reference
+# ---------------------------------------------------------------------------
+class TestParseImageReference:
+    @pytest.mark.parametrize(
+        "ref, expected",
+        [
+            pytest.param(
+                "quay.io/rhdh/plugin:1.11--1.5.4",
+                ("quay.io/rhdh/plugin", "1.11--1.5.4", ""),
+                id="tag_only",
+            ),
+            pytest.param(
+                "quay.io/rhdh/plugin@sha256:abc123",
+                ("quay.io/rhdh/plugin", "", "sha256:abc123"),
+                id="digest_only",
+            ),
+            pytest.param(
+                "quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123",
+                ("quay.io/rhdh/plugin", "1.11--1.5.4", "sha256:abc123"),
+                id="tag_and_digest",
+            ),
+            pytest.param(
+                "",
+                ("", "", ""),
+                id="empty_string",
+            ),
+            pytest.param(
+                "quay.io/rhdh/plugin",
+                ("quay.io/rhdh/plugin", "", ""),
+                id="no_tag_no_digest",
+            ),
+        ],
+    )
+    def test_parse(self, ref, expected):
+        assert parse_image_reference(ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# tag_comment_for_plugin
+# ---------------------------------------------------------------------------
+class TestTagCommentForPlugin:
+    def test_all_fields_present(self):
+        data = {
+            "build-date": "2025-05-01",
+            "imageTag": "1.11--1.5.4",
+            "registryReference": "quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123",
+        }
+        assert tag_comment_for_plugin(data) == "# Tag: 1.11--1.5.4, Build date: 2025-05-01"
+
+    def test_tag_from_registry_reference_fallback(self):
+        data = {
+            "build-date": "2025-05-01",
+            "registryReference": "quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123",
+        }
+        assert tag_comment_for_plugin(data) == "# Tag: 1.11--1.5.4, Build date: 2025-05-01"
+
+    def test_missing_build_date_returns_none(self):
+        data = {
+            "imageTag": "1.11--1.5.4",
+            "registryReference": "quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123",
+        }
+        assert tag_comment_for_plugin(data) is None
+
+    def test_missing_digest_returns_none(self):
+        data = {
+            "build-date": "2025-05-01",
+            "imageTag": "1.11--1.5.4",
+            "registryReference": "quay.io/rhdh/plugin:1.11--1.5.4",
+        }
+        assert tag_comment_for_plugin(data) is None
+
+
+# ---------------------------------------------------------------------------
+# build_digest_comment_map
+# ---------------------------------------------------------------------------
+class TestBuildDigestCommentMap:
+    def test_two_plugins(self):
+        index_data = {
+            "plugin-a": {
+                "registryReference": "quay.io/rhdh/plugin-a@sha256:aaa111",
+                "imageTag": "1.11--1.0.0",
+                "build-date": "2025-05-01",
+            },
+            "plugin-b": {
+                "registryReference": "quay.io/rhdh/plugin-b@sha256:bbb222",
+                "imageTag": "1.11--2.0.0",
+                "build-date": "2025-05-02",
+            },
+        }
+        result = build_digest_comment_map(index_data)
+        assert result == {
+            "sha256:aaa111": "# Tag: 1.11--1.0.0, Build date: 2025-05-01",
+            "sha256:bbb222": "# Tag: 1.11--2.0.0, Build date: 2025-05-02",
+        }
+
+    def test_skips_entries_without_digest(self):
+        index_data = {
+            "plugin-no-digest": {
+                "registryReference": "quay.io/rhdh/plugin:1.11--1.0.0",
+                "imageTag": "1.11--1.0.0",
+                "build-date": "2025-05-01",
+            },
+        }
+        assert build_digest_comment_map(index_data) == {}
+
+
+# ---------------------------------------------------------------------------
+# is_tag_comment_line
+# ---------------------------------------------------------------------------
+class TestIsTagCommentLine:
+    @pytest.mark.parametrize(
+        "line, expected",
+        [
+            pytest.param(
+                "  # Tag: 1.11--1.5.4, Build date: 2025-05-01",
+                True,
+                id="valid_tag_comment",
+            ),
+            pytest.param(
+                "  # Some other comment",
+                False,
+                id="other_comment",
+            ),
+            pytest.param(
+                "  - package: oci://quay.io/rhdh/plugin@sha256:abc",
+                False,
+                id="package_line",
+            ),
+        ],
+    )
+    def test_is_tag_comment(self, line, expected):
+        assert is_tag_comment_line(line) == expected
+
+
+# ---------------------------------------------------------------------------
+# pop_trailing_tag_comments
+# ---------------------------------------------------------------------------
+class TestPopTrailingTagComments:
+    def test_removes_trailing_tag_comment(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+        ]
+        pop_trailing_tag_comments(lines)
+        assert lines == ["  - package: oci://quay.io/rhdh/plugin@sha256:abc\n"]
+
+    def test_no_change_for_non_tag_trailing(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  some-key: value\n",
+        ]
+        original = list(lines)
+        pop_trailing_tag_comments(lines)
+        assert lines == original
+
+    def test_removes_multiple_trailing_tag_comments(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  # Tag: 1.11--1.0.0, Build date: 2025-05-01\n",
+            "  # Tag: 1.11--2.0.0, Build date: 2025-05-02\n",
+        ]
+        pop_trailing_tag_comments(lines)
+        assert lines == ["  - package: oci://quay.io/rhdh/plugin@sha256:abc\n"]
+
+
+# ---------------------------------------------------------------------------
+# trailing_tag_comment_matches
+# ---------------------------------------------------------------------------
+class TestTrailingTagCommentMatches:
+    def test_matches(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+        ]
+        assert trailing_tag_comment_matches(lines, "# Tag: 1.11--1.5.4, Build date: 2025-05-01") is True
+
+    def test_does_not_match(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+        ]
+        assert trailing_tag_comment_matches(lines, "# Tag: 9.99--9.9.9, Build date: 2099-01-01") is False
+
+    def test_none_expected_returns_false(self):
+        lines = [
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+        ]
+        assert trailing_tag_comment_matches(lines, None) is False
+
+
+# ---------------------------------------------------------------------------
+# digest_from_oci_package_line
+# ---------------------------------------------------------------------------
+class TestDigestFromOciPackageLine:
+    @pytest.mark.parametrize(
+        "line, expected",
+        [
+            pytest.param(
+                "  - package: oci://quay.io/rhdh/plugin@sha256:abc123",
+                "sha256:abc123",
+                id="active_line",
+            ),
+            pytest.param(
+                "  # - package: oci://quay.io/rhdh/plugin@sha256:abc123",
+                "sha256:abc123",
+                id="commented_line",
+            ),
+            pytest.param(
+                "  - package: ./dynamic-plugins/dist/foo",
+                None,
+                id="non_oci_line",
+            ),
+        ],
+    )
+    def test_digest_extraction(self, line, expected):
+        assert digest_from_oci_package_line(line) == expected
+
+
+# ---------------------------------------------------------------------------
+# peek_digest_after
+# ---------------------------------------------------------------------------
+class TestPeekDigestAfter:
+    def test_next_line_has_digest(self):
+        lines = [
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc123\n",
+        ]
+        assert peek_digest_after(lines, 0) == "sha256:abc123"
+
+    def test_skips_blanks_and_tag_comments(self):
+        lines = [
+            "  some: line\n",
+            "\n",
+            "  # Tag: old, Build date: 2025-01-01\n",
+            "  - package: oci://quay.io/rhdh/plugin@sha256:def456\n",
+        ]
+        assert peek_digest_after(lines, 0) == "sha256:def456"
+
+    def test_no_digest_found(self):
+        lines = [
+            "  some: line\n",
+            "  another: line\n",
+        ]
+        assert peek_digest_after(lines, 0) is None
+
+    def test_past_end_of_list(self):
+        lines = [
+            "  some: line\n",
+        ]
+        assert peek_digest_after(lines, 0) is None
+
+
+# ---------------------------------------------------------------------------
+# get_query_registry_reference
+# ---------------------------------------------------------------------------
+class TestGetQueryRegistryReference:
+    @pytest.mark.parametrize(
+        "ref, expected",
+        [
+            pytest.param(
+                "registry.access.redhat.com/rhdh/plugin:1.11--1.5.4",
+                "quay.io/rhdh/plugin:1.11--1.5.4",
+                id="rarc_to_quay",
+            ),
+            pytest.param(
+                "quay.io/rhdh/plugin:1.11--1.5.4",
+                "quay.io/rhdh/plugin:1.11--1.5.4",
+                id="quay_passthrough",
+            ),
+            pytest.param(
+                "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/plugin:bs_1.49.4__2.18.0",
+                "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/plugin:bs_1.49.4__2.18.0",
+                id="ghcr_passthrough",
+            ),
+        ],
+    )
+    def test_query_ref(self, ref, expected):
+        assert get_query_registry_reference(ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_image_name_from_package_yaml
+# ---------------------------------------------------------------------------
+class TestGetImageNameFromPackageYaml:
+    def test_with_package_name(self, sample_package_yaml):
+        result = get_image_name_from_package_yaml(sample_package_yaml)
+        assert result == "backstage-plugin-catalog-backend-module-github"
+
+    def test_fallback_to_metadata_name(self, tmp_path):
+        content = """\
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  namespace: rhdh
+  name: my-custom-plugin
+spec:
+  version: "1.0.0"
+"""
+        yaml_file = tmp_path / "my-custom-plugin.yaml"
+        yaml_file.write_text(content)
+        result = get_image_name_from_package_yaml(yaml_file)
+        assert result == "my-custom-plugin"
+
+    def test_nonexistent_file_returns_stem(self, tmp_path):
+        missing = tmp_path / "nonexistent-plugin.yaml"
+        result = get_image_name_from_package_yaml(missing)
+        assert result == "nonexistent-plugin"

--- a/scripts/tests/test_generatePluginBuildInfo.py
+++ b/scripts/tests/test_generatePluginBuildInfo.py
@@ -380,8 +380,8 @@ class TestGetImageMetadata:
         metadata = generatePluginBuildInfo.get_image_metadata(nonexistent_ref)
         assert metadata is None
 
-    def test_fallback_quay_with_absurd_version(self):
-        """Quay.io fallback with an absurd plugin version resolves to the latest real tag."""
+    def test_fallback_quay_with_nonexistent_version(self):
+        """Quay.io fallback with an nonexistent plugin version resolves to the latest real tag."""
         nonexistent_ref = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--9999.99.9"
         metadata = generatePluginBuildInfo.get_image_metadata(nonexistent_ref)
         assert metadata is not None
@@ -398,15 +398,15 @@ class TestGetImageMetadata:
 class TestResolveFallbackTag:
     """Tests for resolve_fallback_tag against real registries."""
 
-    def test_ghcr_absurd_version_resolves_to_latest(self):
-        """An absurd plugin version with a valid prefix resolves to the latest real tag."""
+    def test_ghcr_nonexistent_version_resolves_to_latest(self):
+        """An nonexistent plugin version with a valid prefix resolves to the latest real tag."""
         nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__9999.99.9"
         result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
         assert result is not None
         assert "bs_1.49.4__" in result
         assert "9999" not in result
 
-    def test_quay_absurd_version_resolves_to_latest(self):
+    def test_quay_nonexistent_version_resolves_to_latest(self):
         nonexistent_ref = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--9999.99.9"
         result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
         assert result is not None

--- a/scripts/tests/test_generatePluginBuildInfo.py
+++ b/scripts/tests/test_generatePluginBuildInfo.py
@@ -1,0 +1,282 @@
+"""Tests for generatePluginBuildInfo.py — parsing, tag listing, and registry reference transforms."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import generatePluginBuildInfo
+
+
+# ---------------------------------------------------------------------------
+# parse_registry_reference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "ref, expected",
+    [
+        pytest.param(
+            "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0",
+            ("ghcr.io", "org/repo/plugin", "bs_1.45.3__1.2.0"),
+            id="ghcr-with-tag",
+        ),
+        pytest.param(
+            "quay.io/rhdh/plugin:1.11--1.5.4",
+            ("quay.io", "rhdh/plugin", "1.11--1.5.4"),
+            id="quay-with-tag",
+        ),
+        pytest.param(
+            "registry.access.redhat.com/rhdh/plugin:1.11--1.5.4",
+            ("quay.io", "rhdh/plugin", "1.11--1.5.4"),
+            id="rarc-swapped-to-quay",
+        ),
+        pytest.param(
+            "quay.io/rhdh/plugin@sha256:abc123",
+            ("quay.io", "rhdh/plugin", "sha256:abc123"),
+            id="digest-reference",
+        ),
+        pytest.param(
+            "invalid",
+            None,
+            id="invalid-no-slash",
+        ),
+        pytest.param(
+            "quay.io/rhdh/plugin",
+            None,
+            id="invalid-no-tag-or-digest",
+        ),
+    ],
+)
+def test_parse_registry_reference(ref, expected):
+    assert generatePluginBuildInfo.parse_registry_reference(ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# VERSION_SUFFIX_RE
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param("2.18.0", id="three-part"),
+        pytest.param("1.5", id="two-part"),
+        pytest.param("0.1.0", id="zero-leading"),
+        pytest.param("10.20.30", id="multi-digit"),
+    ],
+)
+def test_version_suffix_re_valid(suffix):
+    assert generatePluginBuildInfo.VERSION_SUFFIX_RE.match(suffix) is not None
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param("2.18.0.att", id="attestation-suffix"),
+        pytest.param("2.18.0.sbom", id="sbom-suffix"),
+        pytest.param("abc", id="letters-only"),
+        pytest.param("", id="empty"),
+        pytest.param("2.18.0-rc.1", id="prerelease"),
+        pytest.param("sha256:abc", id="digest-like"),
+    ],
+)
+def test_version_suffix_re_invalid(suffix):
+    assert generatePluginBuildInfo.VERSION_SUFFIX_RE.match(suffix) is None
+
+
+# ---------------------------------------------------------------------------
+# list_tags_with_prefix — mocked with REAL tag data
+#
+# Tags below are real samples from:
+#   quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator
+#   ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay
+# ---------------------------------------------------------------------------
+
+# Real tags from quay.io (Konflux builds) — mix of valid versions and build artifacts
+QUAY_REAL_TAGS = [
+    # Valid version tags
+    "1.10--1.3.2",
+    "1.10--1.3.3",
+    "1.10--1.5.3",
+    "1.10--1.5.4",
+    "1.10.0--1.3.2",
+    "1.10.0--1.3.3",
+    "1.10.0--1.5.3",
+    "1.10.0--1.5.4",
+    "1.11--1.5.4",
+    "1.11.0--1.5.4",
+    "1.9--1.1.0",
+    "1.9--1.3.1",
+    # Garbage: bare commit SHAs
+    "207c0117f535de0eccd735c458086807165a243c",
+    "2345f799f480ff5a14f72721672c196023f17f00",
+    "08ac113825206cc510c055a1a8a2cf0fb52e5947.git",
+    "19534fb5ee72171fd373729f3a90909f6ef67a6c.prefetch",
+    # Garbage: Konflux build pipeline tags
+    "rhdh-bsp-scaf059cf4428e94deaf092ef2ec86921bc6-build-image-index",
+    "rhdh-bsp-scaffo9b56ccf78578652c0a7291cccef26eaa-build-container",
+    # Garbage: on-pr- tags from Konflux
+    "on-pr-05edbdc5bbaf6059e86697042d65eaa1ab72df48.git",
+    "on-pr-05edbdc5bbaf6059e86697042d65eaa1ab72df48.prefetch",
+    "on-pr-d13a7e6d0d83b7efd8e4e3cfd7a8e092b7b131b9.git",
+    # Garbage: sha256- attestation/sbom/manifest tags
+    "sha256-000c59163f40769db932c1d4ecb2871e5cdd1e3437510776f7ad00fadaa44290",
+    "sha256-000c59163f40769db932c1d4ecb2871e5cdd1e3437510776f7ad00fadaa44290.att",
+    "sha256-000c59163f40769db932c1d4ecb2871e5cdd1e3437510776f7ad00fadaa44290.sbom",
+    "sha256-143e13c52e7e1dfbe4abc73653af76f0bac8a02bfc598ee9bffcedef829e12fb.src",
+    "sha256-143e13c52e7e1dfbe4abc73653af76f0bac8a02bfc598ee9bffcedef829e12fb.dockerfile",
+]
+
+# Real tags from ghcr.io — much cleaner, but still has pr_/next_ prefixes
+GHCR_REAL_TAGS = [
+    # Valid version tags
+    "bs_1.32.6__2.3.0",
+    "bs_1.35.1__2.5.0",
+    "bs_1.36.1__2.6.2",
+    "bs_1.39.1__2.9.1",
+    "bs_1.42.5__2.11.0",
+    "bs_1.45.3__2.11.0",
+    "bs_1.45.3__2.14.0",
+    "bs_1.49.4__2.18.0",
+    # Not matching bs_ prefix
+    "next__2.11.0",
+    "next__2.14.0",
+    "pr_1168__2.6.2",
+    "pr_2457__2.18.0",
+]
+
+
+def _mock_response(tags):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"tags": tags}
+    return resp
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_quay_prefix_filters_garbage(mock_get):
+    """Verify only clean version tags survive from real quay.io Konflux output."""
+    mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator",
+        "1.10--", None, {}
+    )
+    assert result == ["1.10--1.3.2", "1.10--1.3.3", "1.10--1.5.3", "1.10--1.5.4"]
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_quay_three_part_prefix(mock_get):
+    """Verify three-part version prefix (1.10.0--) also works."""
+    mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator",
+        "1.10.0--", None, {}
+    )
+    assert result == ["1.10.0--1.3.2", "1.10.0--1.3.3", "1.10.0--1.5.3", "1.10.0--1.5.4"]
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_ghcr_prefix_filters_other_families(mock_get):
+    """Verify only bs_1.45.3__ tags returned, not next__/pr__ tags."""
+    mock_get.return_value = _mock_response(GHCR_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "ghcr.io", "redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay",
+        "bs_1.45.3__", None, {}
+    )
+    assert result == ["bs_1.45.3__2.11.0", "bs_1.45.3__2.14.0"]
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_no_matching_prefix(mock_get):
+    """Prefix that doesn't exist in the registry returns empty list."""
+    mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/plugin", "1.12--", None, {}
+    )
+    assert result == []
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_empty_response(mock_get):
+    mock_get.return_value = _mock_response([])
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/plugin", "1.11--", None, {}
+    )
+    assert result == []
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_version_sort_order(mock_get):
+    """Verify ascending version sort — latest tag is last."""
+    mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator",
+        "1.9--", None, {}
+    )
+    assert result == ["1.9--1.1.0", "1.9--1.3.1"]
+    assert result[-1] == "1.9--1.3.1"
+
+
+# ---------------------------------------------------------------------------
+# get_query_registry_reference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "ref, expected",
+    [
+        pytest.param(
+            "registry.access.redhat.com/rhdh/plugin:1.11",
+            "quay.io/rhdh/plugin:1.11",
+            id="rarc-swaps-to-quay",
+        ),
+        pytest.param(
+            "quay.io/rhdh/plugin:1.11",
+            "quay.io/rhdh/plugin:1.11",
+            id="quay-passes-through",
+        ),
+        pytest.param(
+            "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0",
+            "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0",
+            id="ghcr-passes-through",
+        ),
+    ],
+)
+def test_get_query_registry_reference(ref, expected):
+    assert generatePluginBuildInfo.get_query_registry_reference(ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_output_registry_reference
+# ---------------------------------------------------------------------------
+
+class TestGetOutputRegistryReference:
+    """Tests that manipulate the module-level REGISTRY_BASE global."""
+
+    def teardown_method(self):
+        generatePluginBuildInfo.REGISTRY_BASE = ""
+
+    def test_rarc_base_swaps_quay_rhdh_ref(self):
+        generatePluginBuildInfo.REGISTRY_BASE = "registry.access.redhat.com/rhdh"
+        ref = "quay.io/rhdh/plugin:1.11--1.5.4"
+        assert generatePluginBuildInfo.get_output_registry_reference(ref) == (
+            "registry.access.redhat.com/rhdh/plugin:1.11--1.5.4"
+        )
+
+    def test_rarc_base_does_not_swap_ghcr_ref(self):
+        generatePluginBuildInfo.REGISTRY_BASE = "registry.access.redhat.com/rhdh"
+        ref = "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"
+        assert generatePluginBuildInfo.get_output_registry_reference(ref) == ref
+
+    def test_quay_rhdh_base_passes_through(self):
+        generatePluginBuildInfo.REGISTRY_BASE = "quay.io/rhdh"
+        ref = "quay.io/rhdh/plugin:1.11--1.5.4"
+        assert generatePluginBuildInfo.get_output_registry_reference(ref) == ref
+
+    def test_ghcr_base_passes_through(self):
+        generatePluginBuildInfo.REGISTRY_BASE = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays"
+        ref = "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"
+        assert generatePluginBuildInfo.get_output_registry_reference(ref) == ref

--- a/scripts/tests/test_generatePluginBuildInfo.py
+++ b/scripts/tests/test_generatePluginBuildInfo.py
@@ -280,3 +280,155 @@ class TestGetOutputRegistryReference:
         generatePluginBuildInfo.REGISTRY_BASE = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays"
         ref = "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"
         assert generatePluginBuildInfo.get_output_registry_reference(ref) == ref
+
+
+# ---------------------------------------------------------------------------
+# _fetch_image_metadata — real HTTP calls against fixed known images
+#
+# These tests use published images with stable digests that won't change.
+# ---------------------------------------------------------------------------
+
+# Fixed known images for testing
+GHCR_KNOWN_REF = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__2.18.0"
+GHCR_KNOWN_DIGEST = "sha256:15128f76a6edca410f0aa83f48b63fbdbfc5c319404ee9cb577969a2140f2a56"
+
+QUAY_KNOWN_REF = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--1.5.4"
+QUAY_KNOWN_DIGEST = "sha256:e8cb33e40f6f846adaf5e0446049d5a2a5e93a2a12cf8b610e3e0e346f98005c"
+
+
+class TestFetchImageMetadata:
+    """Tests for _fetch_image_metadata against real registries."""
+
+    def test_ghcr_returns_digest(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(GHCR_KNOWN_REF)
+        assert metadata is not None
+        assert metadata["digest"] == GHCR_KNOWN_DIGEST
+
+    def test_ghcr_returns_dynamic_packages_annotation(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(GHCR_KNOWN_REF)
+        assert metadata is not None
+        assert "io.backstage.dynamic-packages" in metadata
+
+    def test_ghcr_community_has_no_build_date(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(GHCR_KNOWN_REF)
+        assert metadata is not None
+        assert "build-date" not in metadata
+
+    def test_quay_returns_digest(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(QUAY_KNOWN_REF)
+        assert metadata is not None
+        assert metadata["digest"] == QUAY_KNOWN_DIGEST
+
+    def test_quay_downstream_has_build_date(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(QUAY_KNOWN_REF)
+        assert metadata is not None
+        assert "build-date" in metadata
+        assert metadata["build-date"]  # non-empty
+
+    def test_quay_downstream_has_vcs_ref(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(QUAY_KNOWN_REF)
+        assert metadata is not None
+        assert "vcs-ref" in metadata
+
+    def test_quay_downstream_has_upstream_and_midstream(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(QUAY_KNOWN_REF)
+        assert metadata is not None
+        assert "upstream" in metadata
+        assert "midstream" in metadata
+
+    def test_nonexistent_tag_returns_none(self):
+        bad_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__9999.99.9"
+        metadata = generatePluginBuildInfo._fetch_image_metadata(bad_ref)
+        assert metadata is None
+
+    def test_nonexistent_repo_returns_none(self):
+        bad_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/this-plugin-does-not-exist:bs_1.0.0__1.0.0"
+        metadata = generatePluginBuildInfo._fetch_image_metadata(bad_ref)
+        assert metadata is None
+
+
+# ---------------------------------------------------------------------------
+# get_image_metadata — fallback chain
+# ---------------------------------------------------------------------------
+
+class TestGetImageMetadata:
+    """Tests for get_image_metadata including the fallback path."""
+
+    def test_direct_hit_returns_metadata_without_fallback_fields(self):
+        """When the exact tag exists, no fallback fields are added."""
+        metadata = generatePluginBuildInfo.get_image_metadata(GHCR_KNOWN_REF)
+        assert metadata is not None
+        assert metadata["digest"] == GHCR_KNOWN_DIGEST
+        assert "fallback" not in metadata
+        assert "requestedTag" not in metadata
+
+    def test_fallback_to_older_tag(self):
+        """When the exact tag doesn't exist, falls back to latest available tag with same prefix."""
+        nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__9999.99.9"
+        metadata = generatePluginBuildInfo.get_image_metadata(nonexistent_ref)
+        assert metadata is not None
+        assert metadata.get("fallback") is True
+        assert metadata["requestedTag"] == "bs_1.49.4__9999.99.9"
+        assert "registryReference" in metadata
+        assert "bs_1.49.4__" in metadata["registryReference"]
+        assert "9999" not in metadata["registryReference"]
+        assert metadata["digest"].startswith("sha256:")
+
+    def test_fallback_no_tags_for_prefix_returns_none(self):
+        """When the prefix has zero published tags, fallback returns None."""
+        nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_9999.99.9__1.0.0"
+        metadata = generatePluginBuildInfo.get_image_metadata(nonexistent_ref)
+        assert metadata is None
+
+    def test_fallback_quay_with_absurd_version(self):
+        """Quay.io fallback with an absurd plugin version resolves to the latest real tag."""
+        nonexistent_ref = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--9999.99.9"
+        metadata = generatePluginBuildInfo.get_image_metadata(nonexistent_ref)
+        assert metadata is not None
+        assert metadata.get("fallback") is True
+        assert metadata["requestedTag"] == "1.11--9999.99.9"
+        assert "1.11--" in metadata["registryReference"]
+        assert "9999" not in metadata["registryReference"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_fallback_tag
+# ---------------------------------------------------------------------------
+
+class TestResolveFallbackTag:
+    """Tests for resolve_fallback_tag against real registries."""
+
+    def test_ghcr_absurd_version_resolves_to_latest(self):
+        """An absurd plugin version with a valid prefix resolves to the latest real tag."""
+        nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__9999.99.9"
+        result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
+        assert result is not None
+        assert "bs_1.49.4__" in result
+        assert "9999" not in result
+
+    def test_quay_absurd_version_resolves_to_latest(self):
+        nonexistent_ref = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--9999.99.9"
+        result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
+        assert result is not None
+        assert "1.11--" in result
+        assert "9999" not in result
+
+    def test_nonexistent_prefix_returns_none(self):
+        """When the prefix itself has no tags, returns None."""
+        nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_9999.99.9__1.0.0"
+        result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
+        assert result is None
+
+    def test_exact_tag_exists_returns_none(self):
+        """When the requested tag already exists, no fallback needed — returns None."""
+        result = generatePluginBuildInfo.resolve_fallback_tag(GHCR_KNOWN_REF)
+        assert result is None
+
+    def test_no_separator_in_tag_returns_none(self):
+        """Tags without a separator can't be split into prefix — returns None."""
+        result = generatePluginBuildInfo.resolve_fallback_tag("ghcr.io/org/repo:latest")
+        assert result is None
+
+    def test_unparseable_ref_returns_none(self):
+        result = generatePluginBuildInfo.resolve_fallback_tag("invalid")
+        assert result is None

--- a/scripts/tests/test_injectDpdyTagComments.py
+++ b/scripts/tests/test_injectDpdyTagComments.py
@@ -1,0 +1,329 @@
+"""Tests for injectDpdyTagComments.py — tag comment injection into dynamic-plugins.default.yaml."""
+
+import json
+
+import pytest
+
+import injectDpdyTagComments
+
+
+# ---------------------------------------------------------------------------
+# keys_for_package
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "pkg, expected",
+    [
+        pytest.param(
+            "rhdh-backstage-plugin-foo-dynamic",
+            [
+                "rhdh-backstage-plugin-foo-dynamic",
+                "rhdh-backstage-plugin-foo",
+                "red-hat-developer-hub-backstage-plugin-foo-dynamic",
+            ],
+            id="rhdh-prefix-and-dynamic-suffix",
+        ),
+        pytest.param(
+            "rhdh-backstage-plugin-foo",
+            [
+                "rhdh-backstage-plugin-foo",
+                "red-hat-developer-hub-backstage-plugin-foo",
+            ],
+            id="rhdh-prefix-no-dynamic",
+        ),
+        pytest.param(
+            "backstage-community-plugin-bar",
+            [
+                "backstage-community-plugin-bar",
+            ],
+            id="no-rhdh-prefix-no-dynamic",
+        ),
+        pytest.param(
+            "backstage-community-plugin-bar-dynamic",
+            [
+                "backstage-community-plugin-bar-dynamic",
+                "backstage-community-plugin-bar",
+            ],
+            id="no-rhdh-prefix-with-dynamic",
+        ),
+    ],
+)
+def test_keys_for_package(pkg, expected):
+    assert injectDpdyTagComments.keys_for_package(pkg) == expected
+
+
+# ---------------------------------------------------------------------------
+# package_name_from_oci_comment
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        pytest.param(
+            "  # - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo@sha256:abc",
+            "red-hat-developer-hub-backstage-plugin-foo",
+            id="quay-oci-comment",
+        ),
+        pytest.param(
+            "  # - package: oci://ghcr.io/org/repo/plugin-bar@sha256:def",
+            "plugin-bar",
+            id="ghcr-oci-comment-nested-path",
+        ),
+        pytest.param(
+            "  - package: ./dynamic-plugins/dist/foo",
+            None,
+            id="local-path-not-oci-comment",
+        ),
+        pytest.param(
+            "some random line",
+            None,
+            id="random-line",
+        ),
+    ],
+)
+def test_package_name_from_oci_comment(line, expected):
+    assert injectDpdyTagComments.package_name_from_oci_comment(line) == expected
+
+
+# ---------------------------------------------------------------------------
+# package_name_from_package_value
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        pytest.param(
+            "./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic",
+            "rhdh-backstage-plugin-foo-dynamic",
+            id="local-path",
+        ),
+        pytest.param(
+            "oci://quay.io/rhdh/plugin-bar@sha256:abc",
+            "plugin-bar",
+            id="oci-reference",
+        ),
+        pytest.param(
+            "simple-name",
+            "simple-name",
+            id="bare-name",
+        ),
+    ],
+)
+def test_package_name_from_package_value(val, expected):
+    assert injectDpdyTagComments.package_name_from_package_value(val) == expected
+
+
+# ---------------------------------------------------------------------------
+# comment_for_package
+# ---------------------------------------------------------------------------
+
+class TestCommentForPackage:
+    TAG_BY_KEY = {
+        "red-hat-developer-hub-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+        "rhdh-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+    }
+
+    def test_direct_match(self):
+        result = injectDpdyTagComments.comment_for_package(
+            "red-hat-developer-hub-backstage-plugin-foo", self.TAG_BY_KEY
+        )
+        assert result == "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+
+    def test_match_via_alias_expansion(self):
+        """rhdh- prefix is expanded to red-hat-developer-hub- for lookup."""
+        tag_by_key = {
+            "red-hat-developer-hub-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+        }
+        result = injectDpdyTagComments.comment_for_package(
+            "rhdh-backstage-plugin-foo", tag_by_key
+        )
+        assert result == "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+
+    def test_match_via_dynamic_strip(self):
+        """Stripping -dynamic suffix finds the base name in tag_by_key."""
+        tag_by_key = {
+            "rhdh-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+        }
+        result = injectDpdyTagComments.comment_for_package(
+            "rhdh-backstage-plugin-foo-dynamic", tag_by_key
+        )
+        assert result == "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+
+    def test_no_match(self):
+        result = injectDpdyTagComments.comment_for_package(
+            "unknown-plugin", self.TAG_BY_KEY
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# recent_has_tag
+# ---------------------------------------------------------------------------
+
+class TestRecentHasTag:
+    def test_tag_comment_is_last_line(self):
+        result = [
+            "  - package: foo\n",
+            "  # Tag: 1.0, Build date: 2025\n",
+        ]
+        assert injectDpdyTagComments.recent_has_tag(result) is True
+
+    def test_no_tag_comment_last_is_package(self):
+        result = ["  - package: foo\n"]
+        assert injectDpdyTagComments.recent_has_tag(result) is False
+
+    def test_empty_list(self):
+        assert injectDpdyTagComments.recent_has_tag([]) is False
+
+    def test_tag_comment_before_non_package_lines(self):
+        """Non-package, non-tag lines between the tag comment and current position."""
+        result = [
+            "  - package: foo\n",
+            "  # Tag: 1.0, Build date: 2025\n",
+            "    pluginConfig:\n",
+            "      key: value\n",
+        ]
+        assert injectDpdyTagComments.recent_has_tag(result) is True
+
+    def test_tag_belongs_to_earlier_package(self):
+        """A tag comment followed by another package line means the tag is not recent."""
+        result = [
+            "  # Tag: 1.0, Build date: 2025\n",
+            "  - package: earlier\n",
+            "    pluginConfig:\n",
+        ]
+        # Reverse iteration hits pluginConfig (skip), then "- package: earlier" (stop, no tag) -> False
+        assert injectDpdyTagComments.recent_has_tag(result) is False
+
+
+# ---------------------------------------------------------------------------
+# load_tag_by_key
+# ---------------------------------------------------------------------------
+
+class TestLoadTagByKey:
+    def test_loads_from_json_files(self, tmp_path):
+        workspace_dir = tmp_path / "plugin_builds" / "backstage"
+        workspace_dir.mkdir(parents=True)
+        data = {
+            "red-hat-developer-hub-backstage-plugin-foo": {
+                "registryReference": "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo:1.11--1.5.4",
+                "build-date": "2025-05-01",
+            }
+        }
+        (workspace_dir / "plugin-foo.json").write_text(json.dumps(data))
+
+        result = injectDpdyTagComments.load_tag_by_key(tmp_path / "plugin_builds")
+
+        assert result["red-hat-developer-hub-backstage-plugin-foo"] == ("1.11--1.5.4", "2025-05-01")
+        assert result["rhdh-backstage-plugin-foo"] == ("1.11--1.5.4", "2025-05-01")
+
+    def test_empty_dir(self, tmp_path):
+        empty_dir = tmp_path / "plugin_builds"
+        empty_dir.mkdir()
+        assert injectDpdyTagComments.load_tag_by_key(empty_dir) == {}
+
+    def test_nonexistent_dir(self, tmp_path):
+        assert injectDpdyTagComments.load_tag_by_key(tmp_path / "does_not_exist") == {}
+
+    def test_skips_entries_without_tag_or_build_date(self, tmp_path):
+        workspace_dir = tmp_path / "plugin_builds" / "ws"
+        workspace_dir.mkdir(parents=True)
+        data = {
+            "plugin-no-tag": {
+                "registryReference": "quay.io/rhdh/plugin-no-tag",
+                "build-date": "2025-05-01",
+            },
+            "plugin-no-date": {
+                "registryReference": "quay.io/rhdh/plugin-no-date:1.0",
+                "build-date": "",
+            },
+        }
+        (workspace_dir / "data.json").write_text(json.dumps(data))
+        assert injectDpdyTagComments.load_tag_by_key(tmp_path / "plugin_builds") == {}
+
+    def test_skips_invalid_json(self, tmp_path):
+        workspace_dir = tmp_path / "plugin_builds" / "ws"
+        workspace_dir.mkdir(parents=True)
+        (workspace_dir / "bad.json").write_text("not valid json!!!")
+        assert injectDpdyTagComments.load_tag_by_key(tmp_path / "plugin_builds") == {}
+
+
+# ---------------------------------------------------------------------------
+# inject
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def plugin_builds_dir(tmp_path):
+    """Create a plugin_builds directory with one workspace JSON file."""
+    workspace_dir = tmp_path / "plugin_builds" / "backstage"
+    workspace_dir.mkdir(parents=True)
+    data = {
+        "red-hat-developer-hub-backstage-plugin-foo": {
+            "registryReference": "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo:1.11--1.5.4",
+            "build-date": "2025-05-01",
+        }
+    }
+    (workspace_dir / "plugin-foo.json").write_text(json.dumps(data))
+    return tmp_path / "plugin_builds"
+
+
+class TestInject:
+    def test_inject_after_commented_oci_line(self, tmp_path, plugin_builds_dir):
+        dpdy = tmp_path / "dynamic-plugins.default.yaml"
+        dpdy.write_text(
+            "  # - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo@sha256:abc\n"
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+        )
+
+        changed = injectDpdyTagComments.inject(dpdy, plugin_builds_dir)
+
+        assert changed is True
+        assert dpdy.read_text() == (
+            "  # - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo@sha256:abc\n"
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+        )
+
+    def test_inject_before_file_path_package_line(self, tmp_path, plugin_builds_dir):
+        dpdy = tmp_path / "dynamic-plugins.default.yaml"
+        dpdy.write_text(
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+            "    pluginConfig:\n"
+            "      foo: bar\n"
+        )
+
+        changed = injectDpdyTagComments.inject(dpdy, plugin_builds_dir)
+
+        assert changed is True
+        assert dpdy.read_text() == (
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+            "    pluginConfig:\n"
+            "      foo: bar\n"
+        )
+
+    def test_no_change_when_tag_already_exists(self, tmp_path, plugin_builds_dir):
+        content = (
+            "  # - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo@sha256:abc\n"
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+        )
+        dpdy = tmp_path / "dynamic-plugins.default.yaml"
+        dpdy.write_text(content)
+
+        changed = injectDpdyTagComments.inject(dpdy, plugin_builds_dir)
+
+        assert changed is False
+        assert dpdy.read_text() == content
+
+    def test_no_change_when_no_matching_plugin(self, tmp_path):
+        empty_builds = tmp_path / "plugin_builds"
+        empty_builds.mkdir()
+        dpdy = tmp_path / "dynamic-plugins.default.yaml"
+        content = "  - package: ./dynamic-plugins/dist/unknown-plugin-dynamic\n"
+        dpdy.write_text(content)
+
+        changed = injectDpdyTagComments.inject(dpdy, empty_builds)
+
+        assert changed is False
+        assert dpdy.read_text() == content

--- a/scripts/tests/test_plugin_utils.py
+++ b/scripts/tests/test_plugin_utils.py
@@ -1,0 +1,349 @@
+"""Tests for plugin_utils module."""
+
+import json
+
+import pytest
+
+from plugin_utils import (
+    BuildReport,
+    WorkspaceMappings,
+    _match_workspace_metadata,
+    build_workspace_mappings,
+    detect_file_format,
+    load_and_resolve_to_stems,
+    load_filtered_packages_from_yaml,
+    load_packages_from_txt,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_file_format
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "file_path, expected",
+    [
+        ("file.yaml", "yaml"),
+        ("file.yml", "yaml"),
+        ("file.txt", "txt"),
+        ("file.json", "txt"),
+    ],
+)
+def test_detect_file_format(file_path, expected):
+    assert detect_file_format(file_path) == expected
+
+
+# ---------------------------------------------------------------------------
+# load_filtered_packages_from_yaml
+# ---------------------------------------------------------------------------
+
+class TestLoadFilteredPackagesFromYaml:
+    def test_returns_all_packages_from_enabled_and_disabled(self, sample_packages_yaml):
+        result = load_filtered_packages_from_yaml(sample_packages_yaml)
+        assert result == {
+            "@backstage/plugin-catalog-backend-module-github",
+            "@backstage-community/plugin-analytics-provider-segment",
+            "@backstage-community/plugin-acr",
+        }
+
+    def test_empty_packages_section(self, tmp_path):
+        yaml_file = tmp_path / "empty.yaml"
+        yaml_file.write_text("packages:\n  enabled: []\n  disabled: []\n")
+        result = load_filtered_packages_from_yaml(str(yaml_file))
+        assert result == set()
+
+    def test_missing_file_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            load_filtered_packages_from_yaml("/nonexistent/path.yaml")
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# load_packages_from_txt
+# ---------------------------------------------------------------------------
+
+class TestLoadPackagesFromTxt:
+    def test_skips_comments_and_blank_lines(self, sample_packages_txt):
+        result = load_packages_from_txt(sample_packages_txt)
+        assert result == [
+            "3scale/plugins/3scale-backend",
+            "backstage/plugins/catalog-backend-module-github",
+        ]
+
+    def test_missing_file_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            load_packages_from_txt("/nonexistent/path.txt")
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _match_workspace_metadata
+# ---------------------------------------------------------------------------
+
+class TestMatchWorkspaceMetadata:
+    def test_exact_match(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [("plugin-techdocs", "@backstage-community/plugin-techdocs")],
+            ["plugins/techdocs"],
+        )
+        assert result == {"plugin-techdocs": "ws/plugins/techdocs"}
+
+    def test_suffix_match_with_dash(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [("backstage-community-plugin-techdocs", "@backstage-community/plugin-techdocs")],
+            ["plugins/techdocs"],
+        )
+        assert result == {"backstage-community-plugin-techdocs": "ws/plugins/techdocs"}
+
+    def test_no_plugin_paths_fallback(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [
+                ("plugin-a", "@scope/plugin-a"),
+                ("plugin-b", "@scope/plugin-b"),
+            ],
+            [],
+        )
+        assert result == {
+            "plugin-a": "ws/plugin-a",
+            "plugin-b": "ws/plugin-b",
+        }
+
+    def test_multiple_stems_multiple_paths_no_collision(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [
+                ("backstage-community-plugin-techdocs", "@backstage-community/plugin-techdocs"),
+                ("backstage-community-plugin-catalog", "@backstage-community/plugin-catalog"),
+            ],
+            ["plugins/techdocs", "plugins/catalog"],
+        )
+        assert result == {
+            "backstage-community-plugin-techdocs": "ws/plugins/techdocs",
+            "backstage-community-plugin-catalog": "ws/plugins/catalog",
+        }
+
+    def test_unmatched_stems_fallback(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [
+                ("backstage-community-plugin-techdocs", "@backstage-community/plugin-techdocs"),
+                ("totally-unrelated-name", "@scope/totally-unrelated-name"),
+            ],
+            ["plugins/techdocs"],
+        )
+        assert result["backstage-community-plugin-techdocs"] == "ws/plugins/techdocs"
+        assert result["totally-unrelated-name"] == "ws/totally-unrelated-name"
+
+
+# ---------------------------------------------------------------------------
+# build_workspace_mappings
+# ---------------------------------------------------------------------------
+
+class TestBuildWorkspaceMappings:
+    def test_npm_to_stem_mapping(self, sample_workspace_dir):
+        mappings = build_workspace_mappings(sample_workspace_dir)
+        assert mappings.npm_to_stem["@backstage/plugin-catalog-backend-module-github"] == "backstage-plugin-catalog-backend-module-github"
+        assert mappings.npm_to_stem["@backstage-community/plugin-3scale-backend"] == "backstage-community-plugin-3scale-backend"
+
+    def test_stem_to_npm_mapping(self, sample_workspace_dir):
+        mappings = build_workspace_mappings(sample_workspace_dir)
+        assert mappings.stem_to_npm["backstage-plugin-catalog-backend-module-github"] == "@backstage/plugin-catalog-backend-module-github"
+        assert mappings.stem_to_npm["backstage-community-plugin-3scale-backend"] == "@backstage-community/plugin-3scale-backend"
+
+    def test_ws_path_to_npm_mapping(self, sample_workspace_dir):
+        mappings = build_workspace_mappings(sample_workspace_dir)
+        assert mappings.ws_path_to_npm["backstage/plugins/catalog-backend-module-github"] == "@backstage/plugin-catalog-backend-module-github"
+
+    def test_ws_path_to_stem_mapping(self, sample_workspace_dir):
+        mappings = build_workspace_mappings(sample_workspace_dir)
+        assert mappings.ws_path_to_stem["backstage/plugins/catalog-backend-module-github"] == "backstage-plugin-catalog-backend-module-github"
+
+    def test_empty_workspaces_dir(self, tmp_path):
+        mappings = build_workspace_mappings(tmp_path)
+        assert mappings.npm_to_stem == {}
+        assert mappings.stem_to_npm == {}
+        assert mappings.ws_path_to_npm == {}
+        assert mappings.ws_path_to_stem == {}
+
+
+# ---------------------------------------------------------------------------
+# load_and_resolve_to_stems
+# ---------------------------------------------------------------------------
+
+class TestLoadAndResolveToStems:
+    def _create_workspace(self, base_dir):
+        """Helper: create a minimal workspace for resolution tests."""
+        ws_dir = base_dir / "workspaces" / "backstage"
+        metadata_dir = ws_dir / "metadata"
+        metadata_dir.mkdir(parents=True)
+
+        (ws_dir / "plugins-list.yaml").write_text(
+            "plugins/techdocs\nplugins/catalog\n"
+        )
+
+        (metadata_dir / "backstage-community-plugin-techdocs.yaml").write_text(
+            "apiVersion: extensions.backstage.io/v1alpha1\n"
+            "kind: Package\n"
+            "metadata:\n"
+            "  name: backstage-community-plugin-techdocs\n"
+            "spec:\n"
+            '  packageName: "@backstage-community/plugin-techdocs"\n'
+        )
+
+        (metadata_dir / "backstage-community-plugin-catalog.yaml").write_text(
+            "apiVersion: extensions.backstage.io/v1alpha1\n"
+            "kind: Package\n"
+            "metadata:\n"
+            "  name: backstage-community-plugin-catalog\n"
+            "spec:\n"
+            '  packageName: "@backstage-community/plugin-catalog"\n'
+        )
+
+    def test_yaml_input_resolves_npm_to_stems(self, tmp_path):
+        self._create_workspace(tmp_path)
+
+        yaml_file = tmp_path / "packages.yaml"
+        yaml_file.write_text(
+            "packages:\n"
+            "  enabled:\n"
+            '    - package: "@backstage-community/plugin-techdocs"\n'
+        )
+
+        result = load_and_resolve_to_stems([str(yaml_file)], tmp_path)
+        assert result == {"backstage-community-plugin-techdocs"}
+
+    def test_txt_input_resolves_workspace_paths_to_stems(self, tmp_path):
+        self._create_workspace(tmp_path)
+
+        txt_file = tmp_path / "packages.txt"
+        txt_file.write_text("backstage/plugins/techdocs\n")
+
+        result = load_and_resolve_to_stems([str(txt_file)], tmp_path)
+        assert result == {"backstage-community-plugin-techdocs"}
+
+    def test_multi_file_union(self, tmp_path):
+        self._create_workspace(tmp_path)
+
+        yaml_file = tmp_path / "a.yaml"
+        yaml_file.write_text(
+            "packages:\n"
+            "  enabled:\n"
+            '    - package: "@backstage-community/plugin-techdocs"\n'
+        )
+
+        txt_file = tmp_path / "b.txt"
+        txt_file.write_text("backstage/plugins/catalog\n")
+
+        result = load_and_resolve_to_stems(
+            [str(yaml_file), str(txt_file)], tmp_path
+        )
+        assert result == {
+            "backstage-community-plugin-techdocs",
+            "backstage-community-plugin-catalog",
+        }
+
+    def test_empty_list_returns_empty(self, tmp_path):
+        result = load_and_resolve_to_stems([], tmp_path)
+        assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# BuildReport
+# ---------------------------------------------------------------------------
+
+class TestBuildReport:
+    def test_disabled_report(self):
+        report = BuildReport(None)
+        assert not report.enabled
+        # save is a no-op, should not raise
+        report.save()
+
+    def test_enabled_report_creates_file(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        assert report.enabled
+
+        report.add_plugin("plugin-a", package="@scope/plugin-a")
+        report.set_stage("plugin-a", "bootstrap", "pass")
+        report.save()
+
+        assert report_path.exists()
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["plugin-a"]["stages"]["bootstrap"]["status"] == "pass"
+
+    def test_overall_all_pass(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.set_stage("p1", "export", "pass")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["p1"]["overall"] == "pass"
+
+    def test_overall_any_fail(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.set_stage("p1", "export", "fail")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["p1"]["overall"] == "fail"
+
+    def test_overall_mixed(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.set_stage("p1", "export", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "fail")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["p1"]["overall"] == "pass"
+        assert data["plugins"]["p2"]["overall"] == "fail"
+
+    def test_summary_counts(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "fail")
+        report.add_plugin("p3")
+        report.set_stage("p3", "bootstrap", "pass")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["summary"]["total"] == 3
+        assert data["summary"]["succeeded"] == 2
+        assert data["summary"]["failed"] == 1
+
+    def test_status_success_when_no_failures(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["status"] == "success"
+
+    def test_status_partial_when_some_fail(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "fail")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["status"] == "partial"

--- a/scripts/update-index.sh
+++ b/scripts/update-index.sh
@@ -226,7 +226,7 @@ restore_metadata() {
 trap restore_metadata EXIT
 
 ##############################################
-# Step 2: Enrich plugin_builds/ with registry metadata
+# Step 2: Enrich plugin_builds/ with registry metadata (includes fallback tag resolution)
 ##############################################
 echo -e "\n${green}=== Step 2: Enrich plugin_builds/ with registry metadata ===${norm}"
 # shellcheck disable=SC2086

--- a/scripts/update-index.sh
+++ b/scripts/update-index.sh
@@ -283,13 +283,6 @@ r.save()
           '.plugins |= with_entries(.value.stages.dpdy = {status: $status})' \
           "$REPORT_FILE" > "${REPORT_FILE}.tmp" && mv "${REPORT_FILE}.tmp" "$REPORT_FILE"
     fi
-    cp "$DEFAULT_PACKAGES_FILE" "$OUTPUT_DIR/default.packages.yaml"
-    echo -e "${blue}Copied $DEFAULT_PACKAGES_FILE to $OUTPUT_DIR/default.packages.yaml${norm}"
-    if [[ -n "$REPORT_FILE" && -f "$REPORT_FILE" ]]; then
-        jq --arg status "$DPDY_STATUS" \
-          '.plugins |= with_entries(.value.stages.dpdy = {status: $status})' \
-          "$REPORT_FILE" > "${REPORT_FILE}.tmp" && mv "${REPORT_FILE}.tmp" "$REPORT_FILE"
-    fi
 else
     echo -e "\n${blue}=== Step 3: Skipped (no default.packages.yaml provided) ===${norm}"
     if [[ -n "$REPORT_FILE" && -f "$REPORT_FILE" ]]; then


### PR DESCRIPTION
### Description

Syncs downstream changes by adding a fallback mechanism to attempt to use an existing older tag for an image

Plugins with missing builds are now excluded from catalog index, but catalog index will still build to prevent one broken plugin from blocking the entire catalog index build.

All details on failing/outdated plugins will be displayed in the wiki.

Fixes [RHIDP-13209](https://redhat.atlassian.net/browse/RHIDP-13209)