### PR TITLE
fix: podman create requires dummy command for static plugin images

### DIFF
--- a/scripts/instrument-plugin.sh
+++ b/scripts/instrument-plugin.sh
@@ -115,7 +115,8 @@ while IFS= read -r PROD_IMAGE; do
 
   # Create temp container and extract plugin bundle
   WORK_DIR=$(mktemp -d)
-  CID=$(podman create "$PROD_IMAGE")
+  # Plugin images are static bundles with no CMD/ENTRYPOINT, so we provide a dummy command
+  CID=$(podman create "$PROD_IMAGE" /bin/true)
 
   if ! podman cp "$CID:$PLUGIN_PATH/dist" "$WORK_DIR/dist-original"; then
     echo "  ❌ Failed to extract plugin bundle from container - skipping"


### PR DESCRIPTION
## Problem

The `instrument` job introduced in #2383 fails when creating containers from plugin OCI images:

```
Error: no command or entrypoint provided, and no CMD or ENTRYPOINT from image
Process completed with exit code 125.
```

Plugin images are **static file bundles** (contain only JS/CSS assets, no executable). They have no `CMD` or `ENTRYPOINT` defined. Running `podman create` without a command argument fails.

## Fix

Pass `/bin/true` as a dummy command:

```bash
CID=$(podman create "$PROD_IMAGE" /bin/true)
```

The container is never actually run - it's only created so we can extract files with `podman cp`. The dummy command satisfies podman's requirement.

## Testing

Validated fix against the failed run:
- **Failed run**: https://github.com/redhat-developer/rhdh-plugin-export-overlays/actions/runs/26902663501
- **Test PR**: #2550

After merge, will re-run `/publish` on #2550 to validate end-to-end coverage collection.

## Impact

Without this fix, **all coverage collection is broken** - the `instrument` job fails immediately for every workspace.