### PR TITLE
chore(e2e): bump @red-hat-developer-hub/e2e-test-utils to 1.1.45

### DIFF
--- a/workspaces/acr/e2e-tests/package.json
+++ b/workspaces/acr/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/acr/e2e-tests/yarn.lock
+++ b/workspaces/acr/e2e-tests/yarn.lock
@@ -282,9 +282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -307,7 +307,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -551,7 +551,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/adoption-insights/e2e-tests/package.json
+++ b/workspaces/adoption-insights/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "1.57.0",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/adoption-insights/e2e-tests/yarn.lock
+++ b/workspaces/adoption-insights/e2e-tests/yarn.lock
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -379,7 +379,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -765,7 +765,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:1.57.0"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/analytics/e2e-tests/package.json
+++ b/workspaces/analytics/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/analytics/e2e-tests/yarn.lock
+++ b/workspaces/analytics/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -577,7 +577,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/app-defaults/e2e-tests/package.json
+++ b/workspaces/app-defaults/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/app-defaults/e2e-tests/yarn.lock
+++ b/workspaces/app-defaults/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -567,7 +567,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/argocd/e2e-tests/package.json
+++ b/workspaces/argocd/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/argocd/e2e-tests/yarn.lock
+++ b/workspaces/argocd/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -572,7 +572,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/backstage/e2e-tests/package.json
+++ b/workspaces/backstage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/backstage/e2e-tests/yarn.lock
+++ b/workspaces/backstage/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -626,7 +626,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/bulk-import/e2e-tests/package.json
+++ b/workspaces/bulk-import/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "^1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.44",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/bulk-import/e2e-tests/yarn.lock
+++ b/workspaces/bulk-import/e2e-tests/yarn.lock
@@ -361,9 +361,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.44":
-  version: 1.1.44
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.44"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -386,7 +386,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/530f63e45c5ed712c9960ad80c13592f8f09b50c0d7d8c045b0d2c1d0203f189986f9378be03f16a336b114cfd92444ef3f7051623348dbf3bcaa095d5d5f000
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -991,7 +991,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:^1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.44"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/extensions/e2e-tests/package.json
+++ b/workspaces/extensions/e2e-tests/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "dotenv": "17.4.1",
     "eslint": "10.2.0",

--- a/workspaces/extensions/e2e-tests/yarn.lock
+++ b/workspaces/extensions/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1021,7 +1021,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:17.4.1"
     eslint: "npm:10.2.0"

--- a/workspaces/github/e2e-tests/package.json
+++ b/workspaces/github/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/github/e2e-tests/yarn.lock
+++ b/workspaces/github/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1187,7 +1187,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/global-header/e2e-tests/package.json
+++ b/workspaces/global-header/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/global-header/e2e-tests/yarn.lock
+++ b/workspaces/global-header/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1246,7 +1246,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/homepage/e2e-tests/package.json
+++ b/workspaces/homepage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/homepage/e2e-tests/yarn.lock
+++ b/workspaces/homepage/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1312,7 +1312,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/keycloak/e2e-tests/package.json
+++ b/workspaces/keycloak/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/keycloak/e2e-tests/yarn.lock
+++ b/workspaces/keycloak/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1482,7 +1482,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/orchestrator/e2e-tests/package.json
+++ b/workspaces/orchestrator/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.44",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "dotenv": "16.6.1",
     "eslint": "10.2.0",

--- a/workspaces/orchestrator/e2e-tests/yarn.lock
+++ b/workspaces/orchestrator/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.44":
-  version: 1.1.44
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.44"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/530f63e45c5ed712c9960ad80c13592f8f09b50c0d7d8c045b0d2c1d0203f189986f9378be03f16a336b114cfd92444ef3f7051623348dbf3bcaa095d5d5f000
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1771,7 +1771,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.44"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:16.6.1"
     eslint: "npm:10.2.0"

--- a/workspaces/quay/e2e-tests/package.json
+++ b/workspaces/quay/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quay/e2e-tests/yarn.lock
+++ b/workspaces/quay/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/quickstart/e2e-tests/package.json
+++ b/workspaces/quickstart/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quickstart/e2e-tests/yarn.lock
+++ b/workspaces/quickstart/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1955,7 +1955,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/rbac/e2e-tests/package.json
+++ b/workspaces/rbac/e2e-tests/package.json
@@ -26,7 +26,7 @@
     "@backstage-community/plugin-rbac-common": "1.26.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/rbac/e2e-tests/yarn.lock
+++ b/workspaces/rbac/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1933,7 +1933,7 @@ __metadata:
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/roadie-backstage-plugins/e2e-tests/package.json
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10c0/6efa834364be2fc969e81a68df8e565c33545afc6a3b03c47cead46774a620e32ecdc5a23ffe9dbc92a7ce5b489f68bdff4c43f4aaaf8f5884d8ec6798b7de1a
+  checksum: 10c0/2286203eb06490482472c4127ec3afdecfe3ef3f9908d2bc472b9725d28079aaf9f0f3e9b0e345d07878327f075964c171cc66b90e88c492151a01fd27e0d32b
   languageName: node
   linkType: hard
 
@@ -1936,7 +1936,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scorecard/e2e-tests/package.json
+++ b/workspaces/scorecard/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
+++ b/workspaces/scorecard/e2e-tests/tests/specs/scorecard.spec.ts
@@ -84,8 +84,10 @@ test.describe.serial("Scorecard Plugin Tests", () => {
       jiraMetric.title,
     );
   });
+
   test.describe("Aggregated scorecard drill-down", () => {
     test.describe.configure({ retries: 1 });
+
     test("Aggregated scorecard (GitHub): info tooltips, drill-down, table UI", async () => {
       const [githubMetric] = SCORECARD_METRICS;
       await aggregated.runAggregatedScorecardDrilldownScenario(
@@ -196,12 +198,8 @@ test.describe.serial("Scorecard Plugin Tests", () => {
       await scorecard.expectScorecardHidden(githubMetric.title);
       await scorecard.expectScorecardHidden(jiraMetric.title);
       await scorecard.expectScorecardHidden(maintainedMetric.title);
-      await scorecard.expectScorecardHidden(
-        FILECHECK_METRICS.readme.title,
-      );
-      await scorecard.expectScorecardHidden(
-        FILECHECK_METRICS.license.title,
-      );
+      await scorecard.expectScorecardHidden(FILECHECK_METRICS.readme.title);
+      await scorecard.expectScorecardHidden(FILECHECK_METRICS.license.title);
 
       for (const metric of OPENSSF_LICENSE_SCORECARD) {
         await scorecard.validateScorecardAriaFor(metric);
@@ -296,7 +294,6 @@ test.describe.serial("Scorecard Plugin Tests", () => {
     ] as const;
 
     for (const { entity, key, expected } of filecheckCases) {
-      // eslint-disable-next-line playwright/no-skipped-test
       // TODO: Re-enable once https://redhat.atlassian.net/browse/RHDHBUGS-3294 is fixed
       test.skip(`filecheck.${key} is '${expected}' for ${entity}`, async () => {
         test.skip(

--- a/workspaces/scorecard/e2e-tests/yarn.lock
+++ b/workspaces/scorecard/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tekton/e2e-tests/package.json
+++ b/workspaces/tekton/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tekton/e2e-tests/yarn.lock
+++ b/workspaces/tekton/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -2097,7 +2097,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/theme/e2e-tests/package.json
+++ b/workspaces/theme/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/theme/e2e-tests/yarn.lock
+++ b/workspaces/theme/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -2106,7 +2106,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/topology/e2e-tests/package.json
+++ b/workspaces/topology/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/topology/e2e-tests/yarn.lock
+++ b/workspaces/topology/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
+  version: 1.1.45
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
   languageName: node
   linkType: hard
 
@@ -2133,7 +2133,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
JIRA: https://redhat.atlassian.net/browse/RHDHBUGS-3309
## Summary

- Bumps `@red-hat-developer-hub/e2e-test-utils` from `1.1.43`/`1.1.44` → `1.1.45` across all 23 workspace `e2e-tests/` directories, including `yarn.lock` updates.
- `1.1.45` fixes a 404 when fetching `default.packages.yaml` in nightly mode — the file moved from the `rhdh` repo to `rhdh-plugin-export-overlays`; the fix fetches from the correct repo for all branches except `release-1.10`.

Assisted-by: Claude Code