### PR TITLE
chore(backstage): export some additional plugins

### DIFF
--- a/workspaces/backstage/metadata/backstage-plugin-app-visualizer.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-app-visualizer.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-app-visualizer
+  namespace: rhdh
+  title: 'App Visualizer Frontend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/app-visualizer
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/app-visualizer
+  tags: []
+spec:
+  packageName: '@backstage/plugin-app-visualizer'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-app-visualizer
+  version: 0.2.1
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - app-visualizer
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-openapi.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-openapi.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-catalog-backend-module-openapi
+  namespace: rhdh
+  title: 'Catalog Backend Module OpenAPI'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/catalog-backend-module-openapi
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/catalog-backend-module-openapi
+  tags: []
+spec:
+  packageName: '@backstage/plugin-catalog-backend-module-openapi'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-openapi-dynamic
+  version: 0.2.20
+  backstage:
+    role: backend-plugin-module
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - catalog
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-catalog-backend
+  namespace: rhdh
+  title: 'Catalog Backend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/catalog-backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/catalog-backend
+  tags: []
+spec:
+  packageName: '@backstage/plugin-catalog-backend'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-dynamic
+  version: 3.5.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - catalog
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-catalog.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-catalog
+  namespace: rhdh
+  title: 'Catalog Frontend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/catalog
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/catalog
+  tags: []
+spec:
+  packageName: '@backstage/plugin-catalog'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog
+  version: 2.0.1
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - catalog
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-scaffolder-backend.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-scaffolder-backend.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-scaffolder-backend
+  namespace: rhdh
+  title: 'Scaffolder Backend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/scaffolder-backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/scaffolder-backend
+  tags: []
+spec:
+  packageName: '@backstage/plugin-scaffolder-backend'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-dynamic
+  version: 3.3.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - scaffolder
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-scaffolder.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-scaffolder.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-scaffolder
+  namespace: rhdh
+  title: 'Scaffolder Frontend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/scaffolder
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/scaffolder
+  tags: []
+spec:
+  packageName: '@backstage/plugin-scaffolder'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder
+  version: 1.36.1
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - scaffolder
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-search-backend-module-catalog.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-search-backend-module-catalog.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-search-backend-module-catalog
+  namespace: rhdh
+  title: 'Search Backend Module Catalog'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/search-backend-module-catalog
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/search-backend-module-catalog
+  tags: []
+spec:
+  packageName: '@backstage/plugin-search-backend-module-catalog'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-search-backend-module-catalog-dynamic
+  version: 0.3.13
+  backstage:
+    role: backend-plugin-module
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - search
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-search-backend-module-pg.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-search-backend-module-pg.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-search-backend-module-pg
+  namespace: rhdh
+  title: 'Search Backend Module PG'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/search-backend-module-pg
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/search-backend-module-pg
+  tags: []
+spec:
+  packageName: '@backstage/plugin-search-backend-module-pg'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-search-backend-module-pg-dynamic
+  version: 0.5.53
+  backstage:
+    role: backend-plugin-module
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - search
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-search-backend.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-search-backend.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-search-backend
+  namespace: rhdh
+  title: 'Search Backend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/search-backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/search-backend
+  tags: []
+spec:
+  packageName: '@backstage/plugin-search-backend'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-search-backend-dynamic
+  version: 2.1.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - search
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-search.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-search.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-search
+  namespace: rhdh
+  title: 'Search Frontend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/search
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/search
+  tags: []
+spec:
+  packageName: '@backstage/plugin-search'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-search
+  version: 1.7.0
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - search
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-user-settings-backend.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-user-settings-backend.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-user-settings-backend
+  namespace: rhdh
+  title: 'User Settings Backend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/user-settings-backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/user-settings-backend
+  tags: []
+spec:
+  packageName: '@backstage/plugin-user-settings-backend'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-user-settings-backend-dynamic
+  version: 0.4.1
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - user-settings
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/metadata/backstage-plugin-user-settings.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-user-settings.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-user-settings
+  namespace: rhdh
+  title: 'User Settings Frontend'
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/v1.49.4/plugins/user-settings
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/v1.49.4/plugins/user-settings
+  tags: []
+spec:
+  packageName: '@backstage/plugin-user-settings'
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-user-settings
+  version: 0.9.1
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - user-settings
+  appConfigExamples:
+    - title: Default configuration
+      content: {}

--- a/workspaces/backstage/plugins-list.yaml
+++ b/workspaces/backstage/plugins-list.yaml
@@ -2,7 +2,7 @@
 plugins/api-docs:
 #plugins/app: ==> Added as a static plugin in RHDH
 #plugins/app-backend: ==> Added as a static plugin in RHDH
-#plugins/app-visualizer: ==> Added as a static plugin in RHDH
+plugins/app-visualizer:
 plugins/auth-backend-module-atlassian-provider:
 plugins/auth-backend-module-auth0-provider:
 plugins/auth-backend-module-aws-alb-provider:
@@ -46,11 +46,11 @@ plugins/catalog-backend-module-openapi:
 plugins/catalog-backend-module-puppetdb:
 plugins/catalog-backend-module-scaffolder-entity-model:
 plugins/catalog-backend-module-unprocessed:
-#plugins/catalog-backend: ==> Added as a static plugin in RHDH
+plugins/catalog-backend:
 plugins/catalog-graph:
 plugins/catalog-import:
 plugins/catalog-unprocessed-entities:
-#plugins/catalog: ==> Added as a static plugin in RHDH
+plugins/catalog:
 plugins/config-schema:
 plugins/devtools:
 plugins/devtools-backend:
@@ -79,8 +79,8 @@ plugins/org:
 #plugins/permission-backend: ==> Added as a static plugin in RHDH
 #plugins/permission-backend-module-policy-allow-all: ==> Not meaningful for RHDH
 plugins/proxy-backend:
-#plugins/scaffolder: ==> Added as a static plugin in RHDH
-#plugins/scaffolder-backend: ==> Added as a static plugin in RHDH
+plugins/scaffolder:
+plugins/scaffolder-backend:
 plugins/scaffolder-backend-module-azure:
 plugins/scaffolder-backend-module-bitbucket-cloud:
 plugins/scaffolder-backend-module-bitbucket-server:
@@ -95,14 +95,14 @@ plugins/scaffolder-backend-module-notifications:
 plugins/scaffolder-backend-module-rails:
 plugins/scaffolder-backend-module-sentry:
 plugins/scaffolder-backend-module-yeoman:
-#plugins/search-backend-module-catalog: ==> Added as a static plugin in RHDH
+plugins/search-backend-module-catalog:
 plugins/search-backend-module-elasticsearch:
 plugins/search-backend-module-explore:
 plugins/search-backend-module-pg:
 plugins/search-backend-module-stack-overflow-collator:
 plugins/search-backend-module-techdocs:
-#plugins/search-backend: ==> Added as a static plugin in RHDH
-#plugins/search: ==> Added as a static plugin in RHDH
+plugins/search-backend:
+plugins/search:
 plugins/signals:
 plugins/signals-backend:
 plugins/techdocs:


### PR DESCRIPTION
This change adds entries to produce dynamic plugins for some modules that are currently statically loaded by RHDH to eventually enable them to be loaded dynamically.

Assisted-By: Cursor Desktop

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED