### PR TITLE
fix: use 'true' instead of '1' for E2E_COLLECT_COVERAGE

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -33,7 +33,7 @@ set -euo pipefail
 #   # Coverage collection is ENABLED BY DEFAULT
 #   # Requires e2e-test-utils >= 1.x.x for automatic -coverage image swap
 #   # To disable for faster local development:
-#   E2E_COLLECT_COVERAGE=0 ./run-e2e.sh -w tech-radar
+#   E2E_COLLECT_COVERAGE=false ./run-e2e.sh -w tech-radar
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -69,11 +69,11 @@ E2E_NIGHTLY_MODE="${E2E_NIGHTLY_MODE:-false}"
 # images (plugin:tag__coverage) that e2e-test-utils will load when available.
 #
 # For nightly/local: Depends on e2e-test-utils automatic image swap logic
-# (PR #95, not yet released). Until that lands, coverage collection will be
+# (PR #95, merged 2026-06-04). Until that lands, coverage collection will be
 # skipped silently (no -coverage images exist).
 #
-# To disable (faster local dev): E2E_COLLECT_COVERAGE=0
-export E2E_COLLECT_COVERAGE="${E2E_COLLECT_COVERAGE:-1}"
+# To disable (faster local dev): E2E_COLLECT_COVERAGE=false
+export E2E_COLLECT_COVERAGE="${E2E_COLLECT_COVERAGE:-true}"
 
 # Local e2e-test-utils: absolute path to use a local build instead of npm
 E2E_TEST_UTILS_PATH="${E2E_TEST_UTILS_PATH:-}"
@@ -264,8 +264,8 @@ for ws in "${E2E_WORKSPACES[@]}"; do
     done <<< "$PROJECTS_BLOCK"
 done
 
-if [[ "${E2E_COLLECT_COVERAGE:-}" == "1" ]]; then
-    echo "[INFO] Coverage collection enabled (E2E_COLLECT_COVERAGE=1)"
+if [[ "${E2E_COLLECT_COVERAGE:-}" == "true" ]]; then
+    echo "[INFO] Coverage collection enabled (E2E_COLLECT_COVERAGE=true)"
 fi
 
 cat > playwright.config.ts <<CONFIGEOF
@@ -311,7 +311,7 @@ TEST_EXIT_CODE=0
 npx playwright test "${PLAYWRIGHT_ARGS[@]+"${PLAYWRIGHT_ARGS[@]}"}" || TEST_EXIT_CODE=$?
 
 # ── Merge coverage data ──────────────────────────────────────────────────
-if [[ "${E2E_COLLECT_COVERAGE:-}" == "1" ]]; then
+if [[ "${E2E_COLLECT_COVERAGE:-}" == "true" ]]; then
     if [[ -d "node_modules/.cache/e2e-test-results/coverage" ]]; then
         "$SCRIPT_DIR/scripts/report-coverage.sh" "${E2E_WORKSPACES[@]}"
     else

--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -6,7 +6,7 @@
 #   ./scripts/report-coverage.sh <workspace> [workspace...]
 #
 # Example:
-#   E2E_COLLECT_COVERAGE=1 ./run-e2e.sh -w tech-radar
+#   E2E_COLLECT_COVERAGE=true ./run-e2e.sh -w tech-radar
 #   ./scripts/report-coverage.sh tech-radar
 #
 # The script:

--- a/scripts/upload-coverage.sh
+++ b/scripts/upload-coverage.sh
@@ -6,7 +6,7 @@
 #   ./scripts/upload-coverage.sh <workspace-name>
 #
 # Example:
-#   E2E_COLLECT_COVERAGE=1 ./run-e2e.sh -w tech-radar
+#   E2E_COLLECT_COVERAGE=true ./run-e2e.sh -w tech-radar
 #   ./scripts/upload-coverage.sh tech-radar
 #
 # The script reads source.json to determine the upstream repo and SHA,
@@ -28,7 +28,7 @@ LCOV_FILE="$COVERAGE_DIR/lcov.info"
 
 if [[ ! -f "$LCOV_FILE" ]]; then
   echo "ERROR: No lcov file found at $LCOV_FILE" >&2
-  echo "Run tests with E2E_COLLECT_COVERAGE=1 first" >&2
+  echo "Run tests with E2E_COLLECT_COVERAGE=true first" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Aligns E2E_COLLECT_COVERAGE value with e2e-test-utils PR #95.

## Problem

After merging redhat-developer/rhdh-e2e-test-utils#95, coverage collection stopped working because:
- This repo sets `E2E_COLLECT_COVERAGE=1` (in run-e2e.sh)
- e2e-test-utils now checks for `E2E_COLLECT_COVERAGE === "true"`
- Mismatch causes coverage fixture to return early without collecting

## Fix

Updated all occurrences from "1" to "true" to match:
- run-e2e.sh: default value and all conditional checks
- scripts/upload-coverage.sh: examples and error messages
- scripts/report-coverage.sh: examples

This aligns with the boolean env var convention used elsewhere (E2E_NIGHTLY_MODE, etc).

## Testing

After merge, re-run /publish on PR #2550 to validate end-to-end coverage collection.