### PR TITLE
chore: cherry pick catalog index generation to `release-1.10`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/build-report.json

--- a/.github/workflows/generate-catalog-index.yaml
+++ b/.github/workflows/generate-catalog-index.yaml
@@ -13,6 +13,7 @@ on:
       - 'rhdh-community-packages.txt'
       - 'scripts/**'
       - 'versions.json'
+      - '.github/workflows/generate-catalog-index.yaml'
   workflow_dispatch:
     inputs:
       source-branch:
@@ -111,14 +112,22 @@ jobs:
         id: versions
         run: |
           BS_VERSION=$(jq -r '.backstage' versions.json)
-          CLI_VERSION=$(jq -r '.cli' versions.json)
-          # CLI version is aligned with RHDH version
-          RHDH_VERSION=$(echo "$CLI_VERSION" | grep -oP '^\d+\.\d+')
+
+          # Fetch RHDH version from upstream package.json (matches downstream approach)
+          RHDH_FULL_VERSION=$(curl -sSLf \
+            "https://raw.githubusercontent.com/redhat-developer/rhdh/refs/heads/${GITHUB_REF_NAME}/package.json" \
+            | jq -r '.version') || true
+          if [[ -n "$RHDH_FULL_VERSION" && "$RHDH_FULL_VERSION" != "null" ]]; then
+            RHDH_VERSION="${RHDH_FULL_VERSION%.*}"
+          else
+            echo "::warning::Failed to fetch RHDH version from upstream for branch ${GITHUB_REF_NAME}"
+            RHDH_VERSION=""
+          fi
 
           echo "backstage-version=$BS_VERSION" >> "$GITHUB_OUTPUT"
           echo "rhdh-version=$RHDH_VERSION" >> "$GITHUB_OUTPUT"
           echo "Backstage version: $BS_VERSION"
-          echo "RHDH version: $RHDH_VERSION (from cli $CLI_VERSION)"
+          echo "RHDH version: $RHDH_VERSION (from upstream RHDH $RHDH_BRANCH package.json: $RHDH_FULL_VERSION)"
 
       - name: Generate supported catalog
         id: gen-supported
@@ -140,6 +149,7 @@ jobs:
             --plugin-builds-dir plugin_builds/supported \
             --packages-file default.packages.yaml \
             --packages-file rhdh-supported-packages.txt \
+            --report-file catalog-index/supported/build-report.json \
             $COMMUNITY_ARG \
             $RHDH_VERSION_ARG; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
@@ -165,22 +175,12 @@ jobs:
             --output-dir catalog-index/community \
             --plugin-builds-dir plugin_builds/community \
             --packages-file rhdh-community-packages.txt \
+            --report-file catalog-index/community/build-report.json \
             $RHDH_VERSION_ARG; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::Community catalog generation failed"
             echo "ok=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check if any tier succeeded
-        id: check-success
-        env:
-          SUPPORTED_OK: ${{ steps.gen-supported.outputs.ok }}
-          COMMUNITY_OK: ${{ steps.gen-community.outputs.ok }}
-        run: |
-          if [[ "${SUPPORTED_OK}" != "true" && "${COMMUNITY_OK}" != "true" ]]; then
-            echo "::error::Both supported and community catalog generation failed"
-            exit 1
           fi
 
       - name: Write build-info.json
@@ -246,10 +246,20 @@ jobs:
           path: catalog-index/
           retention-days: 3
 
+      - name: Check generation results
+        env:
+          SUPPORTED_OK: ${{ steps.gen-supported.outputs.ok }}
+          COMMUNITY_OK: ${{ steps.gen-community.outputs.ok }}
+        run: |
+          if [[ "${SUPPORTED_OK}" != "true" || "${COMMUNITY_OK}" != "true" ]]; then
+            echo "::error::Catalog generation failed (supported=$SUPPORTED_OK, community=$COMMUNITY_OK)"
+            exit 1
+          fi
+
   publish-supported:
     runs-on: ubuntu-latest
     needs: generate
-    if: needs.generate.outputs.supported-ok == 'true'
+    if: always() && needs.generate.outputs.supported-ok == 'true'
     permissions:
       packages: write
 
@@ -258,7 +268,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.generate.outputs.source-branch }}
-          sparse-checkout: Dockerfile.catalog-index
+          sparse-checkout: |
+            Dockerfile.catalog-index
+            .dockerignore
 
       - name: Download catalog-index artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -269,19 +281,21 @@ jobs:
       - name: Build OCI image
         env:
           BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+          RHDH_VERSION: ${{ needs.generate.outputs.rhdh-version }}
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
           podman build \
             -f Dockerfile.catalog-index \
             --build-arg TIER=supported \
-            -t "plugin-catalog-index:bs_${BS_VERSION}-${SHORT_SHA}" \
-            -t "plugin-catalog-index:bs_${BS_VERSION}" \
+            -t "plugin-catalog-index:${RHDH_VERSION}-bs_${BS_VERSION}-${SHORT_SHA}" \
+            -t "plugin-catalog-index:${RHDH_VERSION}-bs_${BS_VERSION}" \
             -t "plugin-catalog-index:latest" \
             .
 
       - name: Push OCI image to quay.io
         env:
           BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+          RHDH_VERSION: ${{ needs.generate.outputs.rhdh-version }}
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
         run: |
@@ -289,7 +303,7 @@ jobs:
 
           echo "${QUAY_TOKEN}" | podman login quay.io -u "${QUAY_USERNAME}" --password-stdin
 
-          for tag in "bs_${BS_VERSION}-${SHORT_SHA}" "bs_${BS_VERSION}" "latest"; do
+          for tag in "${RHDH_VERSION}-bs_${BS_VERSION}-${SHORT_SHA}" "${RHDH_VERSION}-bs_${BS_VERSION}" "latest"; do
             podman tag "plugin-catalog-index:${tag}" "${SUPPORTED_CATALOG_INDEX}:${tag}"
             podman push "${SUPPORTED_CATALOG_INDEX}:${tag}"
             echo "Pushed ${SUPPORTED_CATALOG_INDEX}:${tag}"
@@ -298,7 +312,7 @@ jobs:
   publish-community:
     runs-on: ubuntu-latest
     needs: generate
-    if: needs.generate.outputs.community-ok == 'true'
+    if: always() && needs.generate.outputs.community-ok == 'true'
     permissions:
       packages: write
 
@@ -307,7 +321,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.generate.outputs.source-branch }}
-          sparse-checkout: Dockerfile.catalog-index
+          sparse-checkout: |
+            Dockerfile.catalog-index
+            .dockerignore
 
       - name: Download catalog-index artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -318,19 +334,21 @@ jobs:
       - name: Build OCI image
         env:
           BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+          RHDH_VERSION: ${{ needs.generate.outputs.rhdh-version }}
         run: |
           SHORT_SHA="${GITHUB_SHA:0:7}"
           podman build \
             -f Dockerfile.catalog-index \
             --build-arg TIER=community \
-            -t "plugin-catalog-index:bs_${BS_VERSION}-${SHORT_SHA}" \
-            -t "plugin-catalog-index:bs_${BS_VERSION}" \
+            -t "plugin-catalog-index:${RHDH_VERSION}-bs_${BS_VERSION}-${SHORT_SHA}" \
+            -t "plugin-catalog-index:${RHDH_VERSION}-bs_${BS_VERSION}" \
             -t "plugin-catalog-index:latest" \
             .
 
       - name: Push OCI image to ghcr.io
         env:
           BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+          RHDH_VERSION: ${{ needs.generate.outputs.rhdh-version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_ACTOR: ${{ github.actor }}
         run: |
@@ -338,8 +356,172 @@ jobs:
 
           echo "${GITHUB_TOKEN}" | podman login ghcr.io -u "${GH_ACTOR}" --password-stdin
 
-          for tag in "bs_${BS_VERSION}-${SHORT_SHA}" "bs_${BS_VERSION}" "latest"; do
+          for tag in "${RHDH_VERSION}-bs_${BS_VERSION}-${SHORT_SHA}" "${RHDH_VERSION}-bs_${BS_VERSION}" "latest"; do
             podman tag "plugin-catalog-index:${tag}" "${COMMUNITY_CATALOG_INDEX}:${tag}"
             podman push "${COMMUNITY_CATALOG_INDEX}:${tag}"
             echo "Pushed ${COMMUNITY_CATALOG_INDEX}:${tag}"
           done
+
+  update-status:
+    runs-on: ubuntu-latest
+    needs: [generate, publish-supported, publish-community]
+    if: always() && needs.generate.result != 'cancelled'
+    permissions:
+      contents: write
+      packages: read
+
+    steps:
+      - name: Checkout catalog-index branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.generate.outputs.target-branch }}
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install pyyaml requests
+
+      - name: Update build reports with publish status
+        env:
+          PUBLISH_SUPPORTED_RESULT: ${{ needs.publish-supported.result }}
+          PUBLISH_COMMUNITY_RESULT: ${{ needs.publish-community.result }}
+          BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+          RHDH_VERSION: ${{ needs.generate.outputs.rhdh-version }}
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          TAG="${RHDH_VERSION}-bs_${BS_VERSION}-${SHORT_SHA}"
+
+          for TIER in supported community; do
+            REPORT="catalog-index/$TIER/build-report.json"
+            if [[ ! -f "$REPORT" ]]; then
+              echo "No report for $TIER tier, skipping"
+              continue
+            fi
+
+            if [[ "$TIER" == "supported" ]]; then
+              RESULT="${PUBLISH_SUPPORTED_RESULT}"
+              IMAGE="${SUPPORTED_CATALOG_INDEX}:${TAG}"
+            else
+              RESULT="${PUBLISH_COMMUNITY_RESULT}"
+              IMAGE="${COMMUNITY_CATALOG_INDEX}:${TAG}"
+            fi
+
+            jq --arg image "$IMAGE" \
+              '.metadata["catalog-index-image"] = $image' \
+              "$REPORT" > "${REPORT}.tmp" && mv "${REPORT}.tmp" "$REPORT"
+
+            if [[ "$RESULT" == "success" ]]; then
+              jq --arg sha "$GITHUB_SHA" \
+                '.metadata["last-successful-publish"] = $sha' \
+                "$REPORT" > "${REPORT}.tmp" && mv "${REPORT}.tmp" "$REPORT"
+            fi
+            echo "Updated $TIER report: publish=$RESULT, image=$IMAGE"
+          done
+
+      - name: Render catalog status page
+        env:
+          SOURCE_BRANCH: ${{ needs.generate.outputs.source-branch }}
+          TARGET_BRANCH: ${{ needs.generate.outputs.target-branch }}
+          BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+          RHDH_VERSION: ${{ needs.generate.outputs.rhdh-version }}
+          SOURCE_REPO: ${{ github.server_url }}/${{ github.repository }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          ARGS=""
+          if [[ -f catalog-index/supported/build-report.json ]]; then
+            ARGS="$ARGS --supported catalog-index/supported/build-report.json"
+          fi
+          if [[ -f catalog-index/community/build-report.json ]]; then
+            ARGS="$ARGS --community catalog-index/community/build-report.json"
+          fi
+
+          if [[ -z "$ARGS" ]]; then
+            echo "No build reports found to render"
+            exit 0
+          fi
+
+          # shellcheck disable=SC2086
+          python3 scripts/renderCatalogStatus.py \
+            $ARGS \
+            --source-repo "$SOURCE_REPO" \
+            --source-branch "$SOURCE_BRANCH" \
+            --target-branch "$TARGET_BRANCH" \
+            --source-commit "$GITHUB_SHA" \
+            --backstage-version "$BS_VERSION" \
+            --rhdh-version "$RHDH_VERSION" \
+            --workflow-run-url "$WORKFLOW_RUN_URL" \
+            --output /tmp/catalog-status.md
+
+          # Write the same status page to the GitHub Job Summary
+          if [[ -f /tmp/catalog-status.md ]]; then
+            cat /tmp/catalog-status.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Commit updated reports
+        env:
+          TARGET_BRANCH: ${{ needs.generate.outputs.target-branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add catalog-index/
+          if git diff --cached --quiet; then
+            echo "No report changes to commit"
+          else
+            SHORT_SHA="${GITHUB_SHA:0:7}"
+            git commit -m "Update build reports with publish status from ${SHORT_SHA}"
+            git push origin "$TARGET_BRANCH"
+          fi
+
+      - name: Checkout wiki
+        id: wiki-checkout
+        continue-on-error: true
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push status to wiki
+        if: steps.wiki-checkout.outcome == 'success'
+        env:
+          SOURCE_BRANCH: ${{ needs.generate.outputs.source-branch }}
+        run: |
+          if [[ ! -f /tmp/catalog-status.md ]]; then
+            echo "No status page to push"
+            exit 0
+          fi
+
+          PAGE_NAME="Plugin-Catalog-Status-${SOURCE_BRANCH}"
+          cp /tmp/catalog-status.md "wiki/${PAGE_NAME}.md"
+
+          # Update the index page with links to all branch status pages
+          INDEX_FILE="wiki/Plugin-Catalog-Index-Status.md"
+          echo "# Plugin Catalog Index Status" > "$INDEX_FILE"
+          echo "" >> "$INDEX_FILE"
+          echo "Per-branch status pages for the plugin catalog index generation." >> "$INDEX_FILE"
+          echo "" >> "$INDEX_FILE"
+          echo "| Branch | Status Page |" >> "$INDEX_FILE"
+          echo "|--------|-------------|" >> "$INDEX_FILE"
+          for f in wiki/Plugin-Catalog-Status-*.md; do
+            if [[ -f "$f" ]]; then
+              BRANCH_NAME=$(basename "$f" .md | sed 's/^Plugin-Catalog-Status-//')
+              echo "| ${BRANCH_NAME} | [View]($(basename "$f" .md)) |" >> "$INDEX_FILE"
+            fi
+          done
+          echo "" >> "$INDEX_FILE"
+
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes to commit"
+          else
+            git commit -m "Update catalog status for ${SOURCE_BRANCH} [automated]"
+            git push
+          fi

--- a/.github/workflows/generate-catalog-index.yaml
+++ b/.github/workflows/generate-catalog-index.yaml
@@ -1,0 +1,345 @@
+name: Generate Catalog Index
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release-**'
+    paths:
+      - 'workspaces/*/metadata/*.yaml'
+      - 'catalog-entities/extensions/**'
+      - 'default.packages.yaml'
+      - 'rhdh-supported-packages.txt'
+      - 'rhdh-community-packages.txt'
+      - 'scripts/**'
+      - 'versions.json'
+  workflow_dispatch:
+    inputs:
+      source-branch:
+        description: 'Source branch to generate catalog from (default: current branch)'
+        required: false
+        type: string
+        default: ''
+      target-branch:
+        description: 'Target branch to push catalog-index to (default: catalog-index-{source-branch})'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: catalog-index-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: 'quay.io/rhdh'
+  COMMUNITY_REGISTRY: 'ghcr.io/redhat-developer/rhdh-plugin-export-overlays'
+  COMMUNITY_CATALOG_INDEX: 'ghcr.io/redhat-developer/rhdh-plugin-export-overlays/plugin-catalog-index'
+  SUPPORTED_CATALOG_INDEX: 'quay.io/rhdh-community/plugin-catalog-index'
+  YQ_VERSION: '4.53.2'
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      supported-ok: ${{ steps.gen-supported.outputs.ok }}
+      community-ok: ${{ steps.gen-community.outputs.ok }}
+      backstage-version: ${{ steps.versions.outputs.backstage-version }}
+      rhdh-version: ${{ steps.versions.outputs.rhdh-version }}
+      source-branch: ${{ steps.branches.outputs.source-branch }}
+      target-branch: ${{ steps.branches.outputs.target-branch }}
+
+    steps:
+      - name: Determine branches
+        id: branches
+        env:
+          SOURCE_BRANCH: ${{ inputs.source-branch }}
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+        run: |
+          if [[ -z "${SOURCE_BRANCH}" ]]; then
+            SOURCE_BRANCH="${GITHUB_REF_NAME}"
+          fi
+          if [[ -z "${TARGET_BRANCH}" ]]; then
+            TARGET_BRANCH="catalog-index-${SOURCE_BRANCH}"
+          fi
+          echo "source-branch=$SOURCE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "target-branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Source branch: $SOURCE_BRANCH"
+          echo "Target branch: $TARGET_BRANCH"
+
+      - name: Checkout source branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.branches.outputs.source-branch }}
+          fetch-depth: 0
+
+      - name: Sync to target branch
+        env:
+          TARGET_BRANCH: ${{ steps.branches.outputs.target-branch }}
+          SOURCE_BRANCH: ${{ steps.branches.outputs.source-branch }}
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code origin "refs/heads/$TARGET_BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$TARGET_BRANCH"
+            git checkout "$TARGET_BRANCH"
+            git merge "origin/$SOURCE_BRANCH" --no-edit -X theirs || true
+          else
+            git checkout -b "$TARGET_BRANCH"
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install requests pyyaml
+
+          # Install mikefarah yq (required by generateDynamicPluginsDefaultYaml.sh)
+          mkdir -p "$HOME/.local/bin"
+          curl -sSLo "$HOME/.local/bin/yq_mf" \
+            "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          chmod +x "$HOME/.local/bin/yq_mf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/yq_mf" --version
+
+      - name: Read versions
+        id: versions
+        run: |
+          BS_VERSION=$(jq -r '.backstage' versions.json)
+          CLI_VERSION=$(jq -r '.cli' versions.json)
+          # CLI version is aligned with RHDH version
+          RHDH_VERSION=$(echo "$CLI_VERSION" | grep -oP '^\d+\.\d+')
+
+          echo "backstage-version=$BS_VERSION" >> "$GITHUB_OUTPUT"
+          echo "rhdh-version=$RHDH_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Backstage version: $BS_VERSION"
+          echo "RHDH version: $RHDH_VERSION (from cli $CLI_VERSION)"
+
+      - name: Generate supported catalog
+        id: gen-supported
+        env:
+          RHDH_VERSION: ${{ steps.versions.outputs.rhdh-version }}
+        run: |
+          RHDH_VERSION_ARG=""
+          if [[ -n "$RHDH_VERSION" ]]; then
+            RHDH_VERSION_ARG="--rhdh-version $RHDH_VERSION"
+          fi
+
+          COMMUNITY_ARG="--community-registry $COMMUNITY_REGISTRY"
+
+          # shellcheck disable=SC2086
+          if scripts/update-index.sh \
+            --overlays-dir . \
+            --registry "$REGISTRY" \
+            --output-dir catalog-index/supported \
+            --plugin-builds-dir plugin_builds/supported \
+            --packages-file default.packages.yaml \
+            --packages-file rhdh-supported-packages.txt \
+            $COMMUNITY_ARG \
+            $RHDH_VERSION_ARG; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Supported catalog generation failed"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate community catalog
+        id: gen-community
+        env:
+          RHDH_VERSION: ${{ steps.versions.outputs.rhdh-version }}
+        run: |
+          RHDH_VERSION_ARG=""
+          if [[ -n "$RHDH_VERSION" ]]; then
+            RHDH_VERSION_ARG="--rhdh-version $RHDH_VERSION"
+          fi
+
+          # shellcheck disable=SC2086
+          if scripts/update-index.sh \
+            --overlays-dir . \
+            --registry "$REGISTRY" \
+            --output-dir catalog-index/community \
+            --plugin-builds-dir plugin_builds/community \
+            --packages-file rhdh-community-packages.txt \
+            $RHDH_VERSION_ARG; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Community catalog generation failed"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check if any tier succeeded
+        id: check-success
+        env:
+          SUPPORTED_OK: ${{ steps.gen-supported.outputs.ok }}
+          COMMUNITY_OK: ${{ steps.gen-community.outputs.ok }}
+        run: |
+          if [[ "${SUPPORTED_OK}" != "true" && "${COMMUNITY_OK}" != "true" ]]; then
+            echo "::error::Both supported and community catalog generation failed"
+            exit 1
+          fi
+
+      - name: Write build-info.json
+        env:
+          BS_VERSION: ${{ steps.versions.outputs.backstage-version }}
+          RHDH_VERSION: ${{ steps.versions.outputs.rhdh-version }}
+          SOURCE_BRANCH: ${{ steps.branches.outputs.source-branch }}
+          SUPPORTED_OK: ${{ steps.gen-supported.outputs.ok }}
+          COMMUNITY_OK: ${{ steps.gen-community.outputs.ok }}
+          SOURCE_REPO: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          SHORT_SHA="${GITHUB_SHA:0:8}"
+
+          for TIER in supported community; do
+            if [[ "$TIER" == "supported" ]]; then
+              OK="${SUPPORTED_OK}"
+            else
+              OK="${COMMUNITY_OK}"
+            fi
+
+            if [[ "$OK" == "true" ]]; then
+              cat > "catalog-index/$TIER/build-info.json" <<BINFO
+          {
+            "source-repo": "${SOURCE_REPO}/tree/${SOURCE_BRANCH} @ ${SHORT_SHA}",
+            "build-date": "${BUILD_DATE}",
+            "backstage-version": "${BS_VERSION}",
+            "rhdh-version": "${RHDH_VERSION}"
+          }
+          BINFO
+            fi
+          done
+
+      - name: Commit generated outputs
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          git add catalog-index/ plugin_builds/
+          git commit -m "Generate catalog-index from ${SHORT_SHA}" || echo "No changes to commit"
+
+      - name: Push target branch
+        env:
+          TARGET_BRANCH: ${{ steps.branches.outputs.target-branch }}
+        run: |
+          MAX_RETRIES=3
+          for i in $(seq 1 $MAX_RETRIES); do
+            if git push origin "$TARGET_BRANCH"; then
+              echo "Push succeeded"
+              break
+            fi
+            if [[ $i -lt $MAX_RETRIES ]]; then
+              echo "Push failed, retrying (attempt $((i+1))/$MAX_RETRIES)..."
+              git pull --rebase origin "$TARGET_BRANCH"
+            else
+              echo "Push failed after $MAX_RETRIES attempts"
+              exit 1
+            fi
+          done
+
+      - name: Upload catalog-index artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: catalog-index
+          path: catalog-index/
+          retention-days: 3
+
+  publish-supported:
+    runs-on: ubuntu-latest
+    needs: generate
+    if: needs.generate.outputs.supported-ok == 'true'
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout (for Dockerfile)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.generate.outputs.source-branch }}
+          sparse-checkout: Dockerfile.catalog-index
+
+      - name: Download catalog-index artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: catalog-index
+          path: catalog-index/
+
+      - name: Build OCI image
+        env:
+          BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          podman build \
+            -f Dockerfile.catalog-index \
+            --build-arg TIER=supported \
+            -t "plugin-catalog-index:bs_${BS_VERSION}-${SHORT_SHA}" \
+            -t "plugin-catalog-index:bs_${BS_VERSION}" \
+            -t "plugin-catalog-index:latest" \
+            .
+
+      - name: Push OCI image to quay.io
+        env:
+          BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+
+          echo "${QUAY_TOKEN}" | podman login quay.io -u "${QUAY_USERNAME}" --password-stdin
+
+          for tag in "bs_${BS_VERSION}-${SHORT_SHA}" "bs_${BS_VERSION}" "latest"; do
+            podman tag "plugin-catalog-index:${tag}" "${SUPPORTED_CATALOG_INDEX}:${tag}"
+            podman push "${SUPPORTED_CATALOG_INDEX}:${tag}"
+            echo "Pushed ${SUPPORTED_CATALOG_INDEX}:${tag}"
+          done
+
+  publish-community:
+    runs-on: ubuntu-latest
+    needs: generate
+    if: needs.generate.outputs.community-ok == 'true'
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout (for Dockerfile)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.generate.outputs.source-branch }}
+          sparse-checkout: Dockerfile.catalog-index
+
+      - name: Download catalog-index artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: catalog-index
+          path: catalog-index/
+
+      - name: Build OCI image
+        env:
+          BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          podman build \
+            -f Dockerfile.catalog-index \
+            --build-arg TIER=community \
+            -t "plugin-catalog-index:bs_${BS_VERSION}-${SHORT_SHA}" \
+            -t "plugin-catalog-index:bs_${BS_VERSION}" \
+            -t "plugin-catalog-index:latest" \
+            .
+
+      - name: Push OCI image to ghcr.io
+        env:
+          BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+
+          echo "${GITHUB_TOKEN}" | podman login ghcr.io -u "${GH_ACTOR}" --password-stdin
+
+          for tag in "bs_${BS_VERSION}-${SHORT_SHA}" "bs_${BS_VERSION}" "latest"; do
+            podman tag "plugin-catalog-index:${tag}" "${COMMUNITY_CATALOG_INDEX}:${tag}"
+            podman push "${COMMUNITY_CATALOG_INDEX}:${tag}"
+            echo "Pushed ${COMMUNITY_CATALOG_INDEX}:${tag}"
+          done

--- a/.github/workflows/generate-catalog-index.yaml
+++ b/.github/workflows/generate-catalog-index.yaml
@@ -32,7 +32,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY: 'quay.io/rhdh'
   COMMUNITY_REGISTRY: 'ghcr.io/redhat-developer/rhdh-plugin-export-overlays'
   COMMUNITY_CATALOG_INDEX: 'ghcr.io/redhat-developer/rhdh-plugin-export-overlays/plugin-catalog-index'
   SUPPORTED_CATALOG_INDEX: 'quay.io/rhdh-community/plugin-catalog-index'
@@ -46,6 +45,8 @@ jobs:
     outputs:
       supported-ok: ${{ steps.gen-supported.outputs.ok }}
       community-ok: ${{ steps.gen-community.outputs.ok }}
+      supported-clean: ${{ steps.gen-supported.outputs.clean }}
+      community-clean: ${{ steps.gen-community.outputs.clean }}
       backstage-version: ${{ steps.versions.outputs.backstage-version }}
       rhdh-version: ${{ steps.versions.outputs.rhdh-version }}
       source-branch: ${{ steps.branches.outputs.source-branch }}
@@ -139,48 +140,64 @@ jobs:
             RHDH_VERSION_ARG="--rhdh-version $RHDH_VERSION"
           fi
 
-          COMMUNITY_ARG="--community-registry $COMMUNITY_REGISTRY"
-
           # shellcheck disable=SC2086
           if scripts/update-index.sh \
             --overlays-dir . \
-            --registry "$REGISTRY" \
+            --registry "$COMMUNITY_REGISTRY" \
             --output-dir catalog-index/supported \
             --plugin-builds-dir plugin_builds/supported \
             --packages-file default.packages.yaml \
             --packages-file rhdh-supported-packages.txt \
             --report-file catalog-index/supported/build-report.json \
-            $COMMUNITY_ARG \
             $RHDH_VERSION_ARG; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::Supported catalog generation failed"
             echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if the catalog is clean (no fallbacks or missing plugins)
+          REPORT="catalog-index/supported/build-report.json"
+          if [[ -f "$REPORT" ]]; then
+            FAILED=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACKS=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+            if [[ "$FAILED" -eq 0 && "$FALLBACKS" -eq 0 ]]; then
+              echo "clean=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "clean=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Generate community catalog
         id: gen-community
-        env:
-          RHDH_VERSION: ${{ steps.versions.outputs.rhdh-version }}
         run: |
-          RHDH_VERSION_ARG=""
-          if [[ -n "$RHDH_VERSION" ]]; then
-            RHDH_VERSION_ARG="--rhdh-version $RHDH_VERSION"
-          fi
 
-          # shellcheck disable=SC2086
+
           if scripts/update-index.sh \
             --overlays-dir . \
-            --registry "$REGISTRY" \
+            --registry "$COMMUNITY_REGISTRY" \
             --output-dir catalog-index/community \
             --plugin-builds-dir plugin_builds/community \
             --packages-file rhdh-community-packages.txt \
-            --report-file catalog-index/community/build-report.json \
-            $RHDH_VERSION_ARG; then
+            --report-file catalog-index/community/build-report.json; then
             echo "ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::Community catalog generation failed"
             echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if the catalog is clean (no fallbacks or missing plugins)
+          REPORT="catalog-index/community/build-report.json"
+          if [[ -f "$REPORT" ]]; then
+            FAILED=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACKS=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+            if [[ "$FAILED" -eq 0 && "$FALLBACKS" -eq 0 ]]; then
+              echo "clean=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "clean=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Write build-info.json
@@ -250,10 +267,37 @@ jobs:
         env:
           SUPPORTED_OK: ${{ steps.gen-supported.outputs.ok }}
           COMMUNITY_OK: ${{ steps.gen-community.outputs.ok }}
+          SUPPORTED_CLEAN: ${{ steps.gen-supported.outputs.clean }}
+          COMMUNITY_CLEAN: ${{ steps.gen-community.outputs.clean }}
         run: |
           if [[ "${SUPPORTED_OK}" != "true" || "${COMMUNITY_OK}" != "true" ]]; then
             echo "::error::Catalog generation failed (supported=$SUPPORTED_OK, community=$COMMUNITY_OK)"
             exit 1
+          fi
+
+          # Surface fallbacks and missing plugins as warnings
+          HAS_ISSUES=false
+          for TIER in supported community; do
+            REPORT="catalog-index/$TIER/build-report.json"
+            if [[ ! -f "$REPORT" ]]; then continue; fi
+
+            FAILED_COUNT=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACK_COUNT=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+
+            if [[ "$FAILED_COUNT" -gt 0 ]]; then
+              FAILED_PLUGINS=$(jq -r '[.plugins | to_entries[] | select(.value.overall == "fail") | .key] | join(", ")' "$REPORT" 2>/dev/null || echo "")
+              echo "::warning::$TIER catalog: $FAILED_COUNT plugin(s) missing from registry: $FAILED_PLUGINS"
+              HAS_ISSUES=true
+            fi
+            if [[ "$FALLBACK_COUNT" -gt 0 ]]; then
+              FALLBACK_PLUGINS=$(jq -r '[.plugins | to_entries[] | select(.value.stages["registry-enrich"].fallback == true) | .key] | join(", ")' "$REPORT" 2>/dev/null || echo "")
+              echo "::warning::$TIER catalog: $FALLBACK_COUNT plugin(s) using fallback tags: $FALLBACK_PLUGINS"
+              HAS_ISSUES=true
+            fi
+          done
+
+          if [[ "$HAS_ISSUES" == "true" ]]; then
+            echo "::warning::Catalog published with issues — last-successful-publish not updated"
           fi
 
   publish-supported:
@@ -389,6 +433,8 @@ jobs:
         env:
           PUBLISH_SUPPORTED_RESULT: ${{ needs.publish-supported.result }}
           PUBLISH_COMMUNITY_RESULT: ${{ needs.publish-community.result }}
+          SUPPORTED_CLEAN: ${{ needs.generate.outputs.supported-clean }}
+          COMMUNITY_CLEAN: ${{ needs.generate.outputs.community-clean }}
           BS_VERSION: ${{ needs.generate.outputs.backstage-version }}
           RHDH_VERSION: ${{ needs.generate.outputs.rhdh-version }}
         run: |
@@ -404,9 +450,11 @@ jobs:
 
             if [[ "$TIER" == "supported" ]]; then
               RESULT="${PUBLISH_SUPPORTED_RESULT}"
+              CLEAN="${SUPPORTED_CLEAN}"
               IMAGE="${SUPPORTED_CATALOG_INDEX}:${TAG}"
             else
               RESULT="${PUBLISH_COMMUNITY_RESULT}"
+              CLEAN="${COMMUNITY_CLEAN}"
               IMAGE="${COMMUNITY_CATALOG_INDEX}:${TAG}"
             fi
 
@@ -414,12 +462,16 @@ jobs:
               '.metadata["catalog-index-image"] = $image' \
               "$REPORT" > "${REPORT}.tmp" && mv "${REPORT}.tmp" "$REPORT"
 
-            if [[ "$RESULT" == "success" ]]; then
+            # Only mark as last-successful-publish when publish succeeded AND catalog is clean
+            # (no fallback tags, no missing plugins)
+            if [[ "$RESULT" == "success" && "$CLEAN" == "true" ]]; then
               jq --arg sha "$GITHUB_SHA" \
                 '.metadata["last-successful-publish"] = $sha' \
                 "$REPORT" > "${REPORT}.tmp" && mv "${REPORT}.tmp" "$REPORT"
+              echo "Updated $TIER report: publish=$RESULT, clean=$CLEAN, image=$IMAGE (last-successful-publish updated)"
+            else
+              echo "Updated $TIER report: publish=$RESULT, clean=$CLEAN, image=$IMAGE (last-successful-publish NOT updated)"
             fi
-            echo "Updated $TIER report: publish=$RESULT, image=$IMAGE"
           done
 
       - name: Render catalog status page

--- a/.github/workflows/generate-catalog-index.yaml
+++ b/.github/workflows/generate-catalog-index.yaml
@@ -161,7 +161,7 @@ jobs:
           REPORT="catalog-index/supported/build-report.json"
           if [[ -f "$REPORT" ]]; then
             FAILED=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
-            FALLBACKS=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACKS=$(jq '[.plugins[] | select(.stages["image-metadata-fetch"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
             if [[ "$FAILED" -eq 0 && "$FALLBACKS" -eq 0 ]]; then
               echo "clean=true" >> "$GITHUB_OUTPUT"
             else
@@ -172,8 +172,6 @@ jobs:
       - name: Generate community catalog
         id: gen-community
         run: |
-
-
           if scripts/update-index.sh \
             --overlays-dir . \
             --registry "$COMMUNITY_REGISTRY" \
@@ -192,7 +190,7 @@ jobs:
           REPORT="catalog-index/community/build-report.json"
           if [[ -f "$REPORT" ]]; then
             FAILED=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
-            FALLBACKS=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACKS=$(jq '[.plugins[] | select(.stages["image-metadata-fetch"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
             if [[ "$FAILED" -eq 0 && "$FALLBACKS" -eq 0 ]]; then
               echo "clean=true" >> "$GITHUB_OUTPUT"
             else
@@ -249,7 +247,7 @@ jobs:
             fi
             if [[ $i -lt $MAX_RETRIES ]]; then
               echo "Push failed, retrying (attempt $((i+1))/$MAX_RETRIES)..."
-              git pull --rebase origin "$TARGET_BRANCH"
+              git pull -X theirs origin "$TARGET_BRANCH"
             else
               echo "Push failed after $MAX_RETRIES attempts"
               exit 1
@@ -282,7 +280,7 @@ jobs:
             if [[ ! -f "$REPORT" ]]; then continue; fi
 
             FAILED_COUNT=$(jq '.summary.failed // 0' "$REPORT" 2>/dev/null || echo 0)
-            FALLBACK_COUNT=$(jq '[.plugins[] | select(.stages["registry-enrich"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
+            FALLBACK_COUNT=$(jq '[.plugins[] | select(.stages["image-metadata-fetch"].fallback == true)] | length' "$REPORT" 2>/dev/null || echo 0)
 
             if [[ "$FAILED_COUNT" -gt 0 ]]; then
               FAILED_PLUGINS=$(jq -r '[.plugins | to_entries[] | select(.value.overall == "fail") | .key] | join(", ")' "$REPORT" 2>/dev/null || echo "")
@@ -290,7 +288,7 @@ jobs:
               HAS_ISSUES=true
             fi
             if [[ "$FALLBACK_COUNT" -gt 0 ]]; then
-              FALLBACK_PLUGINS=$(jq -r '[.plugins | to_entries[] | select(.value.stages["registry-enrich"].fallback == true) | .key] | join(", ")' "$REPORT" 2>/dev/null || echo "")
+              FALLBACK_PLUGINS=$(jq -r '[.plugins | to_entries[] | select(.value.stages["image-metadata-fetch"].fallback == true) | .key] | join(", ")' "$REPORT" 2>/dev/null || echo "")
               echo "::warning::$TIER catalog: $FALLBACK_COUNT plugin(s) using fallback tags: $FALLBACK_PLUGINS"
               HAS_ISSUES=true
             fi
@@ -507,6 +505,7 @@ jobs:
             --backstage-version "$BS_VERSION" \
             --rhdh-version "$RHDH_VERSION" \
             --workflow-run-url "$WORKFLOW_RUN_URL" \
+            --troubleshooting-content user-guide/troubleshooting-catalog-index.md \
             --output /tmp/catalog-status.md
 
           # Write the same status page to the GitHub Job Summary

--- a/.github/workflows/github-script/sync-user-guide-to-wiki.js
+++ b/.github/workflows/github-script/sync-user-guide-to-wiki.js
@@ -26,6 +26,7 @@ const FILE_MAP = {
   'user-guide/04-metadata-synchronization.md': 'Metadata-Synchronization',
   'user-guide/05-version-updates.md': 'Version-Updates',
   'user-guide/06-patch-management.md': 'Patch-Management',
+  'user-guide/07-plugin-catalog-index.md': 'Plugin-Catalog-Index-Generation',
 };
 
 // Link transformations for wiki format
@@ -37,6 +38,7 @@ const LINK_TRANSFORMS = [
   { from: /\[([^\]]+)\]\(\.\/04-metadata-synchronization\.md(#[^\)]+)?\)/g, to: '[$1](Metadata-Synchronization$2)' },
   { from: /\[([^\]]+)\]\(\.\/05-version-updates\.md(#[^\)]+)?\)/g, to: '[$1](Version-Updates$2)' },
   { from: /\[([^\]]+)\]\(\.\/06-patch-management\.md(#[^\)]+)?\)/g, to: '[$1](Patch-Management$2)' },
+  { from: /\[([^\]]+)\]\(\.\/07-plugin-catalog-index\.md(#[^\)]+)?\)/g, to: '[$1](Plugin-Catalog-Index-Generation$2)' },
 ];
 
 // Source repository metadata
@@ -213,10 +215,13 @@ function transformForWiki(content, dynamicContent) {
 /**
  * Generate the wiki sidebar navigation
  */
-function generateSidebar(workspaceStats, reportPages) {
+function generateSidebar(workspaceStats, reportPages, catalogStatusPages) {
   const reportLinks = reportPages.length > 0
     ? reportPages.map(({ branchName, pageName }) => `  * [${branchName}](${pageName})`).join('\n')
     : '  * [main](main)';
+  const catalogLinks = catalogStatusPages.length > 0
+    ? '\n' + catalogStatusPages.map(({ branchName, pageName }) => `  * [${branchName}](${pageName})`).join('\n')
+    : '';
 
   return `### 📚 User Guide
 * [Home](Home)
@@ -228,11 +233,13 @@ function generateSidebar(workspaceStats, reportPages) {
 * [Metadata Synchronization](Metadata-Synchronization)
 * [Version Updates](Version-Updates)
 * [Patch Management](Patch-Management)
+* [Plugin Catalog Index](Plugin-Catalog-Index-Generation)
 
 ### 📊 Generated Reports
 * [Backstage Compatibility Report](Backstage-Compatibility-Report)
 * [Workspace Status Reports](Workspace-Status-Reports)
 ${reportLinks}
+* [Plugin Catalog Index Status](Plugin-Catalog-Index-Status)${catalogLinks}
 
 ### 📈 Stats
 * **${workspaceStats.total}** workspaces
@@ -267,6 +274,27 @@ async function detectWorkspaceStatusReportPages(wikiDir) {
   }
 
   return pages;
+}
+
+/**
+ * Detect branch-specific catalog status pages in the wiki.
+ * Expected page names are `Plugin-Catalog-Status-*`.
+ */
+async function detectCatalogStatusPages(wikiDir) {
+  const prefix = 'Plugin-Catalog-Status-';
+  const files = await fs.readdir(wikiDir, { withFileTypes: true });
+  return files
+    .filter(file => file.isFile() && file.name.startsWith(prefix) && file.name.endsWith('.md'))
+    .map(file => {
+      const pageName = file.name.replace(/\.md$/, '');
+      const branchName = pageName.slice(prefix.length);
+      return { pageName, branchName };
+    })
+    .sort((a, b) => {
+      if (a.branchName === 'main') return -1;
+      if (b.branchName === 'main') return 1;
+      return b.branchName.localeCompare(a.branchName, undefined, { numeric: true });
+    });
 }
 
 /**
@@ -444,6 +472,8 @@ async function syncUserGuideToWiki({ github, context, core }) {
     // Detect existing workspace status report pages before writing new content
     const reportPages = await detectWorkspaceStatusReportPages(wikiDir);
     core.info(`Detected ${reportPages.length} workspace status report pages`);
+    const catalogStatusPages = await detectCatalogStatusPages(wikiDir);
+    core.info(`Detected ${catalogStatusPages.length} catalog status pages`);
     
     // Process each user guide file
     core.info('\nProcessing user guide files...');
@@ -470,7 +500,7 @@ async function syncUserGuideToWiki({ github, context, core }) {
     
     // Generate sidebar with stats
     core.info('Generating _Sidebar.md...');
-    await fs.writeFile(join(wikiDir, '_Sidebar.md'), generateSidebar(workspaceStats, reportPages), 'utf-8');
+    await fs.writeFile(join(wikiDir, '_Sidebar.md'), generateSidebar(workspaceStats, reportPages, catalogStatusPages), 'utf-8');
 
     // Generate workspace status reports index page
     core.info('Generating Workspace-Status-Reports.md...');
@@ -495,7 +525,9 @@ async function syncUserGuideToWiki({ github, context, core }) {
     }
     
     // Push changes
-    if (!dryRun) {
+    if (dryRun) {
+      core.info('\n🔍 Dry run complete - no changes pushed');
+    } else {
       const commitMessage = `docs: sync user guide from main repository
 
 Synced from commit: ${context.sha?.substring(0, 7) || 'unknown'}
@@ -509,8 +541,6 @@ Triggered by: ${context.eventName}`;
         core.info('\n✅ Wiki updated successfully');
         core.info(`View at: https://github.com/${owner}/${repo}/wiki`);
       }
-    } else {
-      core.info('\n🔍 Dry run complete - no changes pushed');
     }
     
     return { success: true, filesProcessed, versions, workspaceStats };

--- a/.github/workflows/validate-catalog-scripts.yaml
+++ b/.github/workflows/validate-catalog-scripts.yaml
@@ -1,0 +1,40 @@
+name: Validate catalog index scripts
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
+    paths:
+      - 'scripts/*.py'
+      - 'scripts/tests/**'
+      - 'scripts/requirements-dev.txt'
+      - '.github/workflows/validate-catalog-scripts.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: validate-catalog-scripts-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r scripts/requirements-dev.txt
+
+      - name: Run tests
+        working-directory: scripts
+        run: python -m pytest tests/ -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,7 +413,8 @@ Trigger nightly manually: comment `/test e2e-ocp-helm-nightly` on a PR.
 ## Documentation
 
 - `README.md` — Repo overview, PR workflow, testing procedures
-- `user-guide/` — 6-part contributor guide (getting started, export tools, ownership, metadata sync, versions, patches)
+- `user-guide/` — 6-part contributor guide (getting started, export tools, ownership, metadata sync, versions, patches) plus catalog index pipeline docs
+- `user-guide/troubleshooting-catalog-index.md` — Troubleshooting content embedded by `renderCatalogStatus.py` into each generated status page. Anchor slugs must stay in sync with `REASON_ANCHORS` in the renderer
 - `catalog-entities/extensions/README.md` — Extensions catalog metadata format
 - GitHub Wiki — Auto-synced from `user-guide/` with dynamic content injection (`{{AUTO:*}}` placeholders replaced from `versions.json`)
 - **E2E test utils docs** — https://github.com/redhat-developer/rhdh-e2e-test-utils/tree/main/docs — latest API docs, changelogs, tutorials, and configuration reference for `@red-hat-developer-hub/e2e-test-utils`

--- a/Dockerfile.catalog-index
+++ b/Dockerfile.catalog-index
@@ -1,0 +1,9 @@
+FROM scratch
+ARG TIER=supported
+COPY catalog-index/${TIER}/ /
+USER 65534
+
+LABEL summary="Red Hat Developer Hub plugin catalog index" \
+      description="Red Hat Developer Hub plugin catalog index" \
+      maintainer="RHDH Team <rhdh-bot@redhat.com>" \
+      vendor="Red Hat, Inc."

--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -21,8 +21,6 @@ packages:
   - package: '@red-hat-developer-hub/backstage-plugin-global-header' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-extensions' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-extensions-backend' # tech-preview
-  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed" # generally-available
-  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed-backend" # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-quickstart' # generally-available
 
   disabled: # should ideally contain no community content; TODO: remove some community or TP stuff in 2.1?
@@ -53,6 +51,10 @@ packages:
   - package: '@backstage/plugin-signals-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-bulk-import' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-homepage-backend' # tech-preview
+  # Lightspeed plugins are enabled by default in the install methods (Helm chart, Operator)
+  - package: '@red-hat-developer-hub/backstage-plugin-lightspeed' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-lightspeed-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki' # tech-preview

--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -1,0 +1,69 @@
+# MANUALLY maintained list of "core plugins"
+#
+# Do not add packages to this list without prior agreement from PM
+#
+# New packages should only be "tech-preview" or "generally-available"
+#    16 are tech-preview, and should be promoted via a PM-sponsored Feature to generally-available at some point
+#    06 are community, and should be removed over time
+packages:
+  enabled: # should onyly include GA (or TP with a path to GA) content here
+  - package: '@backstage-community/plugin-analytics-provider-segment' # generally-available
+  - package: '@backstage-community/plugin-scaffolder-backend-module-regex' # generally-available
+  - package: '@backstage/plugin-techdocs' # generally-available
+  - package: '@backstage/plugin-techdocs-backend' # generally-available
+  - package: '@backstage/plugin-techdocs-module-addons-contrib' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-adoption-insights' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-adoption-insights-backend' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-dynamic-home-page' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-global-floating-action-button' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-global-header' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-extensions' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-extensions-backend' # tech-preview
+  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed" # generally-available
+  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed-backend" # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-quickstart' # generally-available
+
+  disabled: # should ideally contain no community content; TODO: remove some community or TP stuff in 2.1?
+  - package: '@backstage-community/plugin-acr' # tech-preview
+  - package: '@backstage-community/plugin-catalog-backend-module-keycloak' # generally-available
+  - package: '@backstage-community/plugin-catalog-backend-module-pingidentity' # tech-preview
+  - package: '@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor' # tech-preview
+  - package: '@backstage-community/plugin-rbac' # generally-available
+  - package: '@backstage-community/plugin-scaffolder-backend-module-kubernetes' # generally-available
+  - package: '@backstage-community/plugin-tech-radar' # generally-available
+  - package: '@backstage-community/plugin-tech-radar-backend' # generally-available
+  - package: '@backstage-community/plugin-topology' # generally-available
+  - package: '@backstage/plugin-catalog-backend-module-github' # generally-available
+  - package: '@backstage/plugin-catalog-backend-module-github-org' # generally-available
+  - package: '@backstage/plugin-catalog-backend-module-gitlab' # production
+  - package: '@backstage/plugin-catalog-backend-module-gitlab-org' # production
+  - package: '@backstage/plugin-catalog-backend-module-ldap' # generally-available
+  - package: '@backstage/plugin-catalog-backend-module-msgraph' # generally-available
+  - package: '@backstage/plugin-events-backend-module-github' # tech-preview
+  - package: '@backstage/plugin-kubernetes' # tech-preview
+  - package: '@backstage/plugin-kubernetes-backend' # generally-available
+  - package: '@backstage/plugin-notifications' # tech-preview
+  - package: '@backstage/plugin-notifications-backend' # tech-preview
+  - package: '@backstage/plugin-notifications-backend-module-email' # tech-preview
+  - package: '@backstage/plugin-scaffolder-backend-module-github' # generally-available
+  - package: '@backstage/plugin-scaffolder-backend-module-gitlab' # tech-preview
+  - package: '@backstage/plugin-signals' # tech-preview
+  - package: '@backstage/plugin-signals-backend' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-bulk-import' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator' # generally-available
+  - package: '@roadiehq/scaffolder-backend-module-http-request' # generally-available
+
+  # these community supported plugins do not have a downstream analogue in overlays repo's rhdh-supported-packages.txt
+  - package: '@backstage-community/plugin-quay' # community
+  - package: '@backstage-community/plugin-quay-backend' # community
+  - package: '@backstage-community/plugin-scaffolder-backend-module-quay' # community
+  - package: '@backstage-community/plugin-tekton' # community
+  - package: '@roadiehq/backstage-plugin-argo-cd-backend' # community - TODO: replace with RH Argo CD plugin when it's ready
+  - package: '@roadiehq/scaffolder-backend-argocd' # community - TODO: replace with RH Argo CD plugin when it's ready

--- a/scripts/bootstrapPluginBuilds.py
+++ b/scripts/bootstrapPluginBuilds.py
@@ -29,6 +29,62 @@ from plugin_utils import (
 )
 
 
+def versions_match_minor(v1: str, v2: str) -> bool:
+    """Check if two semver strings share the same major.minor version.
+    Returns False for empty or malformed versions.
+    """
+    if not v1 or not v2:
+        return False
+    parts1 = v1.split(".")[:2]
+    parts2 = v2.split(".")[:2]
+    return len(parts1) == 2 and len(parts2) == 2 and parts1 == parts2
+
+
+def get_outdated_workspaces(
+    workspace_dirs: list[Path],
+    backstage_version: str,
+) -> dict[str, dict[str, str]]:
+    """Identify workspaces whose effective backstage version doesn't match the target minor.
+
+    For each workspace, the effective version is determined by:
+    1. backstage.json (override) if it exists
+    2. source.json repo-backstage-version otherwise
+
+    Returns a dict mapping workspace name to {"expected": ..., "found": ...} for mismatches.
+    """
+    outdated = {}
+    for workspace_dir in workspace_dirs:
+        ws_name = workspace_dir.name
+        effective_version = ""
+        source_json = workspace_dir / "source.json"
+        backstage_json = workspace_dir / "backstage.json"
+
+        if backstage_json.exists():
+            try:
+                with open(backstage_json, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                    effective_version = data.get("version", "")
+            except (json.JSONDecodeError, OSError) as e:
+                log_warn(f"Malformed backstage.json in workspace {ws_name}: {e}")
+        elif source_json.exists():
+            try:
+                with open(source_json, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                    effective_version = data.get("repo-backstage-version", "")
+            except (json.JSONDecodeError, OSError) as e:
+                log_warn(f"Malformed source.json in workspace {ws_name}: {e}")
+        else:
+            log_warn(f"No source.json or backstage.json found in workspace {ws_name}")
+
+        if not effective_version:
+            log_warn(f"Missing backstage version for workspace {ws_name}, treating as outdated")
+            outdated[ws_name] = {"expected": backstage_version, "found": "missing"}
+        elif not versions_match_minor(effective_version, backstage_version):
+            outdated[ws_name] = {"expected": backstage_version, "found": effective_version}
+
+    return outdated
+
+
 def package_name_to_image_name(package_name: str) -> str:
     """Convert an npm package name to an OCI image name.
     e.g., '@red-hat-developer-hub/backstage-plugin-foo' → 'red-hat-developer-hub-backstage-plugin-foo'
@@ -224,9 +280,17 @@ Examples:
         if d.is_dir() and (d / "metadata").is_dir()
     ])
 
+    # Pre-compute outdated workspaces (backstage minor version mismatch)
+    outdated_workspaces = get_outdated_workspaces(workspace_dirs, backstage_version)
+    if outdated_workspaces:
+        log_warn(f"Found {len(outdated_workspaces)} workspace(s) with backstage version mismatch:")
+        for ws_name, info in sorted(outdated_workspaces.items()):
+            log_warn(f"  {ws_name}: expected {info['expected']}, found {info['found']}")
+
     created_count = 0
     updated_count = 0
     skipped_count = 0
+    outdated_count = 0
     no_ref_count = 0
 
     for workspace_dir in workspace_dirs:
@@ -256,6 +320,27 @@ Examples:
                 # Check packages filter (by npm package name)
                 if packages_set is not None and package_name not in packages_set:
                     skipped_count += 1
+                    continue
+
+                # Check workspace backstage version (only for plugins passing the packages filter)
+                if workspace_name in outdated_workspaces:
+                    outdated_count += 1
+                    info = outdated_workspaces[workspace_name]
+                    image_name = package_name_to_image_name(package_name) if package_name else stem
+                    report.add_plugin(
+                        image_name,
+                        package=package_name,
+                        version=version,
+                        workspace=workspace_name,
+                    )
+                    report.set_stage(
+                        image_name, "bootstrap", "outdated",
+                        reason="Backstage version mismatch",
+                        expected_version=info["expected"],
+                        found_version=info["found"],
+                    )
+                    log_debug(f"Skipped {stem} (workspace {workspace_name}): "
+                              f"backstage version {info['found']} != expected {info['expected']}")
                     continue
 
                 # Construct registryReference
@@ -341,6 +426,8 @@ Examples:
         log_info(f"Updated: {Colors.BLUE}{updated_count}{Colors.NORM}")
     if skipped_count > 0:
         log_info(f"Filtered out: {skipped_count}")
+    if outdated_count > 0:
+        log_warn(f"Outdated (backstage version mismatch): {Colors.YELLOW}{outdated_count}{Colors.NORM}")
     if no_ref_count > 0:
         log_warn(f"No OCI reference (local path): {Colors.YELLOW}{no_ref_count}{Colors.NORM}")
     log_info(f"Total: {total}")

--- a/scripts/bootstrapPluginBuilds.py
+++ b/scripts/bootstrapPluginBuilds.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Red Hat, Inc.
+#
+# Generate initial plugin_builds/<workspace>/<stem>.json files from
+# workspace metadata (workspaces/*/metadata/*.yaml).
+#
+# This replaces the bootstrap logic in sync-midstream.sh that reads
+# package.json from cloned workspace sources — we derive the same
+# information from the metadata YAML files instead.
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+from plugin_utils import (
+    Colors,
+    log_debug,
+    log_info,
+    log_warn,
+    log_error,
+    set_debug,
+    read_plugins_list,
+    match_metadata_to_plugin_path,
+    load_and_resolve_to_npm_names,
+)
+
+
+def package_name_to_image_name(package_name: str) -> str:
+    """Convert an npm package name to an OCI image name.
+    e.g., '@red-hat-developer-hub/backstage-plugin-foo' → 'red-hat-developer-hub-backstage-plugin-foo'
+    """
+    return package_name.lstrip('@').replace('/', '-')
+
+
+def parse_dynamic_artifact(dynamic_artifact: str) -> str:
+    """
+    Extract a bare registry reference from a dynamicArtifact value.
+    Strips 'oci://' prefix and '!fragment' suffix.
+    Returns empty string for local paths.
+    """
+    if not dynamic_artifact or dynamic_artifact.startswith('./'):
+        return ""
+
+    ref = dynamic_artifact
+    if ref.startswith('oci://'):
+        ref = ref[len('oci://'):]
+    if '!' in ref:
+        ref = ref.split('!')[0]
+    return ref
+
+
+def construct_registry_reference(
+    registry_base: str,
+    image_name: str,
+    version: str,
+    backstage_version: str,
+    rhdh_version: str,
+    dynamic_artifact: str,
+) -> str:
+    """
+    Construct a registryReference for a plugin from version fields.
+    Always constructs a tag-based ref from spec.version + rhdh_version/backstage_version:
+      - ghcr.io: bs_{backstage_version}__{version}
+      - quay.io/rhdh: {rhdh_version}--{version}
+    """
+    existing_ref = parse_dynamic_artifact(dynamic_artifact)
+    if existing_ref and '@' in existing_ref:
+        log_warn(f"metadata's dynamicArtifact contains digest instead of tag: {dynamic_artifact}")
+
+    if 'ghcr.io' in registry_base:
+        tag = f"bs_{backstage_version}__{version}"
+    else:
+        tag = f"{rhdh_version}--{version}"
+
+    return f"{registry_base}/{image_name}:{tag}"
+
+
+def main():
+    usage="""
+Usage: python3 bootstrapPluginBuilds.py [--debug] \\
+    -r|--registry image-registry \\
+    [-d|--overlays-dir PATH] \\
+    [-b|--plugin-builds-dir PATH] \\
+    [-v|--rhdh-version VERSION] \\
+    [-cr|--community-registry BASE] \\
+    [-p|--packages-file FILE ...]
+
+Examples:
+
+    # Supported plugins from multiple package list files
+    python3 bootstrapPluginBuilds.py \\
+        -b plugin_builds/supported \\
+        -r quay.io/rhdh \\
+        -cr ghcr.io/redhat-developer/rhdh-plugin-export-overlays \\
+        -v 1.10 \\
+        -p catalog-index/default.packages.yaml \\
+        -p rhdh-supported-packages.txt
+
+    # Community plugins (no --rhdh-version needed)
+    python3 bootstrapPluginBuilds.py \\
+        -b plugin_builds/community \\
+        -r ghcr.io/redhat-developer/rhdh-plugin-export-overlays \\
+        -p rhdh-community-packages.txt
+"""
+
+    parser = argparse.ArgumentParser(
+        description='Bootstrap plugin_builds/ from workspace metadata.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=usage
+    )
+    parser.error = lambda msg: (print(f"\n{Colors.RED}[ERROR] {msg}{Colors.NORM}\n{usage}", file=sys.stderr), sys.exit(2))
+    parser.add_argument(
+        '-d', '--overlays-dir',
+        type=str,
+        default='.',
+        metavar='PATH',
+        help='Path to overlays directory containing workspaces/ (default: .)',
+    )
+    parser.add_argument(
+        '-b', '--plugin-builds-dir',
+        type=str,
+        default='plugin_builds',
+        metavar='PATH',
+        help='Output directory for plugin_builds/ (default: plugin_builds)',
+    )
+    parser.add_argument(
+        '-r', '--registry',
+        type=str,
+        required=True,
+        metavar='BASE',
+        help='Registry base for constructing registryReference (e.g., ghcr.io/redhat-developer/rhdh-plugin-export-overlays)',
+    )
+    parser.add_argument(
+        '-v', '--rhdh-version',
+        type=str,
+        metavar='VERSION',
+        help='RHDH version for non-ghcr.io tag convention (e.g., 1.5). Required when registry is not ghcr.io.',
+    )
+    parser.add_argument(
+        '-p', '--packages-file',
+        type=str,
+        action='append',
+        metavar='FILE',
+        help='Package list file to filter plugins. Can be specified multiple times. '
+             'Accepts YAML (default.packages.yaml format with npm names) or txt '
+             '(workspace paths, one per line). Packages from all files are unioned.',
+    )
+    parser.add_argument(
+        '-cr', '--community-registry',
+        type=str,
+        metavar='BASE',
+        default='ghcr.io/redhat-developer/rhdh-plugin-export-overlays',
+        help='Registry base for community-tier plugins '
+             '(default: ghcr.io/redhat-developer/rhdh-plugin-export-overlays). '
+             'Community plugins use this registry instead of --registry.',
+    )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Enable debug output',
+    )
+
+    args = parser.parse_args()
+    set_debug(args.debug)
+
+    overlays_dir = Path(args.overlays_dir)
+    plugin_builds_dir = Path(args.plugin_builds_dir)
+    registry_base = args.registry.rstrip('/')
+    community_registry = args.community_registry.rstrip('/')
+    rhdh_version = args.rhdh_version or ""
+
+    if 'ghcr.io' not in registry_base and not rhdh_version:
+        log_error("--rhdh-version is required when registry is not ghcr.io")
+        sys.exit(1)
+
+    if community_registry != registry_base:
+        log_info(f"Community plugins will use registry: {community_registry}")
+
+    if not overlays_dir.exists():
+        log_error(f"Overlays directory not found: {overlays_dir}")
+        sys.exit(1)
+
+    workspaces_dir = overlays_dir / "workspaces"
+    if not workspaces_dir.exists():
+        log_error(f"Workspaces directory not found: {workspaces_dir}")
+        sys.exit(1)
+
+    # Load backstage version from versions.json
+    versions_file = overlays_dir / "versions.json"
+    backstage_version = ""
+    if versions_file.exists():
+        with open(versions_file, 'r') as f:
+            versions = json.load(f)
+            backstage_version = versions.get("backstage", "")
+    if not backstage_version:
+        log_warn("Could not read backstage version from versions.json")
+
+    # Load packages filter
+    packages_set = None
+    if args.packages_file:
+        packages_set = load_and_resolve_to_npm_names(args.packages_file, overlays_dir)
+        log_info(f"Filtering to {len(packages_set)} packages from {len(args.packages_file)} file(s)")
+
+    print(f"\n{Colors.GREEN}=== Bootstrap plugin_builds from workspace metadata ==={Colors.NORM}\n")
+
+    # Find all workspace directories with metadata
+    workspace_dirs = sorted([
+        d for d in workspaces_dir.iterdir()
+        if d.is_dir() and (d / "metadata").is_dir()
+    ])
+
+    created_count = 0
+    updated_count = 0
+    skipped_count = 0
+    no_ref_count = 0
+
+    for workspace_dir in workspace_dirs:
+        workspace_name = workspace_dir.name
+        metadata_dir = workspace_dir / "metadata"
+        plugin_paths = read_plugins_list(workspace_dir)
+
+        yaml_files = sorted(metadata_dir.glob("*.yaml"))
+        if not yaml_files:
+            continue
+
+        for yaml_file in yaml_files:
+            try:
+                with open(yaml_file, 'r') as f:
+                    data = yaml.safe_load(f)
+
+                if not data or data.get('kind') != 'Package':
+                    continue
+
+                metadata = data.get('metadata', {})
+                spec = data.get('spec', {})
+                stem = metadata.get('name', yaml_file.stem)
+                version = spec.get('version', '')
+                dynamic_artifact = spec.get('dynamicArtifact', '')
+                package_name = spec.get('packageName', '')
+                support_level = spec.get('support', '')
+
+                # Derive workspacePath
+                matched_path = match_metadata_to_plugin_path(stem, plugin_paths)
+                if matched_path:
+                    workspace_path = f"{workspace_name}/{matched_path}"
+                else:
+                    workspace_path = f"{workspace_name}/{stem}"
+                    log_debug(f"No plugins-list match for {stem}, using fallback: {workspace_path}")
+
+                # Check packages filter (by npm package name)
+                if packages_set is not None and package_name not in packages_set:
+                    skipped_count += 1
+                    continue
+
+                # Construct registryReference
+                image_name = package_name_to_image_name(package_name) if package_name else stem
+                effective_registry = registry_base
+                if support_level == 'community' and community_registry != registry_base:
+                    effective_registry = community_registry
+                registry_reference = construct_registry_reference(
+                    effective_registry, image_name, version, backstage_version, rhdh_version, dynamic_artifact,
+                )
+
+                if not registry_reference:
+                    no_ref_count += 1
+                    log_debug(f"No OCI reference for {stem} (local path: {dynamic_artifact})")
+
+                # Write or update JSON file
+                json_dir = plugin_builds_dir / workspace_name
+                json_dir.mkdir(parents=True, exist_ok=True)
+                json_file = json_dir / f"{image_name}.json"
+
+                existing_data = {}
+                if json_file.exists():
+                    try:
+                        with open(json_file, 'r') as f:
+                            existing_data = json.load(f)
+                    except (json.JSONDecodeError, OSError):
+                        existing_data = {}
+
+                # Preserve existing enrichment fields (digest, build-date, etc.)
+                plugin_entry = existing_data.get(image_name, {})
+                plugin_entry['workspacePath'] = workspace_path
+                if support_level:
+                    plugin_entry['support'] = support_level
+                if registry_reference:
+                    plugin_entry['registryReference'] = registry_reference
+                elif 'registryReference' not in plugin_entry:
+                    plugin_entry['registryReference'] = ""
+
+                new_data = {image_name: plugin_entry}
+
+                if json_file.exists():
+                    updated_count += 1
+                    action = "Updated"
+                else:
+                    created_count += 1
+                    action = "Created"
+
+                with open(json_file, 'w') as f:
+                    json.dump(new_data, f, indent=2)
+                    f.write('\n')
+
+                log_debug(f"{action} {json_file.relative_to(plugin_builds_dir)}")
+
+            except Exception as e:
+                log_error(f"Error processing {yaml_file}: {e}")
+
+    # Summary
+    total = created_count + updated_count
+    print(f"\n{Colors.GREEN}=== Results ==={Colors.NORM}")
+    log_info(f"Created: {Colors.GREEN}{created_count}{Colors.NORM}")
+    if updated_count > 0:
+        log_info(f"Updated: {Colors.BLUE}{updated_count}{Colors.NORM}")
+    if skipped_count > 0:
+        log_info(f"Filtered out: {skipped_count}")
+    if no_ref_count > 0:
+        log_warn(f"No OCI reference (local path): {Colors.YELLOW}{no_ref_count}{Colors.NORM}")
+    log_info(f"Total: {total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bootstrapPluginBuilds.py
+++ b/scripts/bootstrapPluginBuilds.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import yaml
 
 from plugin_utils import (
+    BuildReport,
     Colors,
     log_debug,
     log_info,
@@ -159,6 +160,12 @@ Examples:
              'Community plugins use this registry instead of --registry.',
     )
     parser.add_argument(
+        '--report-file',
+        type=str,
+        metavar='PATH',
+        help='Path to build-report.json for tracking generation stages (optional)',
+    )
+    parser.add_argument(
         '--debug',
         action='store_true',
         help='Enable debug output',
@@ -193,7 +200,7 @@ Examples:
     versions_file = overlays_dir / "versions.json"
     backstage_version = ""
     if versions_file.exists():
-        with open(versions_file, 'r') as f:
+        with open(versions_file, 'r', encoding='utf-8') as f:
             versions = json.load(f)
             backstage_version = versions.get("backstage", "")
     if not backstage_version:
@@ -204,6 +211,8 @@ Examples:
     if args.packages_file:
         packages_set = load_and_resolve_to_npm_names(args.packages_file, overlays_dir)
         log_info(f"Filtering to {len(packages_set)} packages from {len(args.packages_file)} file(s)")
+
+    report = BuildReport(args.report_file)
 
     print(f"\n{Colors.GREEN}=== Bootstrap plugin_builds from workspace metadata ==={Colors.NORM}\n")
 
@@ -277,7 +286,7 @@ Examples:
                 existing_data = {}
                 if json_file.exists():
                     try:
-                        with open(json_file, 'r') as f:
+                        with open(json_file, 'r', encoding='utf-8') as f:
                             existing_data = json.load(f)
                     except (json.JSONDecodeError, OSError):
                         existing_data = {}
@@ -301,14 +310,26 @@ Examples:
                     created_count += 1
                     action = "Created"
 
-                with open(json_file, 'w') as f:
+                with open(json_file, 'w', encoding='utf-8') as f:
                     json.dump(new_data, f, indent=2)
                     f.write('\n')
 
                 log_debug(f"{action} {json_file.relative_to(plugin_builds_dir)}")
 
+                report.add_plugin(
+                    image_name,
+                    package=package_name,
+                    version=version,
+                    workspace=workspace_name,
+                )
+                stage_details = {}
+                if registry_reference:
+                    stage_details["oci_ref"] = registry_reference
+                report.set_stage(image_name, "bootstrap", "pass", **stage_details)
+
             except Exception as e:
                 log_error(f"Error processing {yaml_file}: {e}")
+                report.set_stage(yaml_file.stem, "bootstrap", "fail", reason=str(e))
 
     # Summary
     total = created_count + updated_count
@@ -321,6 +342,8 @@ Examples:
     if no_ref_count > 0:
         log_warn(f"No OCI reference (local path): {Colors.YELLOW}{no_ref_count}{Colors.NORM}")
     log_info(f"Total: {total}")
+
+    report.save()
 
 
 if __name__ == "__main__":

--- a/scripts/bootstrapPluginBuilds.py
+++ b/scripts/bootstrapPluginBuilds.py
@@ -24,8 +24,7 @@ from plugin_utils import (
     log_warn,
     log_error,
     set_debug,
-    read_plugins_list,
-    match_metadata_to_plugin_path,
+    build_workspace_mappings,
     load_and_resolve_to_npm_names,
 )
 
@@ -216,6 +215,9 @@ Examples:
 
     print(f"\n{Colors.GREEN}=== Bootstrap plugin_builds from workspace metadata ==={Colors.NORM}\n")
 
+    # Build workspace mappings upfront for stem → workspace path resolution
+    ws_mappings = build_workspace_mappings(overlays_dir)
+
     # Find all workspace directories with metadata
     workspace_dirs = sorted([
         d for d in workspaces_dir.iterdir()
@@ -230,7 +232,6 @@ Examples:
     for workspace_dir in workspace_dirs:
         workspace_name = workspace_dir.name
         metadata_dir = workspace_dir / "metadata"
-        plugin_paths = read_plugins_list(workspace_dir)
 
         yaml_files = sorted(metadata_dir.glob("*.yaml"))
         if not yaml_files:
@@ -252,14 +253,6 @@ Examples:
                 package_name = spec.get('packageName', '')
                 support_level = spec.get('support', '')
 
-                # Derive workspacePath
-                matched_path = match_metadata_to_plugin_path(stem, plugin_paths)
-                if matched_path:
-                    workspace_path = f"{workspace_name}/{matched_path}"
-                else:
-                    workspace_path = f"{workspace_name}/{stem}"
-                    log_debug(f"No plugins-list match for {stem}, using fallback: {workspace_path}")
-
                 # Check packages filter (by npm package name)
                 if packages_set is not None and package_name not in packages_set:
                     skipped_count += 1
@@ -267,6 +260,15 @@ Examples:
 
                 # Construct registryReference
                 image_name = package_name_to_image_name(package_name) if package_name else stem
+
+                # Look up workspacePath from pre-built mappings (uses scored matching
+                # + process-of-elimination to handle divergent folder/package names)
+                workspace_path = ws_mappings.ws_path_to_npm and next(
+                    (wp for wp, npm in ws_mappings.ws_path_to_npm.items() if npm == package_name), None
+                )
+                if not workspace_path:
+                    workspace_path = f"{workspace_name}/{stem}"
+                    log_debug(f"No workspace mapping for {package_name}, using fallback: {workspace_path}")
                 effective_registry = registry_base
                 if support_level == 'community' and community_registry != registry_base:
                     effective_registry = community_registry

--- a/scripts/generateCatalogIndex.py
+++ b/scripts/generateCatalogIndex.py
@@ -12,6 +12,7 @@
 # - Use that file to update all file refs to oci:// refs
 
 import argparse
+import importlib.util
 import json
 import os
 import re
@@ -23,6 +24,7 @@ import requests
 import yaml
 
 from plugin_utils import (
+    BuildReport,
     Colors,
     log_debug,
     log_info,
@@ -48,7 +50,7 @@ def get_image_name_from_package_yaml(yaml_path: Path) -> str | None:
     This matches the key used in plugin_builds JSON and found_plugins.
     Falls back to metadata.name, then filename stem."""
     try:
-        with open(yaml_path, 'r') as f:
+        with open(yaml_path, 'r', encoding='utf-8') as f:
             data = yaml.safe_load(f)
         if not data:
             return yaml_path.stem
@@ -96,6 +98,99 @@ def parse_image_reference(registry_reference: str) -> tuple[str, str, str]:
 
     return name_with_tag, "", digest if sep else ""
 
+
+TAG_COMMENT_RE = re.compile(r'^\s*# Tag: ([^,]+), Build date: (\S+)\s*$')
+OCI_PACKAGE_DIGEST_RE = re.compile(
+    r'^\s*(#\s*)?-\s+package:\s+oci://[^\s]+@(sha256:[a-f0-9]+)\s*$'
+)
+COMMENTED_OCI_PACKAGE_RE = re.compile(r'^\s*#\s*-\s+package:\s+oci://')
+MIGRATION_HINT_RE = re.compile(
+    r'^\s*#\s*(new approach using oci images|the \'package\' line above|disabled: true)\b'
+)
+
+
+def tag_comment_for_plugin(plugin_data: dict) -> str | None:
+    build_date = plugin_data.get('build-date') or ''
+    tag = plugin_data.get('imageTag') or ''
+    _, fallback_tag, digest = parse_image_reference(plugin_data.get('registryReference', ''))
+    tag = tag or fallback_tag
+    if tag and build_date and digest:
+        return f"# Tag: {tag}, Build date: {build_date}"
+    return None
+
+
+def is_tag_comment_line(line: str) -> bool:
+    return bool(TAG_COMMENT_RE.match(line))
+
+
+def tag_comment_line_text(comment: str) -> str:
+    return f"  {comment}\n"
+
+
+def pop_trailing_tag_comments(new_lines: list[str]) -> None:
+    while new_lines and is_tag_comment_line(new_lines[-1]):
+        new_lines.pop()
+
+
+def trailing_tag_comment_matches(new_lines: list[str], expected_comment: str | None) -> bool:
+    if not expected_comment:
+        return False
+    for line in reversed(new_lines):
+        if not line.strip():
+            continue
+        if is_tag_comment_line(line):
+            return line.strip() == expected_comment
+        return False
+    return False
+
+
+def digest_from_oci_package_line(line: str) -> str | None:
+    m = OCI_PACKAGE_DIGEST_RE.match(line)
+    return m.group(2) if m else None
+
+
+def peek_digest_after(lines: list[str], idx: int) -> str | None:
+    j = idx + 1
+    while j < len(lines):
+        nl = lines[j]
+        if not nl.strip():
+            j += 1
+            continue
+        if is_tag_comment_line(nl):
+            j += 1
+            continue
+        digest = digest_from_oci_package_line(nl)
+        if digest:
+            return digest
+        return None
+    return None
+
+
+def inject_dpdy_tag_comments(output_dir: Path, plugin_builds_dir: Path) -> None:
+    """Ensure Tag/Build date comments on commented oci:// lines and wrapper package lines."""
+    dpdy = output_dir / "dynamic-plugins.default.yaml"
+    script = Path(__file__).resolve().parent / "injectDpdyTagComments.py"
+    if not dpdy.is_file() or not script.is_file():
+        return
+    spec = importlib.util.spec_from_file_location("injectDpdyTagComments", script)
+    if spec is None or spec.loader is None:
+        return
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    if mod.inject(dpdy, plugin_builds_dir):
+        log_debug(f"Injected Tag/Build date comments into {dpdy.name}")
+
+
+def build_digest_comment_map(index_data: dict[str, dict]) -> dict[str, str]:
+    digest_comment_map: dict[str, str] = {}
+    for pdata in index_data.values():
+        comment = tag_comment_for_plugin(pdata)
+        if not comment:
+            continue
+        _, _, digest = parse_image_reference(pdata.get('registryReference', ''))
+        if digest:
+            digest_comment_map[digest] = comment
+    return digest_comment_map
 
 def copy_catalog_entities_extensions(source_dir: Path, output_dir: Path) -> None:
     """Copy content from catalog-entities/extensions source to output catalog-entities/extensions."""
@@ -225,7 +320,7 @@ def check_image_exists(registry_reference: str) -> bool:
         return False
 
 
-def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict[str, dict], list[str], list[tuple[str, str, str]], dict[str, str], dict[str, dict]]:
+def generate_index_json(plugin_builds_dir: Path, output_dir: Path, report: BuildReport | None = None) -> tuple[dict[str, dict], list[str], list[tuple[str, str, str]], dict[str, str], dict[str, dict]]:
     """
     Read *.json files in plugin_builds/ and check if registryReference exists.
     Combine valid ones into index.json.
@@ -242,8 +337,8 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict
     json_files = list(plugin_builds_dir.glob("*/*.json"))
 
     if not json_files:
-        log_error("No JSON files found in plugin_builds/")
-        sys.exit(1)
+        log_warn("No JSON files found in plugin_builds/")
+        return {}, [], [], {}, {}
 
     log_info(f"Found {len(json_files)} JSON file(s) to process")
 
@@ -260,7 +355,7 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict
         print(f"\n{Colors.NORM}[{i}/{len(json_files)}] {relative_path}{Colors.NORM}")
 
         try:
-            with open(json_file, 'r') as f:
+            with open(json_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
 
             for plugin_name, plugin_data in data.items():
@@ -276,6 +371,11 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict
                     missing_count += 1
                     print(f"{Colors.RED}[{i}/{len(json_files)}] ! No OCI reference found{Colors.NORM} ({missing_count})")
                     missing_references.append((str(relative_path), plugin_name, "no registryReference field"))
+                    if report:
+                        report.set_stage(
+                            plugin_name, "catalog-index", "fail",
+                            reason="No registryReference field",
+                        )
                     continue
 
                 query_ref = get_query_registry_reference(registry_reference)
@@ -284,10 +384,17 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict
                     print(f"[{i}/{len(json_files)}] {registry_reference} ({found_count})")
                     combined_index[plugin_name] = plugin_data
                     found_plugins.append(plugin_name)
+                    if report:
+                        report.set_stage(plugin_name, "catalog-index", "pass")
                 else:
                     missing_count += 1
                     print(f"{Colors.RED}[{i}/{len(json_files)}]{Colors.NORM} {registry_reference} {Colors.RED}could not be resolved{Colors.NORM} ({missing_count})")
                     missing_references.append((str(relative_path), plugin_name, registry_reference))
+                    if report:
+                        report.set_stage(
+                            plugin_name, "catalog-index", "fail",
+                            reason=f"Image not found in registry: {registry_reference}",
+                        )
 
         except json.JSONDecodeError as e:
             log_error(f"Error parsing JSON file {json_file}: {e}")
@@ -299,8 +406,12 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict
             missing_references.append((str(relative_path), "N/A", f"Error: {e}"))
 
     if not combined_index:
-        log_error("No plugins found! Cannot generate index.json")
-        sys.exit(1)
+        log_warn("No plugins with resolvable OCI images found — writing empty catalog-index/index.json")
+        catalog_index_json.parent.mkdir(parents=True, exist_ok=True)
+        with open(catalog_index_json, 'w', encoding='utf-8') as f:
+            json.dump({}, f, indent=2)
+            f.write('\n')
+        return {}, [], missing_references, plugin_workspace_paths, all_plugin_data
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -329,7 +440,7 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict
                 ordered_plugin[key] = value
         ordered_index[plugin_name] = ordered_plugin
 
-    with open(catalog_index_json, 'w') as f:
+    with open(catalog_index_json, 'w', encoding='utf-8') as f:
         json.dump(ordered_index, f, indent=2)
         f.write('\n')
 
@@ -342,7 +453,7 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict
     return combined_index, found_plugins, missing_references, plugin_workspace_paths, all_plugin_data
 
 
-def update_package_files(output_dir: Path, index_data: dict[str, dict], found_plugins: list[str]) -> None:
+def update_package_files(output_dir: Path, index_data: dict[str, dict], found_plugins: list[str], plugin_builds_dir: Path) -> None:
     """Add OCI reference entries alongside existing file path entries"""
     packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
     dynamic_plugins_yaml = output_dir / "dynamic-plugins.default.yaml"
@@ -353,17 +464,16 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
 
     files_updated = 0
     plugins_matched_in_dynamic_yaml = 0
+    digest_comment_map = build_digest_comment_map(index_data)
 
     for plugin_name in found_plugins:
         plugin_data = index_data[plugin_name]
         registry_reference = plugin_data.get('registryReference', '')
-        build_date = plugin_data.get('build-date', '')
 
         name_no_tag, _, parsed_digest = parse_image_reference(registry_reference)
-        tag = plugin_data.get('imageTag')
         registry_reference_for_oci = f"{name_no_tag}@{parsed_digest}" if parsed_digest else registry_reference
-
-        comment = f"# Tag: {tag}, Build date: {build_date}"
+        expected_comment = tag_comment_for_plugin(plugin_data)
+        expected_oci_line = f"  - package: oci://{registry_reference_for_oci}\n"
 
         plugin_name_alternative = plugin_name.replace("red-hat-developer-hub-", "rhdh-")
 
@@ -383,7 +493,7 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
                 continue
 
             try:
-                with open(yaml_file, 'r') as f:
+                with open(yaml_file, 'r', encoding='utf-8') as f:
                     lines = f.readlines()
 
                 new_lines = []
@@ -392,6 +502,30 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
 
                 while i < len(lines):
                     line = lines[i]
+
+                    if COMMENTED_OCI_PACKAGE_RE.match(line) or MIGRATION_HINT_RE.match(line):
+                        new_lines.append(line)
+                        i += 1
+                        continue
+
+                    if is_tag_comment_line(line):
+                        j = i + 1
+                        while j < len(lines) and not lines[j].strip():
+                            j += 1
+                        if j < len(lines) and COMMENTED_OCI_PACKAGE_RE.match(lines[j]):
+                            new_lines.append(line)
+                            i += 1
+                            continue
+                        digest = peek_digest_after(lines, i)
+                        if digest:
+                            expected = digest_comment_map.get(digest)
+                            if expected and line.strip() == expected:
+                                new_lines.append(line)
+                        else:
+                            new_lines.append(line)
+                        i += 1
+                        continue
+
                     matched_oci = False
 
                     for pname in [plugin_name, plugin_name_alternative,
@@ -406,10 +540,29 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
                             matched_oci = True
 
                     if matched_oci:
-                        modified = True
-                        while new_lines and ('Tag:' in new_lines[-1] or 'Build date:' in new_lines[-1]):
-                            new_lines.pop()
+                        pop_trailing_tag_comments(new_lines)
+                        oci_unchanged = line.rstrip() == expected_oci_line.rstrip()
+                        if oci_unchanged and trailing_tag_comment_matches(new_lines, expected_comment):
+                            new_lines.append(line)
+                            i += 1
+                            while i < len(lines):
+                                next_line = lines[i]
+                                if not next_line.strip():
+                                    new_lines.append(next_line)
+                                    i += 1
+                                    continue
+                                if next_line.startswith((' ', '\t')):
+                                    if not is_tag_comment_line(next_line):
+                                        new_lines.append(next_line)
+                                    i += 1
+                                    continue
+                                if is_tag_comment_line(next_line):
+                                    i += 1
+                                    continue
+                                break
+                            continue
 
+                        modified = True
                         preserved_lines = []
                         i += 1
                         while i < len(lines):
@@ -417,18 +570,19 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
                             if not next_line.strip():
                                 i += 1
                                 continue
-                            if next_line.startswith(' ') or next_line.startswith('\t'):
-                                if not (next_line.strip().startswith('#') and 'Tag:' in next_line):
+                            if next_line.startswith((' ', '\t')):
+                                if not is_tag_comment_line(next_line):
                                     preserved_lines.append(next_line)
                                 i += 1
                                 continue
-                            if next_line.strip().startswith('#') and ('Tag:' in next_line or 'Build date:' in next_line):
+                            if is_tag_comment_line(next_line):
                                 i += 1
                                 continue
                             break
 
-                        new_lines.append(f"  {comment}\n")
-                        new_lines.append(f"  - package: oci://{registry_reference_for_oci}\n")
+                        if expected_comment:
+                            new_lines.append(tag_comment_line_text(expected_comment))
+                        new_lines.append(expected_oci_line)
                         for pl in preserved_lines:
                             new_lines.append(pl)
                         continue
@@ -438,11 +592,30 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
                                   plugin_name_with_dynamic, plugin_name_alternative_with_dynamic]:
                         pattern = rf'^  - package: \.\/dynamic-plugins\/dist\/{re.escape(pname)}\s*$'
                         if re.match(pattern, line):
-                            new_lines.append(f"  # - package: oci://{registry_reference_for_oci}\n")
-                            new_lines.append(f"  {comment}\n")
-                            new_lines.append("  # new approach using oci images: to switch to the new approach, uncomment\n")
-                            new_lines.append("  # the 'package' line above and remove the next two lines, keeping the pluginConfig.\n")
-                            new_lines.append("  # disabled: true\n")
+                            commented_oci = f"  # - package: oci://{registry_reference_for_oci}\n"
+                            block_exists = commented_oci.rstrip() in {
+                                l.rstrip() for l in new_lines[-15:]
+                            }
+                            if block_exists:
+                                if expected_comment and not trailing_tag_comment_matches(
+                                    new_lines, expected_comment
+                                ):
+                                    pop_trailing_tag_comments(new_lines)
+                                    modified = True
+                                    new_lines.append(tag_comment_line_text(expected_comment))
+                            else:
+                                pop_trailing_tag_comments(new_lines)
+                                modified = True
+                                new_lines.append(commented_oci)
+                                if expected_comment:
+                                    new_lines.append(tag_comment_line_text(expected_comment))
+                                new_lines.append(
+                                    "  # new approach using oci images: to switch to the new approach, uncomment\n"
+                                )
+                                new_lines.append(
+                                    "  # the 'package' line above and remove the next two lines, keeping the pluginConfig.\n"
+                                )
+                                new_lines.append("  # disabled: true\n")
 
                             new_lines.append(line)
 
@@ -451,17 +624,16 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
                                 next_line = lines[i]
                                 if next_line.strip() and not next_line.startswith(' ') and not next_line.startswith('\t'):
                                     break
-                                new_lines.append(next_line)
+                                if not is_tag_comment_line(next_line):
+                                    new_lines.append(next_line)
                                 i += 1
 
-                            modified = True
                             log_debug(f"Added OCI reference for {pname} in {yaml_file.name}")
                             i -= 1
                             matched = True
                             break
 
                     if not matched:
-                        # Pattern matches: dynamicArtifact: '', dynamicArtifact: "", dynamicArtifact: ~, dynamicArtifact: null, or just dynamicArtifact:
                         empty_artifact_pattern = r"^(\s*)dynamicArtifact:(\s+(?:''|\"\"|\~|null))?\s*$"
                         empty_match = re.match(empty_artifact_pattern, line)
                         if empty_match:
@@ -477,7 +649,7 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
                     i += 1
 
                 if modified:
-                    with open(yaml_file, 'w') as f:
+                    with open(yaml_file, 'w', encoding='utf-8') as f:
                         f.writelines(new_lines)
                     files_updated += 1
                     if yaml_file == dynamic_plugins_yaml:
@@ -485,6 +657,8 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
 
             except Exception as e:
                 log_error(f"Error updating {yaml_file}: {e}")
+
+    inject_dpdy_tag_comments(output_dir, plugin_builds_dir)
 
     if files_updated > 0:
         log_info(f"Updated {files_updated} file(s) with OCI references")
@@ -542,7 +716,7 @@ def regenerate_all_yaml_files(output_dir: Path) -> None:
             continue
 
         all_yaml_path = dir_path / "all.yaml"
-        with open(all_yaml_path, 'w') as f:
+        with open(all_yaml_path, 'w', encoding='utf-8') as f:
             f.write("apiVersion: backstage.io/v1alpha1\n")
             f.write("kind: Location\n")
             f.write("metadata:\n")
@@ -575,7 +749,7 @@ def scrub_plugin_entity_file(yaml_file: Path, filtered_stems: set[str]) -> str:
     Returns: 'removed' | 'stripped' | 'kept' | 'skipped'
     """
     try:
-        with open(yaml_file, 'r') as f:
+        with open(yaml_file, 'r', encoding='utf-8') as f:
             data = yaml.safe_load(f)
 
         if not data or data.get('kind') != 'Plugin':
@@ -603,7 +777,7 @@ def scrub_plugin_entity_file(yaml_file: Path, filtered_stems: set[str]) -> str:
             return 'kept'
 
         # Mixed plugin: remove excluded package lines using line-based editing
-        with open(yaml_file, 'r') as f:
+        with open(yaml_file, 'r', encoding='utf-8') as f:
             lines = f.readlines()
 
         new_lines = []
@@ -631,7 +805,7 @@ def scrub_plugin_entity_file(yaml_file: Path, filtered_stems: set[str]) -> str:
 
             new_lines.append(line)
 
-        with open(yaml_file, 'w') as f:
+        with open(yaml_file, 'w', encoding='utf-8') as f:
             f.writelines(new_lines)
 
         return 'stripped'
@@ -678,7 +852,7 @@ def scrub_catalog_entities(output_dir: Path, overlays_dir: Path, packages_files:
             if yaml_file.name == "all.yaml":
                 continue
             try:
-                with open(yaml_file, 'r') as f:
+                with open(yaml_file, 'r', encoding='utf-8') as f:
                     data = yaml.safe_load(f)
                 entity_name = (data or {}).get('metadata', {}).get('name', yaml_file.stem)
             except Exception:
@@ -773,6 +947,12 @@ Examples:
              'Defaults to <overlays-dir>/catalog-entities/extensions/',
     )
     parser.add_argument(
+        '--report-file',
+        type=str,
+        metavar='PATH',
+        help='Path to build-report.json for tracking generation stages (optional)',
+    )
+    parser.add_argument(
         '--debug',
         action='store_true',
         help='Enable debug output',
@@ -805,15 +985,17 @@ Examples:
         print(f"\n{Colors.GREEN}=== Scrub catalog entities to packages from {len(args.packages_file)} file(s) ==={Colors.NORM}")
         scrub_catalog_entities(output_dir, overlays_dir, args.packages_file)
 
+    report = BuildReport(args.report_file)
+
     print(f"\n{Colors.GREEN}=== Generate index.json from plugin_builds ==={Colors.NORM}")
-    index_data, found_plugins, missing_references, plugin_workspace_paths, all_plugin_data = generate_index_json(plugin_builds_dir, output_dir)
+    index_data, found_plugins, missing_references, plugin_workspace_paths, all_plugin_data = generate_index_json(plugin_builds_dir, output_dir, report)
 
     print(f"\n{Colors.GREEN}=== Prune packages/ to match index ==={Colors.NORM}")
     prune_packages_dir(output_dir, found_plugins)
 
     print(f"\n{Colors.GREEN}=== Update package files with OCI references ==={Colors.NORM}")
     log_debug(f"Found {len(found_plugins)} plugins with valid OCI images")
-    update_package_files(output_dir, index_data, found_plugins)
+    update_package_files(output_dir, index_data, found_plugins, plugin_builds_dir)
 
     print(f"\n{Colors.GREEN}=== Regenerate all.yaml files ==={Colors.NORM}")
     regenerate_all_yaml_files(output_dir)
@@ -857,6 +1039,8 @@ Examples:
                 label = support if support else '?UNKNOWN?'
                 color = _support_label_color(label)
                 print(f"  - {color}[{label}]{Colors.NORM} {workspace_path}")
+
+    report.save()
 
     if missing_references:
         print("\n========")

--- a/scripts/generateCatalogIndex.py
+++ b/scripts/generateCatalogIndex.py
@@ -39,7 +39,7 @@ REGISTRY_BASE = ""
 
 
 def is_registry_rarc() -> bool:
-    """Check if the registry is registry.access.redhat.com (downstream GA registry)"""
+    """Check if REGISTRY_BASE is registry.access.redhat.com. Used to determine if queries should be routed through quay.io for unauthenticated access."""
     return REGISTRY_BASE.startswith("registry.access.redhat.com")
 
 
@@ -86,6 +86,31 @@ def get_ghcr_token(repository: str) -> str | None:
 
 
 def parse_image_reference(registry_reference: str) -> tuple[str, str, str]:
+    """Split a container image reference into its name, tag, and digest components.
+
+    Handles all combinations of tag and digest presence, including references
+    with both (tag + digest), tag only, digest only, or empty string input.
+    Tag separators vary by registry: ghcr.io uses ``bs_{bsver}__{pluginver}``
+    while quay.io/rhdh uses ``{rhdhver}--{pluginver}``.
+
+    Args:
+        registry_reference: A container image reference string, e.g.
+            ``"quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123"``.
+
+    Returns:
+        A 3-tuple of ``(image_name, tag, digest)`` where any component may
+        be an empty string if not present in the input.
+
+    Examples:
+        >>> parse_image_reference("quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123")
+        ('quay.io/rhdh/plugin', '1.11--1.5.4', 'sha256:abc123')
+        >>> parse_image_reference("quay.io/rhdh/plugin:1.11--1.5.4")
+        ('quay.io/rhdh/plugin', '1.11--1.5.4', '')
+        >>> parse_image_reference("quay.io/rhdh/plugin@sha256:abc123")
+        ('quay.io/rhdh/plugin', '', 'sha256:abc123')
+        >>> parse_image_reference("")
+        ('', '', '')
+    """
     if not registry_reference:
         return "", "", ""
 
@@ -110,6 +135,31 @@ MIGRATION_HINT_RE = re.compile(
 
 
 def tag_comment_for_plugin(plugin_data: dict) -> str | None:
+    """Build a tag/build-date comment string from plugin build data.
+
+    Constructs a YAML comment line summarizing the image tag and build date
+    for a plugin. These comments are inserted above OCI package lines in
+    package YAML files and dynamic-plugins.default.yaml to provide
+    human-readable provenance.
+
+    Args:
+        plugin_data: A dict from plugin_builds JSON containing at minimum
+            ``'build-date'``, ``'registryReference'``, and optionally
+            ``'imageTag'``. The tag is taken from ``'imageTag'`` if present,
+            otherwise extracted from the registryReference.
+
+    Returns:
+        A comment string like ``"# Tag: 1.11--1.5.4, Build date: 2025-05-01"``,
+        or ``None`` if any of tag, build_date, or digest is missing.
+
+    Example:
+        >>> tag_comment_for_plugin({
+        ...     'build-date': '2025-05-01',
+        ...     'registryReference': 'quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc',
+        ...     'imageTag': '1.11--1.5.4',
+        ... })
+        '# Tag: 1.11--1.5.4, Build date: 2025-05-01'
+    """
     build_date = plugin_data.get('build-date') or ''
     tag = plugin_data.get('imageTag') or ''
     _, fallback_tag, digest = parse_image_reference(plugin_data.get('registryReference', ''))
@@ -120,19 +170,23 @@ def tag_comment_for_plugin(plugin_data: dict) -> str | None:
 
 
 def is_tag_comment_line(line: str) -> bool:
+    """Check if a line matches the ``# Tag: ..., Build date: ...`` pattern."""
     return bool(TAG_COMMENT_RE.match(line))
 
 
 def tag_comment_line_text(comment: str) -> str:
+    """Wrap a tag comment string with 2-space indentation and trailing newline."""
     return f"  {comment}\n"
 
 
 def pop_trailing_tag_comments(new_lines: list[str]) -> None:
+    """Remove trailing tag comment lines from the end of a line buffer."""
     while new_lines and is_tag_comment_line(new_lines[-1]):
         new_lines.pop()
 
 
 def trailing_tag_comment_matches(new_lines: list[str], expected_comment: str | None) -> bool:
+    """Check if the last non-blank line in the buffer matches the expected tag comment."""
     if not expected_comment:
         return False
     for line in reversed(new_lines):
@@ -145,11 +199,13 @@ def trailing_tag_comment_matches(new_lines: list[str], expected_comment: str | N
 
 
 def digest_from_oci_package_line(line: str) -> str | None:
+    """Extract the sha256 digest from an OCI package line, or None if not matched."""
     m = OCI_PACKAGE_DIGEST_RE.match(line)
     return m.group(2) if m else None
 
 
 def peek_digest_after(lines: list[str], idx: int) -> str | None:
+    """Look ahead in lines starting after idx to find the next OCI package digest."""
     j = idx + 1
     while j < len(lines):
         nl = lines[j]
@@ -167,7 +223,7 @@ def peek_digest_after(lines: list[str], idx: int) -> str | None:
 
 
 def inject_dpdy_tag_comments(output_dir: Path, plugin_builds_dir: Path) -> None:
-    """Ensure Tag/Build date comments on commented oci:// lines and wrapper package lines."""
+    """Delegate to injectDpdyTagComments.py to add Tag/Build date comments to dynamic-plugins.default.yaml."""
     dpdy = output_dir / "dynamic-plugins.default.yaml"
     script = Path(__file__).resolve().parent / "injectDpdyTagComments.py"
     if not dpdy.is_file() or not script.is_file():
@@ -182,6 +238,31 @@ def inject_dpdy_tag_comments(output_dir: Path, plugin_builds_dir: Path) -> None:
 
 
 def build_digest_comment_map(index_data: dict[str, dict]) -> dict[str, str]:
+    """Build a mapping from sha256 digests to their tag comment strings.
+
+    Iterates over index data and creates a lookup dict so that OCI package
+    lines containing a digest can be matched to their corresponding
+    human-readable tag comment.
+
+    Args:
+        index_data: The combined index dict mapping plugin names to their
+            plugin data dicts (as produced by ``generate_index_json``).
+
+    Returns:
+        A dict mapping digest strings to comment strings, e.g.
+        ``{"sha256:abc123": "# Tag: 1.11--1.5.4, Build date: 2025-05-01"}``.
+        Only entries with a valid tag comment and digest are included.
+
+    Example:
+        >>> build_digest_comment_map({
+        ...     "my-plugin": {
+        ...         "registryReference": "quay.io/rhdh/plugin@sha256:abc123",
+        ...         "imageTag": "1.11--1.5.4",
+        ...         "build-date": "2025-05-01",
+        ...     }
+        ... })
+        {'sha256:abc123': '# Tag: 1.11--1.5.4, Build date: 2025-05-01'}
+    """
     digest_comment_map: dict[str, str] = {}
     for pdata in index_data.values():
         comment = tag_comment_for_plugin(pdata)
@@ -193,7 +274,7 @@ def build_digest_comment_map(index_data: dict[str, dict]) -> dict[str, str]:
     return digest_comment_map
 
 def copy_catalog_entities_extensions(source_dir: Path, output_dir: Path) -> None:
-    """Copy content from catalog-entities/extensions source to output catalog-entities/extensions."""
+    """Copy the catalog-entities/extensions/ source directory to the output directory."""
     target_dir = output_dir / "catalog-entities" / "extensions"
 
     if not source_dir.exists():
@@ -223,11 +304,25 @@ def copy_catalog_entities_extensions(source_dir: Path, output_dir: Path) -> None
 
 
 def copy_workspace_metadata_files(overlays_dir: Path, output_dir: Path) -> tuple[set, dict[str, str]]:
-    """
-    Task 2: Find all *.yaml files in workspaces/*/metadata/ and copy them to
-    output catalog-entities/extensions/packages/
+    """Copy workspace metadata YAML files to the output packages directory.
 
-    Returns: (set of YAML file base names, dict mapping base names to full relative paths)
+    Finds all ``workspaces/*/metadata/*.yaml`` files in the overlays directory
+    and copies them to ``<output_dir>/catalog-entities/extensions/packages/``.
+    These are ``kind: Package`` entity files that describe each built plugin
+    artifact (version, OCI reference, appConfigExamples).
+
+    Args:
+        overlays_dir: Root of the overlays repository containing the
+            ``workspaces/`` directory.
+        output_dir: Output directory where the catalog index is being
+            assembled.
+
+    Returns:
+        A 2-tuple of:
+        - A set of YAML file base names (stems without extension), e.g.
+          ``{"backstage-plugin-techdocs", "backstage-plugin-catalog"}``.
+        - A dict mapping each base name to its relative source path, e.g.
+          ``{"backstage-plugin-techdocs": "workspaces/backstage/metadata/backstage-plugin-techdocs.yaml"}``.
     """
     overlay_workspaces = overlays_dir / "workspaces"
     target_packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
@@ -260,7 +355,7 @@ def copy_workspace_metadata_files(overlays_dir: Path, output_dir: Path) -> tuple
 
 
 def check_image_exists(registry_reference: str) -> bool:
-    """Check if a container image exists using Docker Registry HTTP API v2"""
+    """Check if a container image exists in the registry using a Docker Registry HTTP API v2 HEAD request."""
     try:
         parts = registry_reference.split('/', 1)
         if len(parts) < 2:
@@ -321,12 +416,42 @@ def check_image_exists(registry_reference: str) -> bool:
 
 
 def generate_index_json(plugin_builds_dir: Path, output_dir: Path, report: BuildReport | None = None) -> tuple[dict[str, dict], list[str], list[tuple[str, str, str]], dict[str, str], dict[str, dict]]:
-    """
-    Read *.json files in plugin_builds/ and check if registryReference exists.
-    Combine valid ones into index.json.
-    No filtering — plugin_builds/ is already pre-filtered by bootstrapPluginBuilds.py.
+    """Generate the catalog index.json from plugin_builds/ metadata.
 
-    Returns: (combined_index, found_plugins, missing_references, plugin_workspace_paths, all_plugin_data)
+    This is the core pipeline of the catalog index generator. It reads each
+    JSON file in ``plugin_builds/``, where each file is a dict mapping
+    plugin image names (e.g. ``"red-hat-developer-hub-backstage-plugin-foo"``)
+    to plugin data dicts containing fields like ``registryReference``,
+    ``digest``, ``build-date``, ``vcs-ref``, ``workspacePath``, and
+    ``support``. For each plugin, it verifies the OCI image exists in the
+    registry (swapping registry.access.redhat.com queries to quay.io for
+    unauthenticated access), then writes all valid entries into an ordered
+    ``index.json``.
+
+    The ``plugin_builds/`` directory is pre-filtered by
+    ``bootstrapPluginBuilds.py`` to the appropriate tier (supported,
+    community, etc.), so no additional filtering is performed here.
+
+    Args:
+        plugin_builds_dir: Path to the ``plugin_builds/`` directory
+            containing ``<workspace>/*.json`` files.
+        output_dir: Output directory where ``index.json`` will be written.
+        report: Optional ``BuildReport`` instance for tracking per-plugin
+            pass/fail status of the catalog-index stage.
+
+    Returns:
+        A 5-tuple of:
+        - ``combined_index``: Dict mapping plugin names to their plugin data
+          dicts for all plugins whose OCI images were found.
+        - ``found_plugins``: List of plugin names with valid OCI images,
+          in processing order.
+        - ``missing_references``: List of 3-tuples
+          ``(json_file_path, plugin_name, reason)`` for plugins that could
+          not be resolved.
+        - ``plugin_workspace_paths``: Dict mapping plugin names to their
+          workspace paths (e.g. ``"workspaces/backstage"``).
+        - ``all_plugin_data``: Dict of all plugin data regardless of OCI
+          image existence, used for diagnostic reporting.
     """
     catalog_index_json = output_dir / "index.json"
 
@@ -454,7 +579,37 @@ def generate_index_json(plugin_builds_dir: Path, output_dir: Path, report: Build
 
 
 def update_package_files(output_dir: Path, index_data: dict[str, dict], found_plugins: list[str], plugin_builds_dir: Path) -> None:
-    """Add OCI reference entries alongside existing file path entries"""
+    """Add or update OCI reference entries in package YAML files and dynamic-plugins.default.yaml.
+
+    Performs line-by-line editing on package YAML files and
+    ``dynamic-plugins.default.yaml`` to inject OCI image references. Handles
+    two distinct patterns:
+
+    1. **Replacing existing OCI lines**: When a ``- package: oci://...`` line
+       already exists for the plugin, it is replaced with the current digest
+       reference and its tag comment is updated.
+    2. **Adding commented OCI blocks**: When only a file-path entry exists
+       (``- package: ./dynamic-plugins/dist/...``), a commented-out OCI
+       block is added above it with migration hints, preserving the original
+       file-path entry.
+
+    Plugin name matching accounts for alternatives: the
+    ``red-hat-developer-hub-`` vs ``rhdh-`` prefix, and with/without the
+    ``-dynamic`` suffix.
+
+    Also delegates to ``inject_dpdy_tag_comments`` to handle tag comments
+    on lines that were not matched by the main loop (e.g., wrapper package
+    lines in dynamic-plugins.default.yaml).
+
+    Args:
+        output_dir: Output directory containing the catalog index being
+            assembled.
+        index_data: Combined index dict mapping plugin names to plugin data
+            (from ``generate_index_json``).
+        found_plugins: List of plugin names with valid OCI images.
+        plugin_builds_dir: Path to ``plugin_builds/`` directory, passed
+            through to ``inject_dpdy_tag_comments``.
+    """
     packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
     dynamic_plugins_yaml = output_dir / "dynamic-plugins.default.yaml"
 
@@ -672,7 +827,19 @@ def update_package_files(output_dir: Path, index_data: dict[str, dict], found_pl
 
 
 def prune_packages_dir(output_dir: Path, found_plugins: list[str]) -> None:
-    """Remove package YAML files from the output that don't correspond to plugins in the index."""
+    """Remove package YAML files that don't correspond to plugins in the index.
+
+    Iterates over ``catalog-entities/extensions/packages/*.yaml`` and deletes
+    any file whose image name (derived via ``get_image_name_from_package_yaml``)
+    is not present in the ``found_plugins`` list. This ensures the output
+    catalog only contains Package entities for plugins whose OCI images were
+    successfully resolved.
+
+    Args:
+        output_dir: Output directory containing the assembled catalog index.
+        found_plugins: List of plugin image names that have valid OCI images
+            in the registry (from ``generate_index_json``).
+    """
     packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
     if not packages_dir.exists():
         return
@@ -741,12 +908,30 @@ def _support_label_color(label: str) -> str:
 
 
 def scrub_plugin_entity_file(yaml_file: Path, filtered_stems: set[str]) -> str:
-    """Scrub a single Plugin entity YAML file.
-    - If no packages match the filter: delete the file
-    - If all packages match the filter: keep as-is
-    - If mixed: use line-based editing to remove excluded package refs
+    """Scrub a single Plugin entity YAML file based on a package filter.
 
-    Returns: 'removed' | 'stripped' | 'kept' | 'skipped'
+    Examines the ``spec.packages`` list of a ``kind: Plugin`` entity and
+    determines how to handle it relative to the allowed package stems:
+
+    - If **no** packages match the filter, the file is deleted entirely.
+    - If **all** packages match, the file is kept unchanged.
+    - If the match is **mixed**, line-based editing removes only the
+      excluded package references while preserving the rest of the file.
+
+    Non-Plugin entities (wrong ``kind`` or unparseable) are skipped.
+
+    Args:
+        yaml_file: Path to a Plugin entity YAML file in the
+            ``catalog-entities/extensions/plugins/`` directory.
+        filtered_stems: Set of allowed package entity names (metadata.name
+            values) derived from the package filter files.
+
+    Returns:
+        One of four status strings:
+        - ``'removed'``: File was deleted (no packages matched the filter).
+        - ``'stripped'``: File was edited to remove excluded package refs.
+        - ``'kept'``: File was left unchanged (all packages matched).
+        - ``'skipped'``: File was not a Plugin entity or could not be parsed.
     """
     try:
         with open(yaml_file, 'r', encoding='utf-8') as f:
@@ -817,7 +1002,25 @@ def scrub_plugin_entity_file(yaml_file: Path, filtered_stems: set[str]) -> str:
 
 
 def scrub_catalog_entities(output_dir: Path, overlays_dir: Path, packages_files: list[str]) -> None:
-    """Scrub catalog entities to only retain plugins/packages from the provided package files."""
+    """Scrub both plugins/ and packages/ directories to only retain entities from the package filter files.
+
+    Resolves the union of package stems from all provided filter files
+    (YAML and/or txt format), then:
+
+    1. Scrubs ``plugins/`` by delegating each Plugin entity YAML to
+       ``scrub_plugin_entity_file`` (removes, strips, or keeps).
+    2. Scrubs ``packages/`` by removing any Package metadata YAML whose
+       ``metadata.name`` is not in the resolved filter set.
+
+    Args:
+        output_dir: Output directory containing the assembled catalog index
+            with ``catalog-entities/extensions/plugins/`` and ``packages/``.
+        overlays_dir: Root of the overlays repository, used for resolving
+            workspace paths in txt-format filter files.
+        packages_files: List of paths to package filter files. Accepts YAML
+            (``default.packages.yaml`` with npm names) or txt (workspace
+            paths, one per line). Stems from all files are unioned.
+    """
     filtered_stems = load_and_resolve_to_stems(packages_files, overlays_dir)
     log_info(f"Resolved {len(filtered_stems)} filtered package stems from {len(packages_files)} file(s)")
 
@@ -1044,11 +1247,10 @@ Examples:
 
     if missing_references:
         print("\n========")
-        log_warn(f"Could not find {Colors.RED}{len(missing_references)}{Colors.NORM} plugins listed in plugin_builds/ folder! Remember to export and publish them, then re-run this script.")
+        log_warn(f"Could not find {Colors.YELLOW}{len(missing_references)}{Colors.NORM} plugins listed in plugin_builds/ folder! Remember to export and publish them, then re-run this script.")
         for json_file, _plugin_name, reference in missing_references:
-            print(f"  - {json_file} > {Colors.RED}https://{reference}{Colors.NORM}")
-        log_error(f"{len(missing_references)} plugin(s) missing from registry — catalog is incomplete")
-        sys.exit(1)
+            print(f"  - {json_file} > {Colors.YELLOW}https://{reference}{Colors.NORM}")
+        log_warn(f"{len(missing_references)} plugin(s) missing from registry — catalog published without them")
 
 
 if __name__ == "__main__":

--- a/scripts/generateCatalogIndex.py
+++ b/scripts/generateCatalogIndex.py
@@ -1,0 +1,871 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Using content in plugin_builds folder:
+# - Create a summary index.json file
+# - Use that file to update all file refs to oci:// refs
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+from collections import OrderedDict
+from pathlib import Path
+import requests
+import yaml
+
+from plugin_utils import (
+    Colors,
+    log_debug,
+    log_info,
+    log_warn,
+    log_error,
+    set_debug,
+    load_and_resolve_to_stems,
+)
+
+# Global registry config
+REGISTRY_BASE = ""
+
+
+def is_registry_rarc() -> bool:
+    """Check if the registry is registry.access.redhat.com (downstream GA registry)"""
+    return REGISTRY_BASE.startswith("registry.access.redhat.com")
+
+
+def get_image_name_from_package_yaml(yaml_path: Path) -> str | None:
+    """Extract the image name from a Package entity YAML file.
+    Uses spec.packageName (e.g. @red-hat-developer-hub/backstage-plugin-foo)
+    converted to image name format (red-hat-developer-hub-backstage-plugin-foo).
+    This matches the key used in plugin_builds JSON and found_plugins.
+    Falls back to metadata.name, then filename stem."""
+    try:
+        with open(yaml_path, 'r') as f:
+            data = yaml.safe_load(f)
+        if not data:
+            return yaml_path.stem
+        pkg_name = (data.get('spec') or {}).get('packageName', '')
+        if pkg_name:
+            return pkg_name.lstrip('@').replace('/', '-')
+        return data.get('metadata', {}).get('name', yaml_path.stem)
+    except Exception:
+        return yaml_path.stem
+
+
+def get_query_registry_reference(registry_reference: str) -> str:
+    """
+    Get the registry reference to use for querying.
+    For registry.access.redhat.com refs, swap to quay.io for unauthenticated verification.
+    Per-reference check — works with mixed-registry plugin_builds.
+    """
+    if registry_reference.startswith("registry.access.redhat.com/rhdh/"):
+        return registry_reference.replace("registry.access.redhat.com/rhdh/", "quay.io/rhdh/")
+    return registry_reference
+
+
+def get_ghcr_token(repository: str) -> str | None:
+    """Get anonymous bearer token for ghcr.io"""
+    try:
+        url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        return response.json().get("token")
+    except Exception as e:
+        log_debug(f"Failed to get ghcr.io token for {repository}: {e}")
+        return None
+
+
+def parse_image_reference(registry_reference: str) -> tuple[str, str, str]:
+    if not registry_reference:
+        return "", "", ""
+
+    name_with_tag, sep, digest = registry_reference.partition('@')
+
+    last_slash = name_with_tag.rfind('/')
+    last_colon = name_with_tag.rfind(':')
+    if last_colon > last_slash:
+        return name_with_tag[:last_colon], name_with_tag[last_colon + 1 :], digest if sep else ""
+
+    return name_with_tag, "", digest if sep else ""
+
+
+def copy_catalog_entities_extensions(source_dir: Path, output_dir: Path) -> None:
+    """Copy content from catalog-entities/extensions source to output catalog-entities/extensions."""
+    target_dir = output_dir / "catalog-entities" / "extensions"
+
+    if not source_dir.exists():
+        log_warn(f"Source directory {source_dir} does not exist. Skipping.")
+        return
+
+    if source_dir.resolve() == target_dir.resolve():
+        log_info(f"Source and target are the same directory, skipping copy:\n  {source_dir}")
+        return
+
+    log_info(f"Copy content from\n  {source_dir} to\n  {target_dir}")
+
+    for item in source_dir.iterdir():
+        if item.name == "README.md":
+            continue
+        target_item = target_dir / item.name
+        if target_item.exists():
+            if target_item.is_dir():
+                shutil.rmtree(target_item)
+            else:
+                target_item.unlink()
+        if item.is_dir():
+            shutil.copytree(str(item), str(target_item))
+        else:
+            target_item.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(item), str(target_item))
+
+
+def copy_workspace_metadata_files(overlays_dir: Path, output_dir: Path) -> tuple[set, dict[str, str]]:
+    """
+    Task 2: Find all *.yaml files in workspaces/*/metadata/ and copy them to
+    output catalog-entities/extensions/packages/
+
+    Returns: (set of YAML file base names, dict mapping base names to full relative paths)
+    """
+    overlay_workspaces = overlays_dir / "workspaces"
+    target_packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
+
+    if not overlay_workspaces.exists():
+        log_warn(f"Workspaces directory {overlay_workspaces} does not exist. Skipping Task 2.")
+        return set(), {}
+
+    target_packages_dir.mkdir(parents=True, exist_ok=True)
+
+    yaml_files = list(overlay_workspaces.glob("*/metadata/*.yaml"))
+
+    if not yaml_files:
+        log_warn("No YAML files found in workspace metadata directories")
+        return set(), {}
+
+    log_info(f"Found {len(yaml_files)} workspace/*/metadata/*.yaml")
+
+    yaml_file_names = set()
+    yaml_file_paths = {}
+    for yaml_file in yaml_files:
+        target_file = target_packages_dir / yaml_file.name
+        log_debug(f"Copy\n  {yaml_file.relative_to(overlay_workspaces)} to\n  {target_file.relative_to(output_dir)}")
+        shutil.copy2(str(yaml_file), str(target_file))
+        base_name = yaml_file.stem
+        yaml_file_names.add(base_name)
+        yaml_file_paths[base_name] = Path("workspaces/" + str(yaml_file.relative_to(overlay_workspaces)))
+
+    return yaml_file_names, yaml_file_paths
+
+
+def check_image_exists(registry_reference: str) -> bool:
+    """Check if a container image exists using Docker Registry HTTP API v2"""
+    try:
+        parts = registry_reference.split('/', 1)
+        if len(parts) < 2:
+            log_warn(f"Invalid registry reference format: {registry_reference}")
+            return False
+
+        registry = parts[0]
+        image_and_tag = parts[1]
+
+        if '@' in image_and_tag:
+            name_part, tag = image_and_tag.split('@', 1)
+            if ':' in name_part:
+                repository = name_part.rsplit(':', 1)[0]
+            else:
+                repository = name_part
+        elif ':' in image_and_tag:
+            repository, tag = image_and_tag.rsplit(':', 1)
+        else:
+            repository = image_and_tag
+            tag = 'latest'
+
+        url = f"https://{registry}/v2/{repository}/manifests/{tag}"
+
+        headers = {
+            'Accept': 'application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'
+        }
+
+        auth = None
+        if registry == "ghcr.io":
+            token = get_ghcr_token(repository)
+            if token:
+                headers['Authorization'] = f"Bearer {token}"
+        else:
+            username = os.environ.get('REGISTRY_USERNAME')
+            password = os.environ.get('REGISTRY_PASSWORD')
+            if username and password:
+                auth = (username, password)
+
+        response = requests.head(url, headers=headers, auth=auth, timeout=10, allow_redirects=True)
+
+        if response.status_code == 200:
+            return True
+        elif response.status_code == 401:
+            log_warn(f"Image {registry_reference} requires authentication")
+            return False
+        else:
+            return False
+
+    except requests.exceptions.Timeout:
+        log_warn(f"Timeout checking image {registry_reference}")
+        return False
+    except requests.exceptions.RequestException as e:
+        log_warn(f"Error checking image {registry_reference}: {e}")
+        return False
+    except Exception as e:
+        log_warn(f"Unexpected error checking image {registry_reference}: {e}")
+        return False
+
+
+def generate_index_json(plugin_builds_dir: Path, output_dir: Path) -> tuple[dict[str, dict], list[str], list[tuple[str, str, str]], dict[str, str], dict[str, dict]]:
+    """
+    Read *.json files in plugin_builds/ and check if registryReference exists.
+    Combine valid ones into index.json.
+    No filtering — plugin_builds/ is already pre-filtered by bootstrapPluginBuilds.py.
+
+    Returns: (combined_index, found_plugins, missing_references, plugin_workspace_paths, all_plugin_data)
+    """
+    catalog_index_json = output_dir / "index.json"
+
+    if not plugin_builds_dir.exists():
+        log_error(f"Plugin builds directory {plugin_builds_dir} does not exist")
+        sys.exit(1)
+
+    json_files = list(plugin_builds_dir.glob("*/*.json"))
+
+    if not json_files:
+        log_error("No JSON files found in plugin_builds/")
+        sys.exit(1)
+
+    log_info(f"Found {len(json_files)} JSON file(s) to process")
+
+    combined_index = {}
+    found_plugins = []
+    missing_references = []
+    plugin_workspace_paths = {}
+    all_plugin_data = {}
+    missing_count = 0
+    found_count = 0
+
+    for i, json_file in enumerate(json_files, 1):
+        relative_path = json_file.relative_to(plugin_builds_dir)
+        print(f"\n{Colors.NORM}[{i}/{len(json_files)}] {relative_path}{Colors.NORM}")
+
+        try:
+            with open(json_file, 'r') as f:
+                data = json.load(f)
+
+            for plugin_name, plugin_data in data.items():
+                registry_reference = plugin_data.get('registryReference')
+                workspace_path = plugin_data.get('workspacePath')
+
+                if workspace_path:
+                    plugin_workspace_paths[plugin_name] = f"workspaces/{workspace_path}"
+
+                all_plugin_data[plugin_name] = plugin_data
+
+                if not registry_reference:
+                    missing_count += 1
+                    print(f"{Colors.RED}[{i}/{len(json_files)}] ! No OCI reference found{Colors.NORM} ({missing_count})")
+                    missing_references.append((str(relative_path), plugin_name, "no registryReference field"))
+                    continue
+
+                query_ref = get_query_registry_reference(registry_reference)
+                if check_image_exists(query_ref):
+                    found_count += 1
+                    print(f"[{i}/{len(json_files)}] {registry_reference} ({found_count})")
+                    combined_index[plugin_name] = plugin_data
+                    found_plugins.append(plugin_name)
+                else:
+                    missing_count += 1
+                    print(f"{Colors.RED}[{i}/{len(json_files)}]{Colors.NORM} {registry_reference} {Colors.RED}could not be resolved{Colors.NORM} ({missing_count})")
+                    missing_references.append((str(relative_path), plugin_name, registry_reference))
+
+        except json.JSONDecodeError as e:
+            log_error(f"Error parsing JSON file {json_file}: {e}")
+            missing_count += 1
+            missing_references.append((str(relative_path), "N/A", f"JSON parse error: {e}"))
+        except Exception as e:
+            log_error(f"Error processing {json_file}: {e}")
+            missing_count += 1
+            missing_references.append((str(relative_path), "N/A", f"Error: {e}"))
+
+    if not combined_index:
+        log_error("No plugins found! Cannot generate index.json")
+        sys.exit(1)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    key_order = ['workspacePath', 'registryReference', 'build-date', 'vcs-ref', 'upstream', 'midstream']
+    ordered_index = OrderedDict()
+
+    for plugin_name in sorted(combined_index.keys()):
+        plugin_data = combined_index[plugin_name]
+        ordered_plugin = {}
+
+        registry_reference = plugin_data.get('registryReference', '')
+        digest = plugin_data.get('digest', '')
+
+        if registry_reference and digest:
+            name_no_tag, image_tag, _ = parse_image_reference(registry_reference)
+            plugin_data['imageTag'] = image_tag
+            plugin_data['registryReference'] = f"{name_no_tag}@{digest}"
+            if 'digest' in plugin_data:
+                del plugin_data['digest']
+
+        for key in key_order:
+            if key in plugin_data:
+                ordered_plugin[key] = plugin_data[key]
+        for key, value in plugin_data.items():
+            if key not in ordered_plugin:
+                ordered_plugin[key] = value
+        ordered_index[plugin_name] = ordered_plugin
+
+    with open(catalog_index_json, 'w') as f:
+        json.dump(ordered_index, f, indent=2)
+        f.write('\n')
+
+    log_info(f"Regenerated index.json with {Colors.GREEN}{found_count}{Colors.NORM} of {Colors.BLUE}{len(json_files)}{Colors.NORM} plugins")
+
+    if missing_count > 0:
+        print("\n========")
+        log_warn(f"Could not find {Colors.RED}{missing_count}{Colors.NORM} plugins - remember to export and publish them, then re-run this script")
+
+    return combined_index, found_plugins, missing_references, plugin_workspace_paths, all_plugin_data
+
+
+def update_package_files(output_dir: Path, index_data: dict[str, dict], found_plugins: list[str]) -> None:
+    """Add OCI reference entries alongside existing file path entries"""
+    packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
+    dynamic_plugins_yaml = output_dir / "dynamic-plugins.default.yaml"
+
+    if not packages_dir.exists():
+        log_warn(f"Packages directory {packages_dir} does not exist. Skipping.")
+        return
+
+    files_updated = 0
+    plugins_matched_in_dynamic_yaml = 0
+
+    for plugin_name in found_plugins:
+        plugin_data = index_data[plugin_name]
+        registry_reference = plugin_data.get('registryReference', '')
+        build_date = plugin_data.get('build-date', '')
+
+        name_no_tag, _, parsed_digest = parse_image_reference(registry_reference)
+        tag = plugin_data.get('imageTag')
+        registry_reference_for_oci = f"{name_no_tag}@{parsed_digest}" if parsed_digest else registry_reference
+
+        comment = f"# Tag: {tag}, Build date: {build_date}"
+
+        plugin_name_alternative = plugin_name.replace("red-hat-developer-hub-", "rhdh-")
+
+        plugin_name_with_dynamic = f"{plugin_name}-dynamic"
+        plugin_name_alternative_with_dynamic = f"{plugin_name_alternative}-dynamic"
+
+        log_debug(f"Checking for matches: {plugin_name} (or {plugin_name_alternative}, {plugin_name_with_dynamic}, {plugin_name_alternative_with_dynamic})")
+
+        files_to_update = [
+            dynamic_plugins_yaml,
+            packages_dir / f"{plugin_name}.yaml",
+            packages_dir / f"{plugin_name_alternative}.yaml"
+        ]
+
+        for yaml_file in files_to_update:
+            if not yaml_file.exists():
+                continue
+
+            try:
+                with open(yaml_file, 'r') as f:
+                    lines = f.readlines()
+
+                new_lines = []
+                i = 0
+                modified = False
+
+                while i < len(lines):
+                    line = lines[i]
+                    matched_oci = False
+
+                    for pname in [plugin_name, plugin_name_alternative,
+                                  plugin_name_with_dynamic, plugin_name_alternative_with_dynamic]:
+                        oci_pattern_old = rf'^  - package: oci://.*!{re.escape(pname)}\s*$'
+                        if re.match(oci_pattern_old, line):
+                            matched_oci = True
+                            break
+                    if not matched_oci:
+                        oci_pattern_new = rf'^  - package: oci://{re.escape(registry_reference_for_oci)}\s*$'
+                        if re.match(oci_pattern_new, line):
+                            matched_oci = True
+
+                    if matched_oci:
+                        modified = True
+                        while new_lines and ('Tag:' in new_lines[-1] or 'Build date:' in new_lines[-1]):
+                            new_lines.pop()
+
+                        preserved_lines = []
+                        i += 1
+                        while i < len(lines):
+                            next_line = lines[i]
+                            if not next_line.strip():
+                                i += 1
+                                continue
+                            if next_line.startswith(' ') or next_line.startswith('\t'):
+                                if not (next_line.strip().startswith('#') and 'Tag:' in next_line):
+                                    preserved_lines.append(next_line)
+                                i += 1
+                                continue
+                            if next_line.strip().startswith('#') and ('Tag:' in next_line or 'Build date:' in next_line):
+                                i += 1
+                                continue
+                            break
+
+                        new_lines.append(f"  {comment}\n")
+                        new_lines.append(f"  - package: oci://{registry_reference_for_oci}\n")
+                        for pl in preserved_lines:
+                            new_lines.append(pl)
+                        continue
+
+                    matched = False
+                    for pname in [plugin_name, plugin_name_alternative,
+                                  plugin_name_with_dynamic, plugin_name_alternative_with_dynamic]:
+                        pattern = rf'^  - package: \.\/dynamic-plugins\/dist\/{re.escape(pname)}\s*$'
+                        if re.match(pattern, line):
+                            new_lines.append(f"  # - package: oci://{registry_reference_for_oci}\n")
+                            new_lines.append(f"  {comment}\n")
+                            new_lines.append("  # new approach using oci images: to switch to the new approach, uncomment\n")
+                            new_lines.append("  # the 'package' line above and remove the next two lines, keeping the pluginConfig.\n")
+                            new_lines.append("  # disabled: true\n")
+
+                            new_lines.append(line)
+
+                            i += 1
+                            while i < len(lines):
+                                next_line = lines[i]
+                                if next_line.strip() and not next_line.startswith(' ') and not next_line.startswith('\t'):
+                                    break
+                                new_lines.append(next_line)
+                                i += 1
+
+                            modified = True
+                            log_debug(f"Added OCI reference for {pname} in {yaml_file.name}")
+                            i -= 1
+                            matched = True
+                            break
+
+                    if not matched:
+                        # Pattern matches: dynamicArtifact: '', dynamicArtifact: "", dynamicArtifact: ~, dynamicArtifact: null, or just dynamicArtifact:
+                        empty_artifact_pattern = r"^(\s*)dynamicArtifact:(\s+(?:''|\"\"|\~|null))?\s*$"
+                        empty_match = re.match(empty_artifact_pattern, line)
+                        if empty_match:
+                            indent = empty_match.group(1)
+                            new_lines.append(f"{indent}dynamicArtifact: oci://{registry_reference_for_oci}\n")
+                            modified = True
+                            log_debug(f"Set dynamicArtifact:oci://{registry_reference_for_oci} in {yaml_file.name}")
+                            matched = True
+
+                    if not matched:
+                        new_lines.append(line)
+
+                    i += 1
+
+                if modified:
+                    with open(yaml_file, 'w') as f:
+                        f.writelines(new_lines)
+                    files_updated += 1
+                    if yaml_file == dynamic_plugins_yaml:
+                        plugins_matched_in_dynamic_yaml += 1
+
+            except Exception as e:
+                log_error(f"Error updating {yaml_file}: {e}")
+
+    if files_updated > 0:
+        log_info(f"Updated {files_updated} file(s) with OCI references")
+        if dynamic_plugins_yaml.exists():
+            log_info(f"Added OCI references for {plugins_matched_in_dynamic_yaml} plugin(s) in dynamic-plugins.default.yaml")
+    else:
+        if dynamic_plugins_yaml.exists():
+            log_warn("No files were updated with OCI references")
+        else:
+            log_debug("dynamic-plugins.default.yaml not present, skipping DPDY updates")
+
+
+def prune_packages_dir(output_dir: Path, found_plugins: list[str]) -> None:
+    """Remove package YAML files from the output that don't correspond to plugins in the index."""
+    packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
+    if not packages_dir.exists():
+        return
+
+    found_set = set(found_plugins)
+    removed_count = 0
+
+    for yaml_file in packages_dir.glob("*.yaml"):
+        if yaml_file.name == "all.yaml":
+            continue
+        image_name = get_image_name_from_package_yaml(yaml_file)
+
+        if image_name not in found_set:
+            yaml_file.unlink()
+            removed_count += 1
+            log_debug(f"Pruned {yaml_file.name}")
+
+    if removed_count > 0:
+        log_info(f"Pruned {removed_count} package file(s) not in the index")
+
+
+def regenerate_all_yaml_files(output_dir: Path) -> None:
+    """Regenerate all.yaml files in plugins/ and packages/ directories"""
+    extensions_dir = output_dir / "catalog-entities" / "extensions"
+
+    directories = ["plugins", "packages"]
+
+    for directory in directories:
+        dir_path = extensions_dir / directory
+        if not dir_path.exists():
+            log_warn(f"Directory {dir_path} does not exist. Skipping.")
+            continue
+
+        yaml_files = sorted([
+            f.name for f in dir_path.iterdir()
+            if f.is_file() and f.suffix == '.yaml' and f.name != 'all.yaml'
+        ])
+
+        if not yaml_files:
+            log_warn(f"No YAML files found in {dir_path}")
+            continue
+
+        all_yaml_path = dir_path / "all.yaml"
+        with open(all_yaml_path, 'w') as f:
+            f.write("apiVersion: backstage.io/v1alpha1\n")
+            f.write("kind: Location\n")
+            f.write("metadata:\n")
+            f.write("  namespace: rhdh\n")
+            f.write(f"  name: {directory}\n")
+            f.write("spec:\n")
+            f.write("  targets:\n")
+            for yaml_file in yaml_files:
+                f.write(f"    - ./{yaml_file}\n")
+
+        log_info(f"Regenerated {all_yaml_path.relative_to(output_dir)} with {len(yaml_files)} entries")
+
+
+def _support_label_color(label: str) -> str:
+    """Return ANSI color for a support level label."""
+    colors = {
+        'community': Colors.NORM,
+        'generally-available': Colors.GREEN,
+        'dev-preview': Colors.ORANGE,
+    }
+    return colors.get(label, Colors.RED)
+
+
+def scrub_plugin_entity_file(yaml_file: Path, filtered_stems: set[str]) -> str:
+    """Scrub a single Plugin entity YAML file.
+    - If no packages match the filter: delete the file
+    - If all packages match the filter: keep as-is
+    - If mixed: use line-based editing to remove excluded package refs
+
+    Returns: 'removed' | 'stripped' | 'kept' | 'skipped'
+    """
+    try:
+        with open(yaml_file, 'r') as f:
+            data = yaml.safe_load(f)
+
+        if not data or data.get('kind') != 'Plugin':
+            return 'skipped'
+
+        spec = data.get('spec', {})
+        packages = spec.get('packages', [])
+
+        if not packages:
+            return 'kept'
+
+        # Ensure packages is a list of strings
+        pkg_list = [p for p in packages if isinstance(p, str)]
+        if not pkg_list:
+            return 'kept'
+
+        matched_packages = [p for p in pkg_list if p in filtered_stems]
+        excluded_packages = {p for p in pkg_list if p not in filtered_stems}
+
+        if not matched_packages:
+            yaml_file.unlink()
+            return 'removed'
+
+        if not excluded_packages:
+            return 'kept'
+
+        # Mixed plugin: remove excluded package lines using line-based editing
+        with open(yaml_file, 'r') as f:
+            lines = f.readlines()
+
+        new_lines = []
+        in_packages = False
+        for line in lines:
+            stripped = line.strip()
+
+            if stripped.startswith('packages:'):
+                in_packages = True
+                new_lines.append(line)
+                continue
+
+            if in_packages:
+                if stripped.startswith('- '):
+                    pkg_name = stripped[2:].strip()
+                    if pkg_name in excluded_packages:
+                        continue
+                    new_lines.append(line)
+                    continue
+                elif not stripped or stripped.startswith('#'):
+                    new_lines.append(line)
+                    continue
+                else:
+                    in_packages = False
+
+            new_lines.append(line)
+
+        with open(yaml_file, 'w') as f:
+            f.writelines(new_lines)
+
+        return 'stripped'
+
+    except Exception as e:
+        log_error(f"Error scrubbing plugin entity {yaml_file}: {e}")
+        return 'skipped'
+
+
+
+def scrub_catalog_entities(output_dir: Path, overlays_dir: Path, packages_files: list[str]) -> None:
+    """Scrub catalog entities to only retain plugins/packages from the provided package files."""
+    filtered_stems = load_and_resolve_to_stems(packages_files, overlays_dir)
+    log_info(f"Resolved {len(filtered_stems)} filtered package stems from {len(packages_files)} file(s)")
+
+    # Scrub Plugin entity YAMLs
+    plugins_dir = output_dir / "catalog-entities" / "extensions" / "plugins"
+    removed = stripped = kept = skipped = 0
+    if plugins_dir.exists():
+        for yaml_file in sorted(plugins_dir.glob("*.yaml")):
+            if yaml_file.name in ("all.yaml", "1-boilerplate.yaml.sample"):
+                continue
+            result = scrub_plugin_entity_file(yaml_file, filtered_stems)
+            if result == 'removed':
+                removed += 1
+                log_debug(f"Removed excluded plugin: {yaml_file.name}")
+            elif result == 'stripped':
+                stripped += 1
+                log_info(f"Stripped excluded packages from: {yaml_file.name}")
+            elif result == 'kept':
+                kept += 1
+            else:
+                skipped += 1
+
+    log_info(f"Plugin entities: {kept} kept, {stripped} stripped, {removed} removed" +
+             (f", {skipped} skipped" if skipped else ""))
+
+    # Pre-prune Package metadata to only keep filtered plugins.
+    # filtered_stems uses metadata.name (from build_workspace_mappings), so match on that.
+    packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
+    if packages_dir.exists():
+        pkg_removed = 0
+        for yaml_file in sorted(packages_dir.glob("*.yaml")):
+            if yaml_file.name == "all.yaml":
+                continue
+            try:
+                with open(yaml_file, 'r') as f:
+                    data = yaml.safe_load(f)
+                entity_name = (data or {}).get('metadata', {}).get('name', yaml_file.stem)
+            except Exception:
+                entity_name = yaml_file.stem
+            if entity_name not in filtered_stems:
+                yaml_file.unlink()
+                pkg_removed += 1
+                log_debug(f"Removed excluded package metadata: {yaml_file.name}")
+        if pkg_removed > 0:
+            log_info(f"Package metadata: removed {pkg_removed} excluded files")
+
+
+def main():
+    global REGISTRY_BASE
+
+    usage = """
+Usage: python3 generateCatalogIndex.py [--debug] \\
+    -r|--registry image-registry \\
+    [-d|--overlays-dir PATH] \\
+    [-o|--output-dir PATH] \\
+    [-b|--plugin-builds-dir PATH] \\
+    [-p|--packages-file FILE ...] \\
+    [-c|--catalog-entities-dir PATH]
+
+Examples:
+    # Generate supported catalog index (union of YAML + txt package lists)
+    python3 generateCatalogIndex.py \\
+        -o catalog-index/supported \\
+        -b plugin_builds/supported \\
+        -r quay.io/rhdh \\
+        -p catalog-index/default.packages.yaml \\
+        -p rhdh-supported-packages.txt
+
+    # Generate community catalog index
+    python3 generateCatalogIndex.py \\
+        -o catalog-index/community \\
+        -b plugin_builds/community \\
+        -r ghcr.io/redhat-developer/rhdh-plugin-export-overlays \\
+        -p rhdh-community-packages.txt
+"""
+
+    parser = argparse.ArgumentParser(
+        description='Generate catalog index from plugin_builds and workspace metadata. '
+                    'No filtering — plugin_builds/ is pre-filtered by bootstrapPluginBuilds.py.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=usage
+    )
+    parser.error = lambda msg: (print(f"\n{Colors.RED}[ERROR] {msg}{Colors.NORM}\n{usage}", file=sys.stderr), sys.exit(2))
+
+    parser.add_argument(
+        '-d', '--overlays-dir',
+        type=str,
+        default='.',
+        metavar='PATH',
+        help='Path to overlays directory containing workspaces/ and catalog-entities/ (default: .)',
+    )
+    parser.add_argument(
+        '-o', '--output-dir',
+        type=str,
+        default='catalog-index',
+        metavar='PATH',
+        help='Output directory for catalog-index (index.json, catalog-entities/, etc.) (default: catalog-index)',
+    )
+    parser.add_argument(
+        '-b', '--plugin-builds-dir',
+        type=str,
+        default='plugin_builds',
+        metavar='PATH',
+        help='Path to plugin_builds/ directory (default: plugin_builds)',
+    )
+    parser.add_argument(
+        '-r', '--registry',
+        type=str,
+        required=True,
+        metavar='BASE',
+        help='Registry base (e.g., ghcr.io/redhat-developer/rhdh-plugin-export-overlays, quay.io/rhdh)',
+    )
+    parser.add_argument(
+        '-p', '--packages-file',
+        type=str,
+        action='append',
+        metavar='FILE',
+        help='Package list file to filter catalog entities. Can be specified multiple times. '
+             'Accepts YAML (default.packages.yaml format with npm names) or txt '
+             '(workspace paths, one per line). Stems from all files are unioned.',
+    )
+    parser.add_argument(
+        '-c', '--catalog-entities-dir',
+        type=str,
+        metavar='PATH',
+        help='Path to catalog-entities/extensions/ source directory. '
+             'Defaults to <overlays-dir>/catalog-entities/extensions/',
+    )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Enable debug output',
+    )
+
+    args = parser.parse_args()
+
+    set_debug(args.debug)
+    REGISTRY_BASE = args.registry.rstrip('/')
+
+    overlays_dir = Path(args.overlays_dir)
+    output_dir = Path(args.output_dir)
+    plugin_builds_dir = Path(args.plugin_builds_dir)
+    catalog_entities_dir = Path(args.catalog_entities_dir) if args.catalog_entities_dir else overlays_dir / "catalog-entities" / "extensions"
+
+    if not overlays_dir.exists():
+        print(f"Error: Overlays directory not found: {overlays_dir}")
+        sys.exit(1)
+
+    print(f"{Colors.GREEN}=== Generate Catalog Index ==={Colors.NORM}\n")
+
+    print(f"{Colors.GREEN}=== Copy catalog-entities/extensions to output ==={Colors.NORM}")
+    copy_catalog_entities_extensions(catalog_entities_dir, output_dir)
+
+    print(f"\n{Colors.GREEN}=== Copy workspaces/*/metadata/*.yaml to output packages/ ==={Colors.NORM}")
+    yaml_file_names, _ = copy_workspace_metadata_files(overlays_dir, output_dir)
+
+    # Scrub catalog entities based on package list files
+    if args.packages_file:
+        print(f"\n{Colors.GREEN}=== Scrub catalog entities to packages from {len(args.packages_file)} file(s) ==={Colors.NORM}")
+        scrub_catalog_entities(output_dir, overlays_dir, args.packages_file)
+
+    print(f"\n{Colors.GREEN}=== Generate index.json from plugin_builds ==={Colors.NORM}")
+    index_data, found_plugins, missing_references, plugin_workspace_paths, all_plugin_data = generate_index_json(plugin_builds_dir, output_dir)
+
+    print(f"\n{Colors.GREEN}=== Prune packages/ to match index ==={Colors.NORM}")
+    prune_packages_dir(output_dir, found_plugins)
+
+    print(f"\n{Colors.GREEN}=== Update package files with OCI references ==={Colors.NORM}")
+    log_debug(f"Found {len(found_plugins)} plugins with valid OCI images")
+    update_package_files(output_dir, index_data, found_plugins)
+
+    print(f"\n{Colors.GREEN}=== Regenerate all.yaml files ==={Colors.NORM}")
+    regenerate_all_yaml_files(output_dir)
+
+    # Re-derive yaml_file_names from what actually remains after scrub+prune.
+    # Use spec.packageName→image_name to match found_plugins (which uses the same derivation).
+    packages_dir = output_dir / "catalog-entities" / "extensions" / "packages"
+    if packages_dir.exists():
+        yaml_file_names = {
+            get_image_name_from_package_yaml(f)
+            for f in packages_dir.glob("*.yaml")
+            if f.name != "all.yaml"
+        }
+
+    # Compare YAML files vs plugins found
+    if yaml_file_names:
+        found_plugins_set = set(found_plugins)
+        yaml_without_plugin = yaml_file_names - found_plugins_set
+        plugin_without_yaml = found_plugins_set - yaml_file_names
+
+        if yaml_without_plugin or plugin_without_yaml:
+            print("\n========")
+            print(f"{Colors.BLUE}[INFO] Catalog Entity vs Plugin Analysis:{Colors.NORM}")
+            print(f"  - {len(yaml_file_names)} Catalog Entity Package yaml files moved")
+            print(f"  - {len(found_plugins)} plugins found with valid OCI images")
+
+        if yaml_without_plugin:
+            print(f"\n{Colors.BLUE}[INFO] {len(yaml_without_plugin)} catalog entity package file(s) without corresponding plugin in index - has the plugin been published?{Colors.NORM}")
+            for name in sorted(yaml_without_plugin):
+                support = all_plugin_data.get(name, {}).get('support', '')
+                workspace_path = plugin_workspace_paths.get(name, name)
+                label = support if support else '?UNKNOWN?'
+                color = _support_label_color(label)
+                print(f"  - {color}[{label}]{Colors.NORM} {workspace_path}")
+
+        if plugin_without_yaml:
+            print(f"\n{Colors.BLUE}[INFO] {len(plugin_without_yaml)} plugin(s) without corresponding catalog entity package yaml file - maybe the catalog entity file needs to be renamed?{Colors.NORM}")
+            for name in sorted(plugin_without_yaml):
+                workspace_path = plugin_workspace_paths.get(name, name)
+                support = index_data.get(name, {}).get('support', '')
+                label = support if support else '?UNKNOWN?'
+                color = _support_label_color(label)
+                print(f"  - {color}[{label}]{Colors.NORM} {workspace_path}")
+
+    if missing_references:
+        print("\n========")
+        log_warn(f"Could not find {Colors.RED}{len(missing_references)}{Colors.NORM} plugins listed in plugin_builds/ folder! Remember to export and publish them, then re-run this script.")
+        for json_file, _plugin_name, reference in missing_references:
+            print(f"  - {json_file} > {Colors.RED}https://{reference}{Colors.NORM}")
+        log_error(f"{len(missing_references)} plugin(s) missing from registry — catalog is incomplete")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generateDynamicPluginsDefaultYaml.sh
+++ b/scripts/generateDynamicPluginsDefaultYaml.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Generate dynamic-plugins.default.yaml (DPDY) from default.packages.yaml and overlay-repo/workspaces/*/metadata/*.yaml
-# See also build/ci/update-index.sh
+# See also scripts/update-index.sh
 #
 
 usage() {
@@ -21,15 +21,18 @@ Arguments (required):
   -p, --packages-file  Path to default.packages.yaml
   -o, --output-file    Path to output dynamic-plugins.default.yaml file
 
+Arguments (optional):
+  -b, --plugin-builds-dir  plugin_builds/ tree (default: derived from --output-file)
+      --debug              Enable debug output
+
 The script will:
 1. Read all packages from default.packages.yaml
 2. Find corresponding metadata files in the overlay-repo directory
 3. Extract the appConfigExamples content from each metadata file
 4. Generate dynamic-plugins.default.yaml
+5. Inject Tag/Build date comments from plugin_builds/*.json (via injectDpdyTagComments.py)
 
-Once complete, you should:
-5. Run generateCatalogIndex.py to generate the catalog index, and to
-6. Add oci ref comments into the DPDY file (see build/ci/update-index.sh)
+Once complete, run generateCatalogIndex.py to refresh the catalog index and OCI refs.
 
 Requires: yq (kislyuk/pypi-yq or mikefarah/yq). Prefer to use ~/.local/bin/yq_mf
 
@@ -41,6 +44,7 @@ USAGE
 PACKAGES_FILE=
 OVERLAYS_DIR=
 OUTPUT_FILE=
+PLUGIN_BUILDS_DIR=
 DEBUG=0
 
 while [[ $# -gt 0 ]]; do
@@ -55,6 +59,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -o|--output-file)
       OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    -b|--plugin-builds-dir)
+      PLUGIN_BUILDS_DIR="$2"
       shift 2
       ;;
     --debug)
@@ -87,6 +95,10 @@ fi
 if [[ ! -d "$OVERLAYS_DIR" ]]; then
   echo "Error: Overlays directory not found: $OVERLAYS_DIR" >&2
   exit 1
+fi
+
+if [[ -z "${PLUGIN_BUILDS_DIR:-}" ]]; then
+  PLUGIN_BUILDS_DIR="$(cd "$(dirname "$OUTPUT_FILE")/.." && pwd)/plugin_builds"
 fi
 
 # Prefer mikefarah installed as yq_mf (e.g. builder image), else yq on PATH.
@@ -174,6 +186,7 @@ fi
 if [[ $DEBUG -eq 1 ]]; then
   echo "Using yq binary: $YQ_BIN (mikefarah=$YQ_IS_MIKE_FARAH)"
   echo "Loading packages from: $PACKAGES_FILE"
+  echo "Plugin builds dir: $PLUGIN_BUILDS_DIR"
   echo "Scanning metadata files in: $OVERLAYS_DIR"
   echo "Found ${#METADATA_MAP[@]} metadata files"
 fi
@@ -237,6 +250,14 @@ build_plugin_entry() {
   # shellcheck disable=SC2001
   entry=$(printf '%s\n' "$entry" | sed 's/^/  /')
   echo "$entry"
+}
+
+inject_tag_comments_in_dpdy() {
+  local out_file=$1
+  local script_dir
+  script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  [[ -f "$out_file" ]] || return 0
+  python3 "${script_dir}/injectDpdyTagComments.py" "$out_file" "$PLUGIN_BUILDS_DIR"
 }
 
 # -----------------------------------------------------------------------------
@@ -332,6 +353,8 @@ EOL
 cat "$OUTPUT_FILE".head "$OUTPUT_FILE" > "$OUTPUT_FILE"_
 mv "$OUTPUT_FILE"_ "$OUTPUT_FILE"
 rm -f "$OUTPUT_FILE".head
+
+inject_tag_comments_in_dpdy "$OUTPUT_FILE"
 
 # -----------------------------------------------------------------------------
 # Stats (from final YAML)

--- a/scripts/generateDynamicPluginsDefaultYaml.sh
+++ b/scripts/generateDynamicPluginsDefaultYaml.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+#
+# Generate dynamic-plugins.default.yaml (DPDY) from default.packages.yaml and overlay-repo/workspaces/*/metadata/*.yaml
+# See also build/ci/update-index.sh
+#
+
+usage() {
+  cat <<'USAGE'
+Script to generate dynamic-plugins.default.yaml from default.packages.yaml
+and metadata YAML files from rhdh-plugin-export-overlays.
+
+Usage: generateDynamicPluginsDefaultYaml.sh [--debug] \
+    --overlays-dir  /home/user/rhdh-plugin-catalog/overlay-repo \\
+    --packages-file /home/user/rhdh-plugin-catalog/catalog-index/default.packages.yaml \\
+    --output-file   /home/user/rhdh-plugin-catalog/catalog-index/dynamic-plugins.default.yaml
+
+Arguments (required):
+  -d, --overlays-dir   Path to directory where
+                       https://github.com/redhat-developer/rhdh-plugin-export-overlays
+                       is checked out, or to the overlay-repo folder in the rhdh-plugin-catalog repo
+  -p, --packages-file  Path to default.packages.yaml
+  -o, --output-file    Path to output dynamic-plugins.default.yaml file
+
+The script will:
+1. Read all packages from default.packages.yaml
+2. Find corresponding metadata files in the overlay-repo directory
+3. Extract the appConfigExamples content from each metadata file
+4. Generate dynamic-plugins.default.yaml
+
+Once complete, you should:
+5. Run generateCatalogIndex.py to generate the catalog index, and to
+6. Add oci ref comments into the DPDY file (see build/ci/update-index.sh)
+
+Requires: yq (kislyuk/pypi-yq or mikefarah/yq). Prefer to use ~/.local/bin/yq_mf
+
+Note: Using mikefarah yq, plugin yaml emission uses --unwrapScalar=false and 
+env()+eval --expression to reduce YAML scalar rewrites.
+USAGE
+}
+
+PACKAGES_FILE=
+OVERLAYS_DIR=
+OUTPUT_FILE=
+DEBUG=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--overlays-dir)
+      OVERLAYS_DIR="$2"
+      shift 2
+      ;;
+    -p|--packages-file)
+      PACKAGES_FILE="$2"
+      shift 2
+      ;;
+    -o|--output-file)
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    --debug)
+      DEBUG=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${PACKAGES_FILE:-}" || -z "${OVERLAYS_DIR:-}" || -z "${OUTPUT_FILE:-}" ]]; then
+  echo "Error: --packages-file, --overlays-dir, and --output-file are required." >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -f "$PACKAGES_FILE" ]]; then
+  echo "Error: Packages file not found: $PACKAGES_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -d "$OVERLAYS_DIR" ]]; then
+  echo "Error: Overlays directory not found: $OVERLAYS_DIR" >&2
+  exit 1
+fi
+
+# Prefer mikefarah installed as yq_mf (e.g. builder image), else yq on PATH.
+if command -v yq_mf &>/dev/null; then
+  YQ_BIN=$(command -v yq_mf)
+elif [[ -x "${HOME}/.local/bin/yq_mf" ]]; then
+  YQ_BIN="${HOME}/.local/bin/yq_mf"
+elif command -v yq &>/dev/null; then
+  YQ_BIN=$(command -v yq)
+else
+  echo "Error: yq is required (mikefarah or kislyuk)." >&2
+  exit 1
+fi
+
+# Detect yq variant: only mikefarah accepts -o=json here; kislyuk fails this probe.
+if "$YQ_BIN" -o=json '.' /dev/null >/dev/null 2>&1; then
+  YQ_IS_MIKE_FARAH=1
+else
+  YQ_IS_MIKE_FARAH=0
+fi
+
+# Yaml-output flag for kislyuk `yq -s …` / plugin entry (replacing hardcoded -y).
+YQ_YAML_OPT="-y"
+
+# Raw jq-style scalar read (kislyuk: yq -r; mikefarah: yq eval -r).
+yq_raw() {
+  local expr=$1
+  shift
+  if [[ "${YQ_IS_MIKE_FARAH:-0}" -eq 1 ]]; then
+    "$YQ_BIN" eval -r "$expr" "$@"
+  else
+    "$YQ_BIN" -r "$expr" "$@"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Build metadata map: package name -> path to metadata YAML
+# Also index by file stem (basename without .yaml) so fallback lookup works.
+# -----------------------------------------------------------------------------
+declare -A METADATA_MAP
+WORKSPACES_DIR="${OVERLAYS_DIR}/workspaces"
+
+# Fallback: map @red-hat-developer-hub/backstage-plugin-* to file stem redhat-backstage-plugin-*
+# (metadata files in rhdh-plugin-export-overlays use redhat-* basenames, e.g. orchestrator metadata).
+pkg_to_filestem() {
+  local pkg=$1
+  if [[ "$pkg" == @red-hat-developer-hub/backstage-plugin-* ]]; then
+    echo "redhat-backstage-plugin-${pkg#@red-hat-developer-hub/backstage-plugin-}"
+  fi
+}
+
+if [[ ! -d "$WORKSPACES_DIR" ]]; then
+  echo "Warning: Workspaces directory not found: $WORKSPACES_DIR" >&2
+else
+  while IFS= read -r -d '' meta_path; do
+    package_name=$(yq_raw '.spec.packageName // ""' "$meta_path" 2>/dev/null) || continue
+    dynamic_artifact=$(yq_raw '.spec.dynamicArtifact // ""' "$meta_path" 2>/dev/null)
+
+    # Index by file stem (basename without .yaml) for fallback lookup
+    meta_basename=$(basename "$meta_path" .yaml)
+    METADATA_MAP["$meta_basename"]=$meta_path
+
+    if [[ -n "$package_name" ]]; then
+      METADATA_MAP["$package_name"]=$meta_path
+    fi
+
+    if [[ -n "$dynamic_artifact" && "$dynamic_artifact" != .* ]]; then
+      if [[ "$dynamic_artifact" == *@* && "$dynamic_artifact" != @* ]]; then
+        # package@version
+        artifact_pkg="${dynamic_artifact%%@*}"
+        METADATA_MAP["$artifact_pkg"]=$meta_path
+      elif [[ "$dynamic_artifact" == @* ]]; then
+        # @scope/package@version
+        if [[ $(echo -n "$dynamic_artifact" | tr -cd '@' | wc -c) -gt 1 ]]; then
+          artifact_pkg="${dynamic_artifact%@*}"
+          METADATA_MAP["$artifact_pkg"]=$meta_path
+        fi
+      else
+        METADATA_MAP["$dynamic_artifact"]=$meta_path
+      fi
+    fi
+  done < <(find "$WORKSPACES_DIR" -path '*/metadata/*.yaml' -print0 2>/dev/null)
+fi
+
+if [[ $DEBUG -eq 1 ]]; then
+  echo "Using yq binary: $YQ_BIN (mikefarah=$YQ_IS_MIKE_FARAH)"
+  echo "Loading packages from: $PACKAGES_FILE"
+  echo "Scanning metadata files in: $OVERLAYS_DIR"
+  echo "Found ${#METADATA_MAP[@]} metadata files"
+fi
+
+explain_missing() {
+  local pkg=$1
+  echo ""
+  echo "Error: No metadata found for package '$pkg'!"
+  if [[ ! -d "$WORKSPACES_DIR" ]]; then
+    echo "The workspaces directory does not exist under $OVERLAYS_DIR"
+  elif [[ ${#METADATA_MAP[@]} -eq 0 ]]; then
+    echo "No metadata files were found in $WORKSPACES_DIR/<workspace>/metadata/*.yaml"
+  else
+    echo "Possible reasons:"
+    echo "1. The package name in default.packages.yaml doesn't match the 'packageName' in metadata"
+    echo "2. The package name format differs (e.g., with/without version, with/without @scope)"
+    echo "3. The metadata file is missing or in an unexpected location"
+    echo "4. The package name might need to remove the '-dynamic' suffix (if moving from wrapper to oci artifact)"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Build plugin entry YAML from a metadata file
+# Outputs YAML to stdout for reuse
+# -----------------------------------------------------------------------------
+build_plugin_entry() {
+  local meta_path=$1
+  local disabled=$2
+
+  local dynamic_artifact package_value
+  dynamic_artifact=$(yq_raw '.spec.dynamicArtifact // ""' "$meta_path" 2>/dev/null)
+
+  if [[ "$dynamic_artifact" == ./.* ]]; then
+    package_value=$dynamic_artifact
+  elif [[ "$dynamic_artifact" == *"oci://"*"!"* ]]; then
+    # Strip !fragment if present (e.g. oci://...!package-name)
+    package_value="${dynamic_artifact%%!*}"
+  else
+    package_value=$dynamic_artifact
+  fi
+
+  local entry
+  if [[ "${YQ_IS_MIKE_FARAH:-0}" -eq 1 ]]; then
+    # Preserve nested scalar quoting (pluginConfig); pass package/disabled via env — mikefarah has no jq --arg on eval.
+    export MF_PKG="$package_value"
+    export MF_DIS="$disabled"
+    entry=$("$YQ_BIN" --unwrapScalar=false eval --expression \
+      '{"package": env(MF_PKG), "disabled": (env(MF_DIS) == "true"), "pluginConfig": .spec.appConfigExamples[0].content} | with_entries(select(.value != null))' \
+      "$meta_path" -o yaml)
+  else
+    # shellcheck disable=SC2016
+    entry=$("$YQ_BIN" "${YQ_YAML_OPT}" \
+      --arg pkg "$package_value" \
+      --argjson dis "$disabled" \
+      '({package: $pkg, disabled: $dis} +
+       (if .spec.appConfigExamples[0].content then {pluginConfig: .spec.appConfigExamples[0].content} else {} end))
+       | with_entries(select(.value != null))' \
+      "$meta_path")
+  fi
+  # fix indenting so that the entire entry is precended by 2 spaces per line
+  # shellcheck disable=SC2001
+  entry=$(printf '%s\n' "$entry" | sed 's/^/  /')
+  echo "$entry"
+}
+
+# -----------------------------------------------------------------------------
+# Collect enabled and disabled package entries from default.packages.yaml
+# Each plugin entry is appended to a temp file; merged in default.packages.yaml order (enabled then disabled).
+# -----------------------------------------------------------------------------
+enabled_count=$(yq_raw '.packages.enabled // [] | length' "$PACKAGES_FILE")
+disabled_count=$(yq_raw '.packages.disabled // [] | length' "$PACKAGES_FILE")
+echo ""
+echo "Processing $enabled_count enabled packages..."
+
+ENTRIES_TMP=$(mktemp) || { echo "Cannot create temp file" >&2; exit 1; }
+trap 'rm -f "$ENTRIES_TMP"' EXIT
+first=true
+
+idx=0
+while [[ $idx -lt $enabled_count ]]; do
+  pkg_name=$(yq_raw '.packages.enabled['"$idx"'].package // ""' "$PACKAGES_FILE")
+  [[ "$pkg_name" == "null" ]] && pkg_name=""
+  pkg_name=${pkg_name//\"}; pkg_name=${pkg_name//\'}
+  meta_path="${METADATA_MAP[$pkg_name]:-}"
+  if [[ -z "$meta_path" ]]; then
+    filestem=$(pkg_to_filestem "$pkg_name")
+    [[ -n "$filestem" ]] && meta_path="${METADATA_MAP[$filestem]:-}"
+  fi
+  if [[ -z "$meta_path" ]]; then
+    explain_missing "$pkg_name" >&2
+    exit 1
+  fi
+  entry=$(build_plugin_entry "$meta_path" "false") || {
+    echo "  ✗ $pkg_name (failed to generate entry)" >&2
+    exit 1
+  }
+  echo "  ✓ $pkg_name"
+  if [[ "$first" == true ]]; then
+    first=false
+  else
+    echo "---" >> "$ENTRIES_TMP"
+  fi
+  echo "$entry" >> "$ENTRIES_TMP"
+  ((idx++)) || true
+done
+
+echo ""
+echo "Processing $disabled_count disabled packages..."
+idx=0
+while [[ $idx -lt $disabled_count ]]; do
+  pkg_name=$(yq_raw '.packages.disabled['"$idx"'].package // ""' "$PACKAGES_FILE")
+  [[ "$pkg_name" == "null" ]] && pkg_name=""
+  pkg_name=${pkg_name//\"}; pkg_name=${pkg_name//\'}
+  meta_path="${METADATA_MAP[$pkg_name]:-}"
+  if [[ -z "$meta_path" ]]; then
+    filestem=$(pkg_to_filestem "$pkg_name")
+    [[ -n "$filestem" ]] && meta_path="${METADATA_MAP[$filestem]:-}"
+  fi
+  if [[ -z "$meta_path" ]]; then
+    explain_missing "$pkg_name" >&2
+    exit 1
+  fi
+  entry=$(build_plugin_entry "$meta_path" "true") || {
+    echo "  ✗ $pkg_name (failed to generate entry)" >&2
+    exit 1
+  }
+  echo "  ✓ $pkg_name"
+  echo "---" >> "$ENTRIES_TMP"
+  echo "$entry" >> "$ENTRIES_TMP"
+  ((idx++)) || true
+done
+
+# -----------------------------------------------------------------------------
+# Wrap as {plugins: [...]} preserving list order (kislyuk: yq -s; mikefarah: eval-all).
+# -----------------------------------------------------------------------------
+echo ""
+echo "Merging plugin entries and writing to $OUTPUT_FILE..."
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+if [[ "${YQ_IS_MIKE_FARAH:-0}" -eq 1 ]]; then
+  "$YQ_BIN" eval-all --unwrapScalar=false '[.] | {"plugins": .}' "$ENTRIES_TMP" -o yaml > "$OUTPUT_FILE"
+else
+  "$YQ_BIN" -s "${YQ_YAML_OPT}" '{plugins: .}' "$ENTRIES_TMP" > "$OUTPUT_FILE"
+fi
+
+# add header onto file so people stop asking how it's maintained
+cat << EOL > "$OUTPUT_FILE".head
+# THIS FILE IS GENERATED - DO NOT EDIT!
+#
+# File dynamic-plugins.default.yaml is now generated from default.packages.yaml
+# and default configuration located in the overlays repo under workspaces/*/metadata/*.yaml
+# See https://github.com/redhat-developer/rhdh-plugin-export-overlays/
+#
+# To update this file, trigger a rebuld of the index image from 
+# https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog/-/blob/rhdh-1-rhel-9/build/ci/update-index.sh
+EOL
+cat "$OUTPUT_FILE".head "$OUTPUT_FILE" > "$OUTPUT_FILE"_
+mv "$OUTPUT_FILE"_ "$OUTPUT_FILE"
+rm -f "$OUTPUT_FILE".head
+
+# -----------------------------------------------------------------------------
+# Stats (from final YAML)
+# -----------------------------------------------------------------------------
+total=$(yq_raw '.plugins | length' "$OUTPUT_FILE")
+enabled_num=$(yq_raw '[.plugins[] | select(.disabled == false)] | length' "$OUTPUT_FILE")
+disabled_num=$(yq_raw '[.plugins[] | select(.disabled == true)] | length' "$OUTPUT_FILE")
+with_config=$(yq_raw '[.plugins[] | select(has("pluginConfig"))] | length' "$OUTPUT_FILE")
+
+if [[ $DEBUG -eq 1 ]]; then
+  echo ""
+  echo "============================================================"
+  echo "✓ Successfully generated $OUTPUT_FILE"
+  echo "============================================================"
+  echo "Total plugins:      $total"
+  echo "  - Enabled:        $enabled_num"
+  echo "  - Disabled:       $disabled_num"
+  echo "  - With config:    $with_config"
+  echo "  - Without config: $((total - with_config))"
+  echo "============================================================"
+else
+  echo "Generated: $OUTPUT_FILE"
+fi

--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -650,10 +650,15 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                         if digest:
                             stage_kwargs = {"digest": digest}
                             if pdata.get('fallback'):
-                                ref_tag = pdata.get('registryReference', '').rsplit(':', 1)[-1]
+                                resolved_ref = pdata.get('registryReference', '')
+                                ref_tag = resolved_ref.rsplit(':', 1)[-1]
                                 stage_kwargs["fallback"] = True
                                 stage_kwargs["requestedTag"] = pdata.get('requestedTag', '')
                                 stage_kwargs["resolvedTag"] = ref_tag
+                                separator = "__" if "ghcr.io" in resolved_ref else "--"
+                                if separator in ref_tag:
+                                    resolved_version = ref_tag.rsplit(separator, 1)[-1]
+                                    report.add_plugin(pname, version=resolved_version)
                             report.set_stage(
                                 pname, "image-metadata-fetch", "pass",
                                 **stage_kwargs,
@@ -699,6 +704,12 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                                 da = ""
                             if da.startswith("oci://"):
                                 new_oci = f"oci://{registry_reference_digest}"
+                                fallback_version = None
+                                if plugin_data.get('fallback'):
+                                    tag_str = registry_reference_tag.rsplit(':', 1)[-1] if ':' in registry_reference_tag else ""
+                                    sep = "__" if "ghcr.io" in registry_reference_tag else "--"
+                                    if sep in tag_str:
+                                        fallback_version = tag_str.rsplit(sep, 1)[-1]
                                 lines = content.splitlines()
                                 out = []
                                 for line in lines:
@@ -715,6 +726,9 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                                         else:
                                             out.append(f'{indent}# Tag: {tag}')
                                         out.append(f'{indent}dynamicArtifact: "{new_oci}"')
+                                    elif fallback_version and stripped.startswith("version:"):
+                                        indent = line[: len(line) - len(stripped)]
+                                        out.append(f'{indent}version: {fallback_version}')
                                     else:
                                         out.append(line)
                                 with open(metadata_file, "w", encoding='utf-8') as f:

--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -609,7 +609,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                         print(" ")
                         if report:
                             report.set_stage(
-                                plugin_name, "registry-enrich", "fail",
+                                plugin_name, "image-metadata-fetch", "fail",
                                 reason=f"Image not found in registry: {registry_reference}",
                             )
                 else:
@@ -655,7 +655,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                                 stage_kwargs["requestedTag"] = pdata.get('requestedTag', '')
                                 stage_kwargs["resolvedTag"] = ref_tag
                             report.set_stage(
-                                pname, "registry-enrich", "pass",
+                                pname, "image-metadata-fetch", "pass",
                                 **stage_kwargs,
                             )
 

--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -15,14 +15,14 @@
 # - midstream: from container env MIDSTREAM_REPO
 
 import argparse
+import hashlib
 import json
 import os
+import re
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
 import requests
 import yaml
-import hashlib
 
 from plugin_utils import (
     BuildReport,
@@ -44,24 +44,27 @@ RARC_RHDH_PREFIX = RARC_DOMAIN + "/rhdh/"
 
 DYNAMIC_PACKAGES_ANNOTATION = "io.backstage.dynamic-packages"
 
+# Matches a clean version suffix: "2.18.0", "1.5", but NOT ".att", ".sbom", bare SHAs, etc.
+VERSION_SUFFIX_RE = re.compile(r'^\d+\.\d+(\.\d+)?$')
+
 
 def is_downstream_quay_rhdh() -> bool:
-    """Check if we're in downstream mode (quay.io/rhdh — NOT quay.io/rhdh-community)"""
+    """Check if REGISTRY_BASE is quay.io/rhdh (downstream supported, NOT quay.io/rhdh-community)."""
     return REGISTRY_BASE + "/" == QUAY_RHDH_PREFIX
 
 
 def is_downstream_rarc() -> bool:
-    """Check if the user requested registry.access.redhat.com output via -r"""
+    """Check if the user explicitly requested registry.access.redhat.com output via the ``-r`` flag."""
     return REGISTRY_BASE.startswith(RARC_DOMAIN)
 
 
 def _is_quay_rhdh_ref(registry_reference: str) -> bool:
-    """Check if a registry reference targets quay.io/rhdh/ (not quay.io/rhdh-community/)."""
+    """Per-reference check if a specific ref targets quay.io/rhdh/ (not quay.io/rhdh-community/)."""
     return registry_reference.startswith(QUAY_RHDH_PREFIX)
 
 
-def get_ghcr_token(repository: str) -> Optional[str]:
-    """Get anonymous bearer token for ghcr.io"""
+def get_ghcr_token(repository: str) -> str | None:
+    """Get an anonymous bearer token for ghcr.io"""
     try:
         url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
         response = requests.get(url, timeout=10)
@@ -73,10 +76,10 @@ def get_ghcr_token(repository: str) -> Optional[str]:
 
 
 def get_registry_auth(registry: str, repository: str):
-    """
-    Get authentication for a registry.
-    Returns (auth_tuple, headers_dict) where auth_tuple is for basic auth
-    and headers_dict contains bearer token if applicable.
+    """Return auth tuple and headers for a given registry.
+
+    ghcr.io uses an anonymous bearer token; all other registries fall back to
+    basic auth via ``REGISTRY_USERNAME`` / ``REGISTRY_PASSWORD`` env vars.
     """
     auth = None
     extra_headers = {}
@@ -95,10 +98,9 @@ def get_registry_auth(registry: str, repository: str):
 
 
 def get_query_registry_reference(registry_reference: str) -> str:
-    """
-    Get the registry reference to use for querying.
-    For registry.access.redhat.com refs, swap to quay.io for unauthenticated verification.
-    Per-reference check — works with mixed-registry plugin_builds.
+    """Swap r.a.r.c refs to quay.io/rhdh for unauthenticated querying; leave other refs unchanged.
+
+    Per-reference check, so it works correctly with mixed-registry plugin_builds.
     """
     if registry_reference.startswith(RARC_RHDH_PREFIX):
         return registry_reference.replace(RARC_RHDH_PREFIX, QUAY_RHDH_PREFIX)
@@ -106,22 +108,250 @@ def get_query_registry_reference(registry_reference: str) -> str:
 
 
 def get_output_registry_reference(registry_reference: str) -> str:
-    """
-    Get the registry reference to use for output/storage.
-    Only swap quay.io/rhdh/ → registry.access.redhat.com/rhdh/ when the user
-    explicitly requested r.a.r.c output via -r registry.access.redhat.com/rhdh.
+    """Reverse swap: quay.io/rhdh → r.a.r.c, but ONLY when the user requested r.a.r.c output via ``-r``.
+
+    Leaves non-quay.io/rhdh refs (e.g., ghcr.io, quay.io/rhdh-community) unchanged.
     """
     if is_downstream_rarc() and _is_quay_rhdh_ref(registry_reference):
         return registry_reference.replace(QUAY_RHDH_PREFIX, RARC_RHDH_PREFIX)
     return registry_reference
 
 
-def get_image_metadata(registry_reference: str) -> Optional[Dict[str, str]]:
+def parse_registry_reference(registry_reference: str) -> tuple[str, str, str] | None:
+    """Parse a container image reference into its (registry, repository, tag_or_digest) parts.
+
+    Accepts ``registry/repository:tag`` or ``registry/repository@sha256:...``
+    formats. References targeting registry.access.redhat.com are transparently
+    swapped to quay.io/rhdh before parsing via ``get_query_registry_reference``.
+
+    Args:
+        registry_reference: Full image reference string, e.g.
+            ``"ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"`` or
+            ``"quay.io/rhdh/plugin:1.11--1.5.4"`` or
+            ``"registry.access.redhat.com/rhdh/plugin@sha256:abc123"``.
+
+    Returns:
+        A tuple ``(registry, repository, tag_or_digest)`` on success, or
+        ``None`` if the reference cannot be parsed (e.g. missing ``/``,
+        missing both ``:`` and ``@``).
+
+    Example:
+        >>> parse_registry_reference("ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0")
+        ('ghcr.io', 'org/repo/plugin', 'bs_1.45.3__1.2.0')
+
+        >>> parse_registry_reference("quay.io/rhdh/plugin:1.11--1.5.4")
+        ('quay.io', 'rhdh/plugin', '1.11--1.5.4')
+
+        >>> parse_registry_reference("registry.access.redhat.com/rhdh/plugin@sha256:abc123")
+        ('quay.io', 'rhdh/plugin', 'sha256:abc123')
+
+        >>> parse_registry_reference("invalid-no-slash")
+        None
     """
-    Get container image metadata from Docker Registry HTTP API v2
-    Returns: dict with 'digest', 'build-date', 'vcs-ref', 'upstream', 'midstream' or None if failed
+    query_ref = get_query_registry_reference(registry_reference)
+    parts = query_ref.split('/', 1)
+    if len(parts) < 2:
+        return None
+    registry = parts[0]
+    image_and_tag = parts[1]
+    if '@' in image_and_tag:
+        name_part = image_and_tag.split('@', 1)[0]
+        repository = name_part.rsplit(':', 1)[0] if ':' in name_part else name_part
+        tag = image_and_tag.split('@', 1)[1]
+    elif ':' in image_and_tag:
+        repository, tag = image_and_tag.rsplit(':', 1)
+    else:
+        return None
+    return registry, repository, tag
+
+
+def list_tags_with_prefix(registry: str, repository: str, prefix: str, auth, headers: dict) -> list[str]:
+    """List all tags matching a prefix from the registry, filtered to clean versions, sorted ascending.
+
+    Queries the Docker Registry HTTP API v2 with pagination to collect all tags,
+    then filters to only those starting with ``prefix`` whose suffix is a clean
+    version number (e.g. ``2.18.0``, ``1.5``).  This rejects Konflux/Tekton
+    build artifacts such as ``.att``, ``.sbom``, ``.sig``, ``.prefetch``, ``.git``,
+    ``.src``, ``.dockerfile``, bare SHA tags, ``on-pr-*``, ``rhdh-bsp-*``, etc.
+
+    Args:
+        registry: Registry hostname, e.g. ``"ghcr.io"`` or ``"quay.io"``.
+        repository: Image repository path, e.g. ``"rhdh/plugin-foo"``.
+        prefix: Tag prefix to match, e.g. ``"bs_1.49.4__"`` or ``"1.11--"``.
+        auth: Basic-auth tuple ``(username, password)`` or ``None``.
+        headers: Request headers dict (must include Accept and any Bearer token).
+
+    Returns:
+        Tags sorted in ascending version order.  The last element is the
+        latest version.  Empty list if no matching tags are found.
+
+    Example:
+        Given these tags in the registry for ``quay.io/rhdh/plugin-foo``::
+
+            "1.11--1.5.4"           # valid
+            "1.11--1.3.0"           # valid
+            "sha256-abc123.att"     # rejected (doesn't match prefix)
+            "on-pr-abc123.prefetch" # rejected (doesn't match prefix)
+
+        With ``prefix="1.11--"``, returns::
+
+            ["1.11--1.3.0", "1.11--1.5.4"]
+
+        Given these tags for ``ghcr.io/org/repo/plugin``::
+
+            "bs_1.49.4__2.14.0"    # valid
+            "bs_1.49.4__2.18.0"    # valid
+            "sha256:d054dbee..."    # rejected (doesn't match prefix)
+
+        With ``prefix="bs_1.49.4__"``, returns::
+
+            ["bs_1.49.4__2.14.0", "bs_1.49.4__2.18.0"]
+    """
+    matched = []
+    n = 500
+    last = ""
+    while True:
+        url = f"https://{registry}/v2/{repository}/tags/list?n={n}"
+        if last:
+            url += f"&last={requests.utils.quote(last)}"
+        try:
+            resp = requests.get(url, headers=headers, auth=auth, timeout=60)
+            if resp.status_code != 200:
+                break
+            data = resp.json()
+            tags = data.get("tags") or []
+            for t in tags:
+                if t.startswith(prefix) and VERSION_SUFFIX_RE.match(t[len(prefix):]):
+                    matched.append(t)
+            if len(tags) < n:
+                break
+            last = tags[-1] if tags else ""
+            if not last:
+                break
+        except Exception as e:
+            log_debug(f"Error listing tags for {registry}/{repository}: {e}")
+            break
+
+    def version_key(tag: str):
+        suffix = tag[len(prefix):]
+        parts = []
+        for p in suffix.split('.'):
+            try:
+                parts.append((0, int(p)))
+            except ValueError:
+                parts.append((1, p))
+        return parts
+
+    return sorted(matched, key=version_key)
+
+
+def resolve_fallback_tag(registry_reference: str) -> str | None:
+    """Find the latest published tag sharing the same version prefix when the exact tag doesn't exist.
+
+    Constructs a prefix by splitting the tag on the registry-appropriate
+    separator (``"__"`` for ghcr.io, ``"--"`` for quay.io/rhdh) and keeping
+    everything up to and including the separator. Then queries the registry
+    for all tags with that prefix and returns the highest version.
+
+    Args:
+        registry_reference: Full image reference with the requested tag, e.g.
+            ``"quay.io/rhdh/plugin:1.11--1.6.0"`` or
+            ``"ghcr.io/org/repo/plugin:bs_1.45.3__2.18.0"``.
+
+    Returns:
+        The full registry reference with the fallback tag substituted, e.g.
+        ``"quay.io/rhdh/plugin:1.11--1.5.4"``. Returns ``None`` if no tags
+        match the prefix, if the reference cannot be parsed, or if the best
+        matching tag equals the originally requested tag (no fallback needed).
+
+    Example:
+        If ``quay.io/rhdh/plugin:1.11--1.6.0`` does not exist but
+        ``1.11--1.5.4`` and ``1.11--1.3.0`` do::
+
+            >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.11--1.6.0")
+            'quay.io/rhdh/plugin:1.11--1.5.4'
+
+        For ghcr.io with prefix ``bs_1.45.3__``::
+
+            >>> resolve_fallback_tag("ghcr.io/org/repo/plugin:bs_1.45.3__2.18.0")
+            'ghcr.io/org/repo/plugin:bs_1.45.3__2.14.0'
+
+        When the requested prefix has no tags at all — even if older prefixes
+        exist in the registry — the fallback returns ``None``.  For example,
+        if the registry has ``1.11--1.5.4`` and ``1.10--1.5.4`` but nothing
+        with prefix ``1.12--``::
+
+            >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.12--1.5.4")
+            None  # no tags match prefix "1.12--", older prefixes are ignored
+    """
+    parsed = parse_registry_reference(registry_reference)
+    if not parsed:
+        return None
+
+    registry, repository, tag = parsed
+
+    # Detect prefix: ghcr.io uses "__", others use "--"
+    separator = "__" if registry == "ghcr.io" else "--"
+    if separator not in tag:
+        return None
+    prefix = tag.rsplit(separator, 1)[0] + separator
+
+    auth, extra_headers = get_registry_auth(registry, repository)
+    headers = {'Accept': 'application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'}
+    headers.update(extra_headers)
+
+    tags = list_tags_with_prefix(registry, repository, prefix, auth, headers)
+    if not tags:
+        return None
+
+    best_tag = tags[-1]
+    if best_tag == tag:
+        return None
+
+    # Reconstruct the reference with the fallback tag (using original registry, not query registry)
+    original_ref_base = registry_reference.rsplit(':', 1)[0]
+    return f"{original_ref_base}:{best_tag}"
+
+
+def _fetch_image_metadata(registry_reference: str) -> dict[str, str] | None:
+    """Fetch container image metadata via Docker Registry HTTP API v2.
+
+    Retrieves the image manifest to obtain the digest, then fetches the config
+    blob to extract build labels and environment variables. References targeting
+    registry.access.redhat.com are transparently swapped to quay.io/rhdh for
+    querying, since r.a.r.c requires authentication that may not be available.
+
+    Args:
+        registry_reference: Full image reference, e.g.
+            ``"ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"`` or
+            ``"quay.io/rhdh/plugin:1.11--1.5.4"``.
+
+    Returns:
+        A dict of metadata fields on success, or ``None`` on any failure
+        (timeout, HTTP error, invalid reference). The returned dict looks like::
+
+            {
+                'digest': 'sha256:a1b2c3d4...',
+                'build-date': '2025-05-01',
+                'vcs-ref': 'abc123def456',
+                'upstream': 'https://github.com/org/upstream-repo',
+                'midstream': 'https://github.com/org/midstream-repo',
+            }
+
+        Not all fields are guaranteed to be present; only ``'digest'`` is
+        always included on success. Labels (``build-date``, ``vcs-ref``) and
+        env vars (``upstream``, ``midstream``) depend on how the image was
+        built.
+
+    Example:
+        >>> _fetch_image_metadata("ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0")
+        {'digest': 'sha256:a1b2c3...', 'build-date': '2025-05-01', 'vcs-ref': 'abc123'}
+
+        >>> _fetch_image_metadata("quay.io/rhdh/plugin:nonexistent-tag")
+        None
     """
     try:
+        # Swap r.a.r.c → quay.io for queries as r.a.r.c is not always accessible without authentication
         query_ref = get_query_registry_reference(registry_reference)
 
         # Parse the registry reference: registry.io/repo/image:tag
@@ -214,10 +444,104 @@ def get_image_metadata(registry_reference: str) -> Optional[Dict[str, str]]:
         return None
 
 
-def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, report: BuildReport | None = None) -> Tuple[int, int, List[str], int]:
+def get_image_metadata(registry_reference: str) -> dict | None:
+    """Fetch container image metadata, with automatic fallback to the latest published tag.
+
+    Wraps ``_fetch_image_metadata`` with a two-step strategy: first tries the
+    exact tag, and if that fails, calls ``resolve_fallback_tag`` to find the
+    latest published tag with the same version prefix.
+
+    Args:
+        registry_reference: Full image reference, e.g.
+            ``"quay.io/rhdh/plugin:1.11--1.6.0"``.
+
+    Returns:
+        A metadata dict on success, or ``None`` if metadata could not be
+        fetched even after fallback.
+
+        On a **direct hit** (exact tag exists), the dict contains only the
+        fields from ``_fetch_image_metadata``::
+
+            {'digest': 'sha256:...', 'build-date': '2025-05-01', ...}
+
+        On a **fallback hit** (exact tag missing, older tag used), the dict
+        includes three extra fields::
+
+            {
+                'digest': 'sha256:...',
+                'build-date': '2025-05-01',
+                'registryReference': 'quay.io/rhdh/plugin:1.11--1.5.4',
+                'fallback': True,
+                'requestedTag': '1.11--1.6.0',
+            }
+
+    Example:
+        Direct hit (tag ``1.11--1.5.4`` exists)::
+
+            >>> get_image_metadata("quay.io/rhdh/plugin:1.11--1.5.4")
+            {'digest': 'sha256:a1b2c3...', 'build-date': '2025-05-01'}
+
+        Fallback hit (tag ``1.11--1.6.0`` missing, ``1.11--1.5.4`` used)::
+
+            >>> get_image_metadata("quay.io/rhdh/plugin:1.11--1.6.0")
+            {'digest': 'sha256:a1b2c3...', 'registryReference': 'quay.io/rhdh/plugin:1.11--1.5.4',
+             'fallback': True, 'requestedTag': '1.11--1.6.0'}
     """
-    Update all plugin_builds/*.json files with image metadata
-    Returns: (updated_count, error_count, missing_refs, overlays_metadata_changes)
+    metadata = _fetch_image_metadata(registry_reference)
+    if metadata is not None:
+        return metadata
+    
+    original_tag = registry_reference.rsplit(':', 1)[-1] if ':' in registry_reference else ""
+
+    fallback_ref = resolve_fallback_tag(registry_reference)
+    if fallback_ref is None:
+        log_warn(f"Requested tag {Colors.YELLOW}{original_tag}{Colors.NORM} not found, no fallback available")
+        return None
+
+    fallback_tag = fallback_ref.rsplit(':', 1)[-1] if ':' in fallback_ref else ""
+    
+    log_warn(
+        f"[FALLBACK] requested tag {Colors.YELLOW}{original_tag}{Colors.NORM} but tag not found,"
+        f" using latest published tag {Colors.GREEN}{fallback_tag}{Colors.NORM} instead"
+    )
+
+    metadata = _fetch_image_metadata(fallback_ref)
+    if metadata is None:
+        return None
+
+    metadata['registryReference'] = fallback_ref
+    metadata['fallback'] = True
+    metadata['requestedTag'] = original_tag
+    return metadata
+
+
+def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, report: BuildReport | None = None) -> tuple[int, int, list[str], int, int]:
+    """Enrich plugin_builds JSON files with container image metadata from the registry.
+
+    The main enrichment pipeline. For each ``plugin_builds/*/*.json`` file,
+    fetches image metadata (digest, build-date, vcs-ref, upstream, midstream)
+    from the Docker Registry HTTP API v2 and writes the results back into the
+    JSON. Also updates the corresponding ``workspaces/*/metadata/*.yaml``
+    overlay files with the resolved ``dynamicArtifact`` OCI reference
+    (including digest).
+
+    Args:
+        plugin_builds_dir: Path to the ``plugin_builds/`` directory containing
+            per-workspace subdirectories with JSON files.
+        overlays_dir: Path to the overlays repository root (containing
+            ``workspaces/``). Used to locate and update metadata YAML files.
+        report: Optional ``BuildReport`` instance for tracking per-plugin
+            stage results (pass/fail with digest and fallback info).
+
+    Returns:
+        A 5-tuple of ``(updated_count, error_count, missing_refs,
+        overlays_metadata_changes, fallback_count)`` where:
+
+        - ``updated_count``: Number of JSON files successfully enriched.
+        - ``error_count``: Number of JSON files that failed to parse or process.
+        - ``missing_refs``: List of registry references where no image was found.
+        - ``overlays_metadata_changes``: Number of metadata YAML files updated.
+        - ``fallback_count``: Number of plugins that used a fallback tag.
     """
     if not plugin_builds_dir.exists():
         log_error(f"Plugin builds directory {plugin_builds_dir} does not exist")
@@ -233,6 +557,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
     error_count = 0
     missing_refs = []
     overlays_metadata_changes = 0
+    fallback_count = 0
 
     for i, json_file in enumerate(json_files, 1):
         relative_path = json_file.relative_to(plugin_builds_dir)
@@ -253,30 +578,25 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                     metadata = get_image_metadata(registry_reference)
 
                     if metadata:
-                        if 'digest' in metadata:
-                            plugin_data['digest'] = metadata['digest']
-                            modified = True
+                        if 'registryReference' in metadata:
+                            registry_reference = metadata['registryReference']
 
-                        if 'build-date' in metadata:
-                            plugin_data['build-date'] = metadata['build-date']
-                            modified = True
+                        if metadata.get('fallback'):
+                            fallback_count += 1
 
-                        if 'vcs-ref' in metadata:
-                            plugin_data['vcs-ref'] = metadata['vcs-ref']
-                            modified = True
+                        for key, value in metadata.items():
+                            if plugin_data.get(key) != value:
+                                plugin_data[key] = value
+                                modified = True
 
-                        if 'upstream' in metadata:
-                            plugin_data['upstream'] = metadata['upstream']
-                            modified = True
+                        # Clean up stale fallback fields from a previous run
+                        if 'fallback' not in metadata:
+                            for stale_key in ('fallback', 'requestedTag'):
+                                if stale_key in plugin_data:
+                                    del plugin_data[stale_key]
+                                    modified = True
 
-                        if 'midstream' in metadata:
-                            plugin_data['midstream'] = metadata['midstream']
-                            modified = True
-
-                        if DYNAMIC_PACKAGES_ANNOTATION in metadata:
-                            plugin_data[DYNAMIC_PACKAGES_ANNOTATION] = metadata[DYNAMIC_PACKAGES_ANNOTATION]
-                            modified = True
-
+                        # Output ref swap back from quay.io to registry.access.redhat.com if registry is set as r.a.r.c
                         output_ref = get_output_registry_reference(registry_reference)
                         if output_ref != registry_reference:
                             log_debug(f"registry_reference switched to: {output_ref}")
@@ -294,7 +614,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                             )
                 else:
                     fields_removed = []
-                    for field in ['digest', 'build-date', 'vcs-ref', 'upstream', 'midstream', DYNAMIC_PACKAGES_ANNOTATION]:
+                    for field in ['digest', 'build-date', 'vcs-ref', 'upstream', 'midstream', DYNAMIC_PACKAGES_ANNOTATION, 'fallback', 'requestedTag']:
                         if field in plugin_data:
                             del plugin_data[field]
                             fields_removed.append(field)
@@ -302,7 +622,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
 
             if modified:
                 ordered_data = {}
-                key_order = ['workspacePath', 'registryReference', 'digest', 'build-date', 'upstream', 'midstream', 'vcs-ref']
+                key_order = ['workspacePath', 'registryReference', 'fallback', 'requestedTag', 'digest', 'build-date', 'upstream', 'midstream', 'vcs-ref']
 
                 for plugin_name, plugin_data in data.items():
                     ordered_plugin = {}
@@ -328,85 +648,86 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                     for pname, pdata in data.items():
                         digest = pdata.get('digest', '')
                         if digest:
+                            stage_kwargs = {"digest": digest}
+                            if pdata.get('fallback'):
+                                ref_tag = pdata.get('registryReference', '').rsplit(':', 1)[-1]
+                                stage_kwargs["fallback"] = True
+                                stage_kwargs["requestedTag"] = pdata.get('requestedTag', '')
+                                stage_kwargs["resolvedTag"] = ref_tag
                             report.set_stage(
                                 pname, "registry-enrich", "pass",
-                                digest=digest,
+                                **stage_kwargs,
                             )
 
                 # Update the equivalent metadata.yaml file in the overlays directory
-                # Skip metadata write-back for ghcr.io — those images use tagged dynamicArtifacts
-                # and don't include build-date labels (per-reference check)
-                if registry_reference.startswith("ghcr.io/"):
-                    log_debug(f"Skipping metadata write-back for ghcr.io plugin: {relative_path}")
-                else:
-                    metadata_dir = overlays_dir / "workspaces" / relative_path.parent / "metadata"
-                    if metadata_dir.exists():
-                        for plugin_name, plugin_data in data.items():
-                            registry_reference_tag = plugin_data.get('registryReference', '')
-                            if not registry_reference_tag:
+                metadata_dir = overlays_dir / "workspaces" / relative_path.parent / "metadata"
+                if metadata_dir.exists():
+                    for plugin_name, plugin_data in data.items():
+                        registry_reference_tag = plugin_data.get('registryReference', '')
+                        if not registry_reference_tag:
+                            continue
+                        digest = plugin_data.get("digest")
+                        registry_reference_digest = registry_reference_tag
+                        if digest:
+                            ref_base = (registry_reference_tag.split("@")[0] if "@" in registry_reference_tag
+                                        else registry_reference_tag.rsplit(":", 1)[0])
+                            registry_reference_digest = f"{ref_base}@{digest}"
+                        registry_reference_digest = get_output_registry_reference(registry_reference_digest)
+                        metadata_file = None
+                        for f in metadata_dir.glob("*.yaml"):
+                            try:
+                                with open(f, "r", encoding='utf-8') as fp:
+                                    meta = yaml.safe_load(fp)
+                                spec = (meta or {}).get("spec") or {}
+                                pkg = spec.get("packageName") or ""
+                                da = spec.get("dynamicArtifact") or ""
+                                log_debug(f"pkg: {pkg}; f.stem: {f.stem}; plugin_name: {plugin_name}")
+                                image_in_artifact = ("/" + plugin_name + ":" in da or "/" + plugin_name + "@" in da)
+                                stem_matches = f.stem.replace("redhat-backstage-plugin-", "red-hat-developer-hub-backstage-plugin-") == plugin_name
+                                if image_in_artifact or stem_matches or f.stem == plugin_name:
+                                    metadata_file = f
+                                    break
+                            except Exception:
                                 continue
-                            digest = plugin_data.get("digest")
-                            registry_reference_digest = registry_reference_tag
-                            if digest:
-                                ref_base = (registry_reference_tag.split("@")[0] if "@" in registry_reference_tag
-                                            else registry_reference_tag.rsplit(":", 1)[0])
-                                registry_reference_digest = f"{ref_base}@{digest}"
-                            registry_reference_digest = get_output_registry_reference(registry_reference_digest)
-                            metadata_file = None
-                            for f in metadata_dir.glob("*.yaml"):
-                                try:
-                                    with open(f, "r", encoding='utf-8') as fp:
-                                        meta = yaml.safe_load(fp)
-                                    spec = (meta or {}).get("spec") or {}
-                                    pkg = spec.get("packageName") or ""
-                                    da = spec.get("dynamicArtifact") or ""
-                                    log_debug(f"pkg: {pkg}; f.stem: {f.stem}; plugin_name: {plugin_name}")
-                                    image_in_artifact = ("/" + plugin_name + ":" in da or "/" + plugin_name + "@" in da)
-                                    stem_matches = f.stem.replace("redhat-backstage-plugin-", "red-hat-developer-hub-backstage-plugin-") == plugin_name
-                                    if image_in_artifact or stem_matches or f.stem == plugin_name:
-                                        metadata_file = f
-                                        break
-                                except Exception:
-                                    continue
-                            if metadata_file is not None:
-                                with open(metadata_file, "r", encoding='utf-8') as f:
-                                    content = f.read()
-                                try:
-                                    meta = yaml.safe_load(content)
-                                    da = ((meta or {}).get("spec") or {}).get("dynamicArtifact") or ""
-                                except Exception:
-                                    da = ""
-                                if da.startswith("oci://"):
-                                    new_oci = f"oci://{registry_reference_digest}"
-                                    lines = content.splitlines()
-                                    out = []
-                                    for line in lines:
-                                        stripped = line.lstrip()
-                                        if stripped.startswith("dynamicArtifact:") and ("oci://" in line or "quay.io" in line or "registry.access" in line):
-                                            indent = line[: len(line) - len(stripped)]
-                                            tag_parts = registry_reference_tag.split(":")
-                                            tag = tag_parts[1] if len(tag_parts) > 1 else ""
-                                            build_date = plugin_data.get("build-date")
-                                            while out and out[-1].lstrip().startswith("# Tag:"):
-                                                out.pop()
-                                            if build_date:
-                                                out.append(f'{indent}# Tag: {tag}, Build date: {build_date}')
-                                            else:
-                                                out.append(f'{indent}# Tag: {tag}')
-                                            out.append(f'{indent}dynamicArtifact: "{new_oci}"')
+                        if metadata_file is not None:
+                            with open(metadata_file, "r", encoding='utf-8') as f:
+                                content = f.read()
+                            try:
+                                meta = yaml.safe_load(content)
+                                da = ((meta or {}).get("spec") or {}).get("dynamicArtifact") or ""
+                            except Exception:
+                                da = ""
+                            if da.startswith("oci://"):
+                                new_oci = f"oci://{registry_reference_digest}"
+                                lines = content.splitlines()
+                                out = []
+                                for line in lines:
+                                    stripped = line.lstrip()
+                                    if stripped.startswith("dynamicArtifact:") and ("oci://" in line or "quay.io" in line or "registry.access" in line or "ghcr.io" in line):
+                                        indent = line[: len(line) - len(stripped)]
+                                        tag_parts = registry_reference_tag.split(":")
+                                        tag = tag_parts[1] if len(tag_parts) > 1 else ""
+                                        build_date = plugin_data.get("build-date")
+                                        while out and out[-1].lstrip().startswith("# Tag:"):
+                                            out.pop()
+                                        if build_date:
+                                            out.append(f'{indent}# Tag: {tag}, Build date: {build_date}')
                                         else:
-                                            out.append(line)
-                                    with open(metadata_file, "w", encoding='utf-8') as f:
-                                        f.write("\n".join(out))
-                                        f.write("\n")
-                                    overlays_metadata_changes += 1
-                                    log_debug(f"Set 'dynamicArtifact: oci://{registry_reference_digest}'")
-                                    log_debug(f" in {metadata_file}")
-                                    print(
-                                        f"[{i}/{len(json_files)}]   >> https://{Colors.GREEN}"
-                                        f"{registry_reference_digest.replace('@', ' @')}"
-                                        f"{Colors.NORM}\n"
-                                    )
+                                            out.append(f'{indent}# Tag: {tag}')
+                                        out.append(f'{indent}dynamicArtifact: "{new_oci}"')
+                                    else:
+                                        out.append(line)
+                                with open(metadata_file, "w", encoding='utf-8') as f:
+                                    f.write("\n".join(out))
+                                    f.write("\n")
+                                overlays_metadata_changes += 1
+                                log_debug(f"Set 'dynamicArtifact: oci://{registry_reference_digest}'")
+                                log_debug(f" in {metadata_file}")
+                                print(
+                                    f"[{i}/{len(json_files)}]   >> https://{Colors.GREEN}"
+                                    f"{registry_reference_digest.replace('@', ' @')}"
+                                    f"{Colors.NORM}\n"
+                                )
 
         except json.JSONDecodeError as e:
             log_error(f"Error parsing JSON file {json_file}: {e}")
@@ -415,7 +736,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
             log_error(f"Error processing {json_file}: {e}")
             error_count += 1
 
-    return updated_count, error_count, missing_refs, overlays_metadata_changes
+    return updated_count, error_count, missing_refs, overlays_metadata_changes, fallback_count
 
 
 def main():
@@ -491,11 +812,13 @@ Examples:
         sys.exit(1)
 
     log_info("\n=== Update plugin_builds/*.json files with container metadata ===")
-    updated_count, error_count, missing_refs, overlays_metadata_changes = update_plugin_build_files(plugin_builds_dir, overlays_dir, report)
+    updated_count, error_count, missing_refs, overlays_metadata_changes, fallback_count = update_plugin_build_files(plugin_builds_dir, overlays_dir, report)
     total = updated_count + error_count + len(missing_refs)
 
     log_info("\n=== Results ===")
     log_info(f"Updated: {Colors.GREEN}{updated_count}{Colors.NORM} of {total}")
+    if fallback_count > 0:
+        log_warn(f"Fallback Tags: {Colors.YELLOW}{fallback_count}{Colors.NORM} plugin(s) using older published tags")
     if len(missing_refs) > 0:
         log_warn(f"Missing Tags: {Colors.YELLOW}{len(missing_refs)}{Colors.NORM}")
         for ref in missing_refs:

--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -22,8 +22,10 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 import requests
 import yaml
+import hashlib
 
 from plugin_utils import (
+    BuildReport,
     Colors,
     log_debug,
     log_info,
@@ -161,7 +163,6 @@ def get_image_metadata(registry_reference: str) -> Optional[Dict[str, str]]:
         # Get digest from Docker-Content-Digest header
         digest = manifest_response.headers.get('Docker-Content-Digest')
         if not digest:
-            import hashlib
             digest = 'sha256:' + hashlib.sha256(manifest_response.content).hexdigest()
 
         manifest = manifest_response.json()
@@ -213,7 +214,7 @@ def get_image_metadata(registry_reference: str) -> Optional[Dict[str, str]]:
         return None
 
 
-def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tuple[int, int, List[str], int]:
+def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, report: BuildReport | None = None) -> Tuple[int, int, List[str], int]:
     """
     Update all plugin_builds/*.json files with image metadata
     Returns: (updated_count, error_count, missing_refs, overlays_metadata_changes)
@@ -238,7 +239,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tu
         print(f"[{i}/{len(json_files)}] {relative_path}", end="")
 
         try:
-            with open(json_file, 'r') as f:
+            with open(json_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
 
             modified = False
@@ -286,6 +287,11 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tu
                         missing_refs.append(registry_reference)
                         log_warn(f"[{Colors.YELLOW}{len(missing_refs)}{Colors.NORM}] Could not find metadata for https://{Colors.YELLOW}{registry_reference}{Colors.NORM} !")
                         print(" ")
+                        if report:
+                            report.set_stage(
+                                plugin_name, "registry-enrich", "fail",
+                                reason=f"Image not found in registry: {registry_reference}",
+                            )
                 else:
                     fields_removed = []
                     for field in ['digest', 'build-date', 'vcs-ref', 'upstream', 'midstream', DYNAMIC_PACKAGES_ANNOTATION]:
@@ -308,7 +314,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tu
                             ordered_plugin[key] = value
                     ordered_data[plugin_name] = ordered_plugin
 
-                with open(json_file, 'w') as f:
+                with open(json_file, 'w', encoding='utf-8') as f:
                     json.dump(ordered_data, f, indent=2)
                     f.write('\n')
                 updated_count += 1
@@ -317,6 +323,15 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tu
                     f"{get_query_registry_reference(registry_reference)}"
                     f"{Colors.NORM}"
                 )
+
+                if report:
+                    for pname, pdata in data.items():
+                        digest = pdata.get('digest', '')
+                        if digest:
+                            report.set_stage(
+                                pname, "registry-enrich", "pass",
+                                digest=digest,
+                            )
 
                 # Update the equivalent metadata.yaml file in the overlays directory
                 # Skip metadata write-back for ghcr.io — those images use tagged dynamicArtifacts
@@ -340,7 +355,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tu
                             metadata_file = None
                             for f in metadata_dir.glob("*.yaml"):
                                 try:
-                                    with open(f, "r") as fp:
+                                    with open(f, "r", encoding='utf-8') as fp:
                                         meta = yaml.safe_load(fp)
                                     spec = (meta or {}).get("spec") or {}
                                     pkg = spec.get("packageName") or ""
@@ -354,7 +369,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tu
                                 except Exception:
                                     continue
                             if metadata_file is not None:
-                                with open(metadata_file, "r") as f:
+                                with open(metadata_file, "r", encoding='utf-8') as f:
                                     content = f.read()
                                 try:
                                     meta = yaml.safe_load(content)
@@ -381,7 +396,7 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tu
                                             out.append(f'{indent}dynamicArtifact: "{new_oci}"')
                                         else:
                                             out.append(line)
-                                    with open(metadata_file, "w") as f:
+                                    with open(metadata_file, "w", encoding='utf-8') as f:
                                         f.write("\n".join(out))
                                         f.write("\n")
                                     overlays_metadata_changes += 1
@@ -452,6 +467,12 @@ Examples:
         help='Registry base (e.g., ghcr.io/redhat-developer/rhdh-plugin-export-overlays, quay.io/rhdh)',
     )
     parser.add_argument(
+        '--report-file',
+        type=str,
+        metavar='PATH',
+        help='Path to build-report.json for tracking generation stages (optional)',
+    )
+    parser.add_argument(
         '--debug',
         action='store_true',
         help='Enable debug output',
@@ -463,13 +484,14 @@ Examples:
 
     overlays_dir = Path(args.overlays_dir)
     plugin_builds_dir = Path(args.plugin_builds_dir)
+    report = BuildReport(args.report_file)
 
     if not overlays_dir.exists():
         print(f"Error: Overlays directory not found: {overlays_dir}")
         sys.exit(1)
 
     log_info("\n=== Update plugin_builds/*.json files with container metadata ===")
-    updated_count, error_count, missing_refs, overlays_metadata_changes = update_plugin_build_files(plugin_builds_dir, overlays_dir)
+    updated_count, error_count, missing_refs, overlays_metadata_changes = update_plugin_build_files(plugin_builds_dir, overlays_dir, report)
     total = updated_count + error_count + len(missing_refs)
 
     log_info("\n=== Results ===")
@@ -485,6 +507,8 @@ Examples:
         log_info(f"Changes to overlay repo metadata: {Colors.GREEN}{overlays_metadata_changes}{Colors.NORM}")
         log_info(f"To review changes and create a pull request:\n\tcd {overlays_dir}; git diff")
         print(" ")
+
+    report.save()
 
 if __name__ == "__main__":
     main()

--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Update plugin_builds/*.json files with container image metadata:
+# - digest: sha256 digest of the image
+# - build-date: from container label
+# - vcs-ref: from container label
+# - upstream: from container env UPSTREAM_REPO
+# - midstream: from container env MIDSTREAM_REPO
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+import requests
+import yaml
+
+from plugin_utils import (
+    Colors,
+    log_debug,
+    log_info,
+    log_warn,
+    log_error,
+    set_debug,
+)
+
+# Global registry config
+REGISTRY_BASE = ""
+
+# Registry path constants
+QUAY_RHDH_PREFIX = "quay.io/rhdh/"
+RARC_DOMAIN = "registry.access.redhat.com"
+RARC_RHDH_PREFIX = RARC_DOMAIN + "/rhdh/"
+
+DYNAMIC_PACKAGES_ANNOTATION = "io.backstage.dynamic-packages"
+
+
+def is_downstream_quay_rhdh() -> bool:
+    """Check if we're in downstream mode (quay.io/rhdh — NOT quay.io/rhdh-community)"""
+    return REGISTRY_BASE + "/" == QUAY_RHDH_PREFIX
+
+
+def is_downstream_rarc() -> bool:
+    """Check if the user requested registry.access.redhat.com output via -r"""
+    return REGISTRY_BASE.startswith(RARC_DOMAIN)
+
+
+def _is_quay_rhdh_ref(registry_reference: str) -> bool:
+    """Check if a registry reference targets quay.io/rhdh/ (not quay.io/rhdh-community/)."""
+    return registry_reference.startswith(QUAY_RHDH_PREFIX)
+
+
+def get_ghcr_token(repository: str) -> Optional[str]:
+    """Get anonymous bearer token for ghcr.io"""
+    try:
+        url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        return response.json().get("token")
+    except Exception as e:
+        log_debug(f"Failed to get ghcr.io token for {repository}: {e}")
+        return None
+
+
+def get_registry_auth(registry: str, repository: str):
+    """
+    Get authentication for a registry.
+    Returns (auth_tuple, headers_dict) where auth_tuple is for basic auth
+    and headers_dict contains bearer token if applicable.
+    """
+    auth = None
+    extra_headers = {}
+
+    if registry == "ghcr.io":
+        token = get_ghcr_token(repository)
+        if token:
+            extra_headers['Authorization'] = f"Bearer {token}"
+    else:
+        username = os.environ.get('REGISTRY_USERNAME')
+        password = os.environ.get('REGISTRY_PASSWORD')
+        if username and password:
+            auth = (username, password)
+
+    return auth, extra_headers
+
+
+def get_query_registry_reference(registry_reference: str) -> str:
+    """
+    Get the registry reference to use for querying.
+    For registry.access.redhat.com refs, swap to quay.io for unauthenticated verification.
+    Per-reference check — works with mixed-registry plugin_builds.
+    """
+    if registry_reference.startswith(RARC_RHDH_PREFIX):
+        return registry_reference.replace(RARC_RHDH_PREFIX, QUAY_RHDH_PREFIX)
+    return registry_reference
+
+
+def get_output_registry_reference(registry_reference: str) -> str:
+    """
+    Get the registry reference to use for output/storage.
+    Only swap quay.io/rhdh/ → registry.access.redhat.com/rhdh/ when the user
+    explicitly requested r.a.r.c output via -r registry.access.redhat.com/rhdh.
+    """
+    if is_downstream_rarc() and _is_quay_rhdh_ref(registry_reference):
+        return registry_reference.replace(QUAY_RHDH_PREFIX, RARC_RHDH_PREFIX)
+    return registry_reference
+
+
+def get_image_metadata(registry_reference: str) -> Optional[Dict[str, str]]:
+    """
+    Get container image metadata from Docker Registry HTTP API v2
+    Returns: dict with 'digest', 'build-date', 'vcs-ref', 'upstream', 'midstream' or None if failed
+    """
+    try:
+        query_ref = get_query_registry_reference(registry_reference)
+
+        # Parse the registry reference: registry.io/repo/image:tag
+        parts = query_ref.split('/', 1)
+        if len(parts) < 2:
+            log_error(f"Invalid registry reference format: {query_ref}")
+            return None
+
+        registry = parts[0]
+        image_and_tag = parts[1]
+
+        # Split image from tag/digest
+        if '@' in image_and_tag:
+            name_part, tag = image_and_tag.split('@', 1)
+            if ':' in name_part:
+                repository = name_part.rsplit(':', 1)[0]
+            else:
+                repository = name_part
+        elif ':' in image_and_tag:
+            repository, tag = image_and_tag.rsplit(':', 1)
+        else:
+            repository = image_and_tag
+            tag = 'latest'
+
+        auth, extra_headers = get_registry_auth(registry, repository)
+
+        headers = {
+            'Accept': 'application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'
+        }
+        headers.update(extra_headers)
+
+        # Get manifest to obtain digest
+        manifest_url = f"https://{registry}/v2/{repository}/manifests/{tag}"
+        manifest_response = requests.get(manifest_url, headers=headers, auth=auth, timeout=30)
+
+        if manifest_response.status_code != 200:
+            return None
+
+        # Get digest from Docker-Content-Digest header
+        digest = manifest_response.headers.get('Docker-Content-Digest')
+        if not digest:
+            import hashlib
+            digest = 'sha256:' + hashlib.sha256(manifest_response.content).hexdigest()
+
+        manifest = manifest_response.json()
+
+        # Get config blob to extract labels
+        config_digest = None
+        if 'config' in manifest and 'digest' in manifest['config']:
+            config_digest = manifest['config']['digest']
+
+        metadata = {'digest': digest}
+
+        # Extract OCI manifest-level annotations (e.g., io.backstage.dynamic-packages)
+        manifest_annotations = manifest.get('annotations', {})
+        dynamic_packages = manifest_annotations.get(DYNAMIC_PACKAGES_ANNOTATION)
+        if dynamic_packages:
+            metadata[DYNAMIC_PACKAGES_ANNOTATION] = dynamic_packages
+
+        if config_digest:
+            blob_url = f"https://{registry}/v2/{repository}/blobs/{config_digest}"
+            blob_response = requests.get(blob_url, headers=headers, auth=auth, timeout=30)
+
+            if blob_response.status_code == 200:
+                config = blob_response.json()
+                config_data = config.get('config', {})
+
+                labels = config_data.get('Labels', {})
+                if 'build-date' in labels:
+                    metadata['build-date'] = labels['build-date']
+                if 'vcs-ref' in labels:
+                    metadata['vcs-ref'] = labels['vcs-ref']
+
+                env_vars = config_data.get('Env', [])
+                for env_var in env_vars:
+                    if env_var.startswith('UPSTREAM_REPO='):
+                        metadata['upstream'] = env_var.split('=', 1)[1]
+                    elif env_var.startswith('MIDSTREAM_REPO='):
+                        metadata['midstream'] = env_var.split('=', 1)[1]
+
+        return metadata
+
+    except requests.exceptions.Timeout:
+        log_warn(f"Timeout getting metadata for {registry_reference}")
+        return None
+    except requests.exceptions.RequestException as e:
+        log_warn(f"Error getting metadata for {registry_reference}: {e}")
+        return None
+    except Exception as e:
+        log_warn(f"Unexpected error getting metadata for {registry_reference}: {e}")
+        return None
+
+
+def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path) -> Tuple[int, int, List[str], int]:
+    """
+    Update all plugin_builds/*.json files with image metadata
+    Returns: (updated_count, error_count, missing_refs, overlays_metadata_changes)
+    """
+    if not plugin_builds_dir.exists():
+        log_error(f"Plugin builds directory {plugin_builds_dir} does not exist")
+        sys.exit(1)
+
+    json_files = list(plugin_builds_dir.glob("*/*.json"))
+
+    if not json_files:
+        log_error("No JSON files found in plugin_builds/")
+        sys.exit(1)
+
+    updated_count = 0
+    error_count = 0
+    missing_refs = []
+    overlays_metadata_changes = 0
+
+    for i, json_file in enumerate(json_files, 1):
+        relative_path = json_file.relative_to(plugin_builds_dir)
+        print(f"[{i}/{len(json_files)}] {relative_path}", end="")
+
+        try:
+            with open(json_file, 'r') as f:
+                data = json.load(f)
+
+            modified = False
+
+            for plugin_name, plugin_data in data.items():
+                registry_reference = plugin_data.get('registryReference')
+
+                if registry_reference:
+                    log_debug(f"\nFetching metadata for {registry_reference}")
+
+                    metadata = get_image_metadata(registry_reference)
+
+                    if metadata:
+                        if 'digest' in metadata:
+                            plugin_data['digest'] = metadata['digest']
+                            modified = True
+
+                        if 'build-date' in metadata:
+                            plugin_data['build-date'] = metadata['build-date']
+                            modified = True
+
+                        if 'vcs-ref' in metadata:
+                            plugin_data['vcs-ref'] = metadata['vcs-ref']
+                            modified = True
+
+                        if 'upstream' in metadata:
+                            plugin_data['upstream'] = metadata['upstream']
+                            modified = True
+
+                        if 'midstream' in metadata:
+                            plugin_data['midstream'] = metadata['midstream']
+                            modified = True
+
+                        if DYNAMIC_PACKAGES_ANNOTATION in metadata:
+                            plugin_data[DYNAMIC_PACKAGES_ANNOTATION] = metadata[DYNAMIC_PACKAGES_ANNOTATION]
+                            modified = True
+
+                        output_ref = get_output_registry_reference(registry_reference)
+                        if output_ref != registry_reference:
+                            log_debug(f"registry_reference switched to: {output_ref}")
+                            plugin_data['registryReference'] = output_ref
+                            registry_reference = output_ref
+                    else:
+                        print(" ")
+                        missing_refs.append(registry_reference)
+                        log_warn(f"[{Colors.YELLOW}{len(missing_refs)}{Colors.NORM}] Could not find metadata for https://{Colors.YELLOW}{registry_reference}{Colors.NORM} !")
+                        print(" ")
+                else:
+                    fields_removed = []
+                    for field in ['digest', 'build-date', 'vcs-ref', 'upstream', 'midstream', DYNAMIC_PACKAGES_ANNOTATION]:
+                        if field in plugin_data:
+                            del plugin_data[field]
+                            fields_removed.append(field)
+                            modified = True
+
+            if modified:
+                ordered_data = {}
+                key_order = ['workspacePath', 'registryReference', 'digest', 'build-date', 'upstream', 'midstream', 'vcs-ref']
+
+                for plugin_name, plugin_data in data.items():
+                    ordered_plugin = {}
+                    for key in key_order:
+                        if key in plugin_data:
+                            ordered_plugin[key] = plugin_data[key]
+                    for key, value in plugin_data.items():
+                        if key not in ordered_plugin:
+                            ordered_plugin[key] = value
+                    ordered_data[plugin_name] = ordered_plugin
+
+                with open(json_file, 'w') as f:
+                    json.dump(ordered_data, f, indent=2)
+                    f.write('\n')
+                updated_count += 1
+                print(
+                    f" >> https://{Colors.GREEN}"
+                    f"{get_query_registry_reference(registry_reference)}"
+                    f"{Colors.NORM}"
+                )
+
+                # Update the equivalent metadata.yaml file in the overlays directory
+                # Skip metadata write-back for ghcr.io — those images use tagged dynamicArtifacts
+                # and don't include build-date labels (per-reference check)
+                if registry_reference.startswith("ghcr.io/"):
+                    log_debug(f"Skipping metadata write-back for ghcr.io plugin: {relative_path}")
+                else:
+                    metadata_dir = overlays_dir / "workspaces" / relative_path.parent / "metadata"
+                    if metadata_dir.exists():
+                        for plugin_name, plugin_data in data.items():
+                            registry_reference_tag = plugin_data.get('registryReference', '')
+                            if not registry_reference_tag:
+                                continue
+                            digest = plugin_data.get("digest")
+                            registry_reference_digest = registry_reference_tag
+                            if digest:
+                                ref_base = (registry_reference_tag.split("@")[0] if "@" in registry_reference_tag
+                                            else registry_reference_tag.rsplit(":", 1)[0])
+                                registry_reference_digest = f"{ref_base}@{digest}"
+                            registry_reference_digest = get_output_registry_reference(registry_reference_digest)
+                            metadata_file = None
+                            for f in metadata_dir.glob("*.yaml"):
+                                try:
+                                    with open(f, "r") as fp:
+                                        meta = yaml.safe_load(fp)
+                                    spec = (meta or {}).get("spec") or {}
+                                    pkg = spec.get("packageName") or ""
+                                    da = spec.get("dynamicArtifact") or ""
+                                    log_debug(f"pkg: {pkg}; f.stem: {f.stem}; plugin_name: {plugin_name}")
+                                    image_in_artifact = ("/" + plugin_name + ":" in da or "/" + plugin_name + "@" in da)
+                                    stem_matches = f.stem.replace("redhat-backstage-plugin-", "red-hat-developer-hub-backstage-plugin-") == plugin_name
+                                    if image_in_artifact or stem_matches or f.stem == plugin_name:
+                                        metadata_file = f
+                                        break
+                                except Exception:
+                                    continue
+                            if metadata_file is not None:
+                                with open(metadata_file, "r") as f:
+                                    content = f.read()
+                                try:
+                                    meta = yaml.safe_load(content)
+                                    da = ((meta or {}).get("spec") or {}).get("dynamicArtifact") or ""
+                                except Exception:
+                                    da = ""
+                                if da.startswith("oci://"):
+                                    new_oci = f"oci://{registry_reference_digest}"
+                                    lines = content.splitlines()
+                                    out = []
+                                    for line in lines:
+                                        stripped = line.lstrip()
+                                        if stripped.startswith("dynamicArtifact:") and ("oci://" in line or "quay.io" in line or "registry.access" in line):
+                                            indent = line[: len(line) - len(stripped)]
+                                            tag_parts = registry_reference_tag.split(":")
+                                            tag = tag_parts[1] if len(tag_parts) > 1 else ""
+                                            build_date = plugin_data.get("build-date")
+                                            while out and out[-1].lstrip().startswith("# Tag:"):
+                                                out.pop()
+                                            if build_date:
+                                                out.append(f'{indent}# Tag: {tag}, Build date: {build_date}')
+                                            else:
+                                                out.append(f'{indent}# Tag: {tag}')
+                                            out.append(f'{indent}dynamicArtifact: "{new_oci}"')
+                                        else:
+                                            out.append(line)
+                                    with open(metadata_file, "w") as f:
+                                        f.write("\n".join(out))
+                                        f.write("\n")
+                                    overlays_metadata_changes += 1
+                                    log_debug(f"Set 'dynamicArtifact: oci://{registry_reference_digest}'")
+                                    log_debug(f" in {metadata_file}")
+                                    print(
+                                        f"[{i}/{len(json_files)}]   >> https://{Colors.GREEN}"
+                                        f"{registry_reference_digest.replace('@', ' @')}"
+                                        f"{Colors.NORM}\n"
+                                    )
+
+        except json.JSONDecodeError as e:
+            log_error(f"Error parsing JSON file {json_file}: {e}")
+            error_count += 1
+        except Exception as e:
+            log_error(f"Error processing {json_file}: {e}")
+            error_count += 1
+
+    return updated_count, error_count, missing_refs, overlays_metadata_changes
+
+
+def main():
+    usage="""
+Usage: python3 generatePluginBuildInfo.py [--debug] \\
+    -r|--registry image-registry \\
+    [-d|--overlays-dir PATH] \\
+    [-b|--plugin-builds-dir PATH]
+
+Examples:
+    # From repo root with defaults (overlays-dir=., plugin-builds-dir=plugin_builds)
+    python3 generatePluginBuildInfo.py \\
+        -r ghcr.io/redhat-developer/rhdh-plugin-export-overlays
+
+    # Enrich specific plugin_builds/ with quay.io/rhdh image metadata
+    python3 generatePluginBuildInfo.py \\
+        -b plugin_builds/supported \\
+        -r quay.io/rhdh
+"""
+
+    global REGISTRY_BASE
+
+    parser = argparse.ArgumentParser(
+        description='Update plugin_builds/*.json with container image metadata from the registry.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=usage
+    )
+    parser.error = lambda msg: (print(f"\n{Colors.RED}[ERROR] {msg}{Colors.NORM}\n{usage}", file=sys.stderr), sys.exit(2))
+
+    parser.add_argument(
+        '-d', '--overlays-dir',
+        type=str,
+        default='.',
+        metavar='PATH',
+        help='Path to overlays directory containing workspaces/ (default: .)',
+    )
+    parser.add_argument(
+        '-b', '--plugin-builds-dir',
+        type=str,
+        default='plugin_builds',
+        metavar='PATH',
+        help='Path to plugin_builds/ directory (default: plugin_builds)',
+    )
+    parser.add_argument(
+        '-r', '--registry',
+        type=str,
+        required=True,
+        metavar='BASE',
+        help='Registry base (e.g., ghcr.io/redhat-developer/rhdh-plugin-export-overlays, quay.io/rhdh)',
+    )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Enable debug output',
+    )
+
+    args = parser.parse_args()
+    set_debug(args.debug)
+    REGISTRY_BASE = args.registry.rstrip('/')
+
+    overlays_dir = Path(args.overlays_dir)
+    plugin_builds_dir = Path(args.plugin_builds_dir)
+
+    if not overlays_dir.exists():
+        print(f"Error: Overlays directory not found: {overlays_dir}")
+        sys.exit(1)
+
+    log_info("\n=== Update plugin_builds/*.json files with container metadata ===")
+    updated_count, error_count, missing_refs, overlays_metadata_changes = update_plugin_build_files(plugin_builds_dir, overlays_dir)
+    total = updated_count + error_count + len(missing_refs)
+
+    log_info("\n=== Results ===")
+    log_info(f"Updated: {Colors.GREEN}{updated_count}{Colors.NORM} of {total}")
+    if len(missing_refs) > 0:
+        log_warn(f"Missing Tags: {Colors.YELLOW}{len(missing_refs)}{Colors.NORM}")
+        for ref in missing_refs:
+            log_warn(f"  - https://{Colors.YELLOW}{ref}{Colors.NORM}")
+        print(" ")
+    if error_count > 0:
+        log_error(f"Errors: {Colors.RED}{error_count}{Colors.NORM}")
+    if overlays_metadata_changes > 0:
+        log_info(f"Changes to overlay repo metadata: {Colors.GREEN}{overlays_metadata_changes}{Colors.NORM}")
+        log_info(f"To review changes and create a pull request:\n\tcd {overlays_dir}; git diff")
+        print(" ")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/injectDpdyTagComments.py
+++ b/scripts/injectDpdyTagComments.py
@@ -18,6 +18,29 @@ TAG_LINE_RE = re.compile(r"^\s*# Tag:")
 
 
 def load_tag_by_key(plugin_builds_dir: Path) -> dict[str, tuple[str, str]]:
+    """Read all plugin_builds/*/*.json and build a lookup dict from image name to (tag, build_date).
+
+    Each JSON file maps plugin image names to their registry references and
+    build dates. For every entry, an alias is also added so that both the
+    ``red-hat-developer-hub-`` and ``rhdh-`` prefixed forms resolve to the
+    same tag info.
+
+    Args:
+        plugin_builds_dir: Path to the plugin_builds/ directory. Each
+            subdirectory contains JSON files with plugin build metadata.
+
+    Returns:
+        A dict mapping image name (str) to a (tag, build_date) tuple.
+        Returns an empty dict if the directory does not exist.
+
+    Example::
+
+        >>> load_tag_by_key(Path("plugin_builds"))
+        {
+            "red-hat-developer-hub-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+            "rhdh-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+        }
+    """
     tag_by_key: dict[str, tuple[str, str]] = {}
     if not plugin_builds_dir.is_dir():
         return tag_by_key
@@ -40,6 +63,26 @@ def load_tag_by_key(plugin_builds_dir: Path) -> dict[str, tuple[str, str]]:
 
 
 def keys_for_package(pkg: str) -> list[str]:
+    """Generate all lookup keys for a package name to try against tag_by_key.
+
+    Produces the original name, a variant with the ``-dynamic`` suffix
+    stripped, and a variant with the ``rhdh-`` prefix expanded to
+    ``red-hat-developer-hub-``.
+
+    Args:
+        pkg: The package name to generate keys for (e.g.
+            ``"rhdh-backstage-plugin-foo-dynamic"``).
+
+    Returns:
+        A list of candidate keys, ordered from most specific to least.
+
+    Example::
+
+        >>> keys_for_package("rhdh-backstage-plugin-foo-dynamic")
+        ["rhdh-backstage-plugin-foo-dynamic",
+         "rhdh-backstage-plugin-foo",
+         "red-hat-developer-hub-backstage-plugin-foo-dynamic"]
+    """
     keys = [pkg]
     if pkg.endswith("-dynamic"):
         keys.append(pkg[: -len("-dynamic")])
@@ -49,6 +92,25 @@ def keys_for_package(pkg: str) -> list[str]:
 
 
 def comment_for_package(pkg: str, tag_by_key: dict[str, tuple[str, str]]) -> str | None:
+    """Look up the tag comment string for a package name.
+
+    Tries each key from ``keys_for_package`` against ``tag_by_key`` and
+    returns the formatted YAML comment for the first match.
+
+    Args:
+        pkg: The package name to look up.
+        tag_by_key: The lookup dict built by ``load_tag_by_key``.
+
+    Returns:
+        A formatted comment string (e.g.
+        ``"  # Tag: 1.11--1.5.4, Build date: 2025-05-01\\n"``), or None
+        if no matching tag info was found.
+
+    Example::
+
+        >>> comment_for_package("rhdh-backstage-plugin-foo", tag_by_key)
+        "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\\n"
+    """
     for key in keys_for_package(pkg):
         if key in tag_by_key:
             tag, bd = tag_by_key[key]
@@ -57,6 +119,11 @@ def comment_for_package(pkg: str, tag_by_key: dict[str, tuple[str, str]]) -> str
 
 
 def package_name_from_oci_comment(line: str) -> str | None:
+    """Extract the image name from a commented OCI package line.
+
+    Parses lines like ``# - package: oci://registry/image-name@sha256:...``
+    and returns the image name portion.
+    """
     m = re.search(r"oci://[^/]+/([^@\s!]+)", line)
     if not m:
         return None
@@ -64,13 +131,18 @@ def package_name_from_oci_comment(line: str) -> str | None:
 
 
 def package_name_from_package_value(val: str) -> str:
+    """Extract the package name from a package value string.
+
+    Handles both local paths (``./dynamic-plugins/dist/foo`` returns
+    ``foo``) and OCI references (returns the image name before ``@``).
+    """
     if val.startswith("./"):
         return val.rsplit("/", 1)[-1]
     return val.split("/")[-1].split("@")[0]
 
 
 def recent_has_tag(result: list[str]) -> bool:
-    """Check if a Tag comment exists between the current position and the previous package line."""
+    """Check if a Tag comment already exists between the current position and the previous package line."""
     for line in reversed(result):
         if TAG_LINE_RE.match(line):
             return True
@@ -80,6 +152,36 @@ def recent_has_tag(result: list[str]) -> bool:
 
 
 def inject(dpdy_path: Path, plugin_builds_dir: Path) -> bool:
+    """Insert ``# Tag: ..., Build date: ...`` comments into dynamic-plugins.default.yaml.
+
+    Reads the DPDY file and plugin build metadata, then inserts tag/build-date
+    comments in two positions:
+
+    - After ``# - package: oci://...`` lines (commented-out migration blocks)
+    - Before ``- package: ./dynamic-plugins/dist/...`` lines (wrapper package
+      entries), only when no Tag comment already exists nearby
+
+    Args:
+        dpdy_path: Path to the dynamic-plugins.default.yaml file.
+        plugin_builds_dir: Path to the plugin_builds/ directory containing
+            workspace subdirectories with JSON build metadata files.
+
+    Returns:
+        True if the file was modified and written back, False otherwise.
+
+    Example:
+
+        Before::
+
+            # - package: oci://quay.io/rhdh/plugin-foo@sha256:abc123
+            - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic
+
+        After::
+
+            # - package: oci://quay.io/rhdh/plugin-foo@sha256:abc123
+            # Tag: 1.11--1.5.4, Build date: 2025-05-01
+            - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic
+    """
     tag_by_key = load_tag_by_key(plugin_builds_dir)
     lines = dpdy_path.read_text(encoding="utf-8").splitlines(keepends=True)
     result: list[str] = []

--- a/scripts/injectDpdyTagComments.py
+++ b/scripts/injectDpdyTagComments.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+#
+# Insert # Tag / Build date comments into dynamic-plugins.default.yaml from plugin_builds/.
+# TODO: Once we drop wrappers, this will be obsolete and can be deleted
+#
+# - After "# - package: oci://..." (migration block)
+# - Before "- package: ./dynamic-plugins/dist/..." only when no Tag comment is already nearby
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+COMMENTED_OCI_RE = re.compile(r"^ {2}# - package: oci://")
+PKG_LINE_RE = re.compile(r"^ {2}- package: (?P<val>\S+)")
+TAG_LINE_RE = re.compile(r"^\s*# Tag:")
+
+
+def load_tag_by_key(plugin_builds_dir: Path) -> dict[str, tuple[str, str]]:
+    tag_by_key: dict[str, tuple[str, str]] = {}
+    if not plugin_builds_dir.is_dir():
+        return tag_by_key
+    for jf in sorted(plugin_builds_dir.glob("*/*.json")):
+        try:
+            data = json.loads(jf.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"Warning: Skipping invalid plugin build file: {jf} ({e})", file=sys.stderr)
+            continue
+        for name, pdata in data.items():
+            ref = pdata.get("registryReference") or ""
+            tag = ref.rsplit(":", 1)[-1] if ":" in ref else ""
+            bd = pdata.get("build-date") or ""
+            if not (tag and bd):
+                continue
+            tag_by_key[name] = (tag, bd)
+            alt = name.replace("red-hat-developer-hub-", "rhdh-")
+            tag_by_key[alt] = (tag, bd)
+    return tag_by_key
+
+
+def keys_for_package(pkg: str) -> list[str]:
+    keys = [pkg]
+    if pkg.endswith("-dynamic"):
+        keys.append(pkg[: -len("-dynamic")])
+    if pkg.startswith("rhdh-"):
+        keys.append("red-hat-developer-hub-" + pkg[5:])
+    return keys
+
+
+def comment_for_package(pkg: str, tag_by_key: dict[str, tuple[str, str]]) -> str | None:
+    for key in keys_for_package(pkg):
+        if key in tag_by_key:
+            tag, bd = tag_by_key[key]
+            return f"  # Tag: {tag}, Build date: {bd}\n"
+    return None
+
+
+def package_name_from_oci_comment(line: str) -> str | None:
+    m = re.search(r"oci://[^/]+/([^@\s!]+)", line)
+    if not m:
+        return None
+    return m.group(1).rsplit("/", 1)[-1]
+
+
+def package_name_from_package_value(val: str) -> str:
+    if val.startswith("./"):
+        return val.rsplit("/", 1)[-1]
+    return val.split("/")[-1].split("@")[0]
+
+
+def recent_has_tag(result: list[str]) -> bool:
+    """Check if a Tag comment exists between the current position and the previous package line."""
+    for line in reversed(result):
+        if TAG_LINE_RE.match(line):
+            return True
+        if PKG_LINE_RE.match(line) or COMMENTED_OCI_RE.match(line):
+            return False
+    return False
+
+
+def inject(dpdy_path: Path, plugin_builds_dir: Path) -> bool:
+    tag_by_key = load_tag_by_key(plugin_builds_dir)
+    lines = dpdy_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    result: list[str] = []
+    changed = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+
+        if COMMENTED_OCI_RE.match(line):
+            result.append(line)
+            i += 1
+            if i < len(lines) and TAG_LINE_RE.match(lines[i]):
+                result.append(lines[i])
+                i += 1
+                continue
+            pkg = package_name_from_oci_comment(line)
+            cmt = comment_for_package(pkg, tag_by_key) if pkg else None
+            if cmt:
+                result.append(cmt)
+                changed = True
+            continue
+
+        m = PKG_LINE_RE.match(line)
+        if m:
+            pkg = package_name_from_package_value(m.group("val"))
+            if not recent_has_tag(result):
+                cmt = comment_for_package(pkg, tag_by_key)
+                if cmt:
+                    result.append(cmt)
+                    changed = True
+
+        result.append(line)
+        i += 1
+
+    if changed:
+        dpdy_path.write_text("".join(result), encoding="utf-8")
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inject Tag/Build date comments into DPDY from plugin_builds")
+    parser.add_argument("dpdy_file", type=Path, help="Path to dynamic-plugins.default.yaml")
+    parser.add_argument("plugin_builds_dir", type=Path, help="Path to plugin_builds/ directory containing workspace JSON files")
+    args = parser.parse_args()
+    if not args.dpdy_file.is_file():
+        print(f"Error: DPDY file not found: {args.dpdy_file}", file=sys.stderr)
+        return 1
+    inject(args.dpdy_file, args.plugin_builds_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/plugin_utils.py
+++ b/scripts/plugin_utils.py
@@ -700,7 +700,9 @@ class BuildReport:
 
         for plugin in self._data.get("plugins", {}).values():
             stages = plugin.get("stages", {})
-            if any(s.get("status") == "fail" for s in stages.values()):
+            if any(s.get("status") == "outdated" for s in stages.values()):
+                plugin["overall"] = "outdated"
+            elif any(s.get("status") == "fail" for s in stages.values()):
                 plugin["overall"] = "fail"
             elif stages and all(
                 s.get("status") in ("pass", "skip") for s in stages.values()
@@ -713,16 +715,18 @@ class BuildReport:
         total = len(plugins)
         succeeded = sum(1 for p in plugins.values() if p.get("overall") == "pass")
         failed = sum(1 for p in plugins.values() if p.get("overall") == "fail")
+        outdated = sum(1 for p in plugins.values() if p.get("overall") == "outdated")
 
         self._data["summary"] = {
             "total": total,
             "succeeded": succeeded,
             "failed": failed,
+            "outdated": outdated,
         }
 
         if total == 0:
             self._data["status"] = "initial"
-        elif failed == 0:
+        elif failed == 0 and outdated == 0:
             self._data["status"] = "success"
         else:
             self._data["status"] = "partial"

--- a/scripts/plugin_utils.py
+++ b/scripts/plugin_utils.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+#
+# Shared utilities for catalog index generation scripts.
+#
+# Provides logging, package file loading, workspace metadata resolution,
+# and multi-format package list handling (YAML npm names + txt workspace paths).
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+DEBUG = False
+
+
+class Colors:
+    NORM = "\033[0;39m"
+    GREEN = "\033[1;32m"
+    BLUE = "\033[1;34m"
+    RED = "\033[1;31m"
+    ORANGE = "\033[38;5;208m"
+    YELLOW = "\033[1;33m"
+    RESET = "\033[0m"
+
+
+def set_debug(enabled: bool) -> None:
+    global DEBUG
+    DEBUG = enabled
+
+
+def log_debug(message: str) -> None:
+    if DEBUG:
+        print(f"{Colors.ORANGE}[DEBUG]{Colors.NORM} {message}")
+
+
+def log_info(message: str) -> None:
+    print(f"{Colors.GREEN}[INFO]{Colors.NORM} {message}")
+
+
+def log_warn(message: str) -> None:
+    print(f"{Colors.YELLOW}[WARN]{Colors.NORM} {message}")
+
+
+def log_error(message: str) -> None:
+    print(f"{Colors.RED}[ERROR]{Colors.NORM} {message}")
+
+
+def read_plugins_list(workspace_dir: Path) -> list[str]:
+    """Read plugins-list.yaml and return list of plugin paths (without trailing colon/args)."""
+    plugins_list_file = workspace_dir / "plugins-list.yaml"
+    if not plugins_list_file.exists():
+        return []
+
+    paths = []
+    with open(plugins_list_file, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            path = line.split(':')[0].strip()
+            if path:
+                paths.append(path)
+    return paths
+
+
+def match_metadata_to_plugin_path(metadata_name: str, plugin_paths: list[str]) -> str | None:
+    """
+    Match a metadata file stem to a plugins-list.yaml entry.
+    metadata_name: e.g., 'backstage-community-plugin-acr'
+    plugin_paths:  e.g., ['plugins/acr']
+    Returns the matching path or None.
+    """
+    sorted_paths = sorted(plugin_paths, key=lambda p: -len(p.split('/')[-1]))
+    for path in sorted_paths:
+        last_segment = path.split('/')[-1]
+        if metadata_name == last_segment:
+            return path
+        if metadata_name.endswith('-' + last_segment):
+            return path
+        if metadata_name.endswith(last_segment):
+            return path
+    return None
+
+
+def detect_file_format(file_path: str) -> str:
+    """Returns 'yaml' or 'txt' based on file extension."""
+    p = Path(file_path)
+    if p.suffix in ('.yaml', '.yml'):
+        return 'yaml'
+    return 'txt'
+
+
+def load_filtered_packages_from_yaml(packages_file: str) -> set[str]:
+    """Load filtered package names from default.packages.yaml.
+    Returns set of npm package names from both enabled and disabled sections."""
+    path = Path(packages_file)
+    if not path.exists():
+        log_error(f"Packages file not found: {packages_file}")
+        sys.exit(1)
+
+    with open(path, 'r') as f:
+        data = yaml.safe_load(f)
+
+    packages = set()
+    for section in ['enabled', 'disabled']:
+        for entry in data.get('packages', {}).get(section, []) or []:
+            pkg = entry.get('package', '').strip()
+            if pkg:
+                packages.add(pkg)
+
+    return packages
+
+
+def load_packages_from_txt(txt_file: str) -> list[str]:
+    """Load workspace paths from a txt file (e.g., rhdh-supported-packages.txt).
+    Returns list of workspace paths like 'backstage/plugins/techdocs'."""
+    path = Path(txt_file)
+    if not path.exists():
+        log_error(f"Packages txt file not found: {txt_file}")
+        sys.exit(1)
+
+    paths = []
+    with open(path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                paths.append(line)
+    return paths
+
+
+@dataclass
+class WorkspaceMappings:
+    ws_path_to_npm: dict[str, str] = field(default_factory=dict)
+    ws_path_to_stem: dict[str, str] = field(default_factory=dict)
+    npm_to_stem: dict[str, str] = field(default_factory=dict)
+    stem_to_npm: dict[str, str] = field(default_factory=dict)
+
+
+def _match_workspace_metadata(
+    ws_name: str,
+    metadata_entries: list[tuple[str, str]],
+    plugin_paths: list[str],
+) -> dict[str, str]:
+    """Match metadata entries to plugin paths within a single workspace.
+
+    Uses scored matching to avoid greedy collisions (e.g., two stems matching
+    the same path), then process-of-elimination for remaining unmatched pairs.
+
+    metadata_entries: list of (stem, npm_name) pairs
+    plugin_paths: list of plugin paths from plugins-list.yaml
+    Returns: dict mapping stem -> workspace_path
+    """
+    result: dict[str, str] = {}
+
+    if not plugin_paths:
+        for stem, npm_name in metadata_entries:
+            result[stem] = f"{ws_name}/{stem}"
+            log_debug(f"No plugins-list for workspace {ws_name}, using fallback: {ws_name}/{stem}")
+        return result
+
+    # Pass 1: build scored candidates — (stem, path, score)
+    # Higher score = more specific match. Prefer longest last_segment matches.
+    candidates: list[tuple[str, str, int]] = []
+    for stem, npm_name in metadata_entries:
+        for path in plugin_paths:
+            last_seg = path.split('/')[-1]
+            if stem == last_seg:
+                candidates.append((stem, path, len(last_seg) * 10 + 3))
+            elif stem.endswith('-' + last_seg):
+                candidates.append((stem, path, len(last_seg) * 10 + 2))
+            elif stem.endswith(last_seg):
+                candidates.append((stem, path, len(last_seg) * 10 + 1))
+
+    # Assign greedily by score descending, no duplicates on either side
+    candidates.sort(key=lambda c: -c[2])
+    matched_stems: set[str] = set()
+    matched_paths: set[str] = set()
+    for stem, path, _score in candidates:
+        if stem in matched_stems or path in matched_paths:
+            continue
+        result[stem] = f"{ws_name}/{path}"
+        matched_stems.add(stem)
+        matched_paths.add(path)
+
+    # Pass 2: process of elimination for unmatched
+    unmatched = [(s, n) for s, n in metadata_entries if s not in matched_stems]
+    remaining_paths = [p for p in plugin_paths if p not in matched_paths]
+
+    if unmatched and remaining_paths:
+        # Try substring matching on remaining pairs
+        still_unmatched = []
+        still_available = list(remaining_paths)
+        for stem, npm_name in unmatched:
+            found = False
+            for path in still_available:
+                last_seg = path.split('/')[-1]
+                if last_seg in stem:
+                    result[stem] = f"{ws_name}/{path}"
+                    still_available.remove(path)
+                    log_debug(f"Matched by substring: {stem} -> {path}")
+                    found = True
+                    break
+            if not found:
+                still_unmatched.append((stem, npm_name))
+
+        # Final elimination: pair remaining 1:1 if counts match
+        if len(still_unmatched) == len(still_available):
+            for (stem, npm_name), path in zip(still_unmatched, still_available):
+                result[stem] = f"{ws_name}/{path}"
+                log_debug(f"Matched by elimination: {stem} -> {path}")
+            still_unmatched = []
+
+        unmatched = still_unmatched
+
+    # Fallback for anything truly unmatched
+    for stem, npm_name in unmatched:
+        result[stem] = f"{ws_name}/{stem}"
+        log_debug(f"No plugins-list match for {stem}, using fallback: {ws_name}/{stem}")
+
+    return result
+
+
+def build_workspace_mappings(overlays_dir: Path) -> WorkspaceMappings:
+    """Scan workspaces/*/metadata/*.yaml and plugins-list.yaml to build
+    bidirectional maps between workspace paths, npm names, and stems."""
+    mappings = WorkspaceMappings()
+    workspaces_dir = overlays_dir / "workspaces"
+    if not workspaces_dir.exists():
+        return mappings
+
+    log_debug("Scanning all workspaces to build workspace path mappings (this covers the full repo, not just filtered packages)...")
+
+    for ws_dir in sorted(workspaces_dir.iterdir()):
+        if not ws_dir.is_dir():
+            continue
+        metadata_dir = ws_dir / "metadata"
+        if not metadata_dir.exists():
+            continue
+
+        ws_name = ws_dir.name
+        plugin_paths = read_plugins_list(ws_dir)
+
+        # Collect all metadata entries for this workspace
+        metadata_entries: list[tuple[str, str]] = []  # (stem, npm_name)
+        stem_to_npm_local: dict[str, str] = {}
+
+        for yaml_file in sorted(metadata_dir.glob("*.yaml")):
+            try:
+                with open(yaml_file, 'r') as f:
+                    data = yaml.safe_load(f)
+                if not data or data.get('kind') != 'Package':
+                    continue
+
+                stem = data.get('metadata', {}).get('name', yaml_file.stem)
+                npm_name = data.get('spec', {}).get('packageName', '')
+                if not npm_name:
+                    continue
+
+                metadata_entries.append((stem, npm_name))
+                stem_to_npm_local[stem] = npm_name
+            except Exception:
+                continue
+
+        # Match all metadata to plugin paths
+        stem_to_ws_path = _match_workspace_metadata(ws_name, metadata_entries, plugin_paths)
+
+        for stem, ws_path in stem_to_ws_path.items():
+            npm_name = stem_to_npm_local[stem]
+            mappings.ws_path_to_npm[ws_path] = npm_name
+            mappings.ws_path_to_stem[ws_path] = stem
+            mappings.npm_to_stem[npm_name] = stem
+            mappings.stem_to_npm[stem] = npm_name
+
+    log_debug(f"Workspace mapping complete: {len(mappings.npm_to_stem)} packages across {len({ p.split('/')[0] for p in mappings.ws_path_to_npm })} workspaces")
+
+    return mappings
+
+
+def _load_file_entries(file_path: str) -> tuple[str, set[str]]:
+    """Load entries from a file, auto-detecting format.
+    Returns (format, set_of_entries) where entries are npm names or workspace paths."""
+    fmt = detect_file_format(file_path)
+    if fmt == 'yaml':
+        entries = load_filtered_packages_from_yaml(file_path)
+    else:
+        entries = set(load_packages_from_txt(file_path))
+    log_debug(f"Loaded {len(entries)} packages from {file_path} ({fmt} format)")
+    for entry in sorted(entries):
+        log_debug(f"  - {entry}")
+    return fmt, entries
+
+
+def load_and_resolve_to_stems(
+    packages_files: list[str],
+    overlays_dir: Path,
+) -> set[str]:
+    """Takes a list of file paths (YAML or txt), auto-detects format,
+    resolves all to metadata entity stems.
+    Returns union of all resolved stems."""
+    if not packages_files:
+        return set()
+
+    mappings = build_workspace_mappings(overlays_dir)
+
+    per_file_stems: dict[str, set[str]] = {}
+
+    for file_path in packages_files:
+        fmt, entries = _load_file_entries(file_path)
+        stems = set()
+
+        if fmt == 'yaml':
+            for npm_name in entries:
+                stem = mappings.npm_to_stem.get(npm_name)
+                if stem:
+                    stems.add(stem)
+                    log_debug(f"Resolved: {npm_name} -> {stem} (from {file_path})")
+                else:
+                    log_warn(f"Package '{npm_name}' from {file_path} not found in workspace metadata")
+        else:
+            for ws_path in entries:
+                stem = mappings.ws_path_to_stem.get(ws_path)
+                if stem:
+                    stems.add(stem)
+                    log_debug(f"Resolved: {ws_path} -> {stem} (from {file_path})")
+                else:
+                    log_warn(f"Entry '{ws_path}' from {file_path} could not be resolved to a metadata stem")
+
+        per_file_stems[file_path] = stems
+
+    # Log overlaps between files
+    file_list = list(per_file_stems.keys())
+    for i in range(len(file_list)):
+        for j in range(i + 1, len(file_list)):
+            f1, f2 = file_list[i], file_list[j]
+            overlap = per_file_stems[f1] & per_file_stems[f2]
+            if overlap:
+                for stem in sorted(overlap):
+                    log_debug(f"Overlap: stem '{stem}' found in both {f1} and {f2}")
+
+    # Build union and log summary
+    all_stems = set()
+    for stems in per_file_stems.values():
+        all_stems |= stems
+
+    if len(packages_files) > 1:
+        parts = []
+        for fp, stems in per_file_stems.items():
+            parts.append(f"{len(stems)} from {fp}")
+        total_overlap = sum(
+            len(per_file_stems[file_list[i]] & per_file_stems[file_list[j]])
+            for i in range(len(file_list))
+            for j in range(i + 1, len(file_list))
+        )
+        log_debug(f"Union: {len(all_stems)} total stems ({', '.join(parts)}, {total_overlap} overlap)")
+    else:
+        log_debug(f"Resolved {len(all_stems)} stems from {packages_files[0]}")
+
+    return all_stems
+
+
+def load_and_resolve_to_npm_names(
+    packages_files: list[str],
+    overlays_dir: Path,
+) -> set[str]:
+    """Takes a list of file paths (YAML or txt), auto-detects format,
+    resolves all to npm package names.
+    Returns union of all resolved npm names."""
+    if not packages_files:
+        return set()
+
+    mappings = build_workspace_mappings(overlays_dir)
+
+    per_file_npms: dict[str, set[str]] = {}
+
+    for file_path in packages_files:
+        fmt, entries = _load_file_entries(file_path)
+        npms = set()
+
+        if fmt == 'yaml':
+            for npm_name in entries:
+                if npm_name in mappings.npm_to_stem:
+                    npms.add(npm_name)
+                    log_debug(f"Resolved: {npm_name} (from {file_path})")
+                else:
+                    log_warn(f"Package '{npm_name}' from {file_path} not found in workspace metadata")
+        else:
+            for ws_path in entries:
+                npm_name = mappings.ws_path_to_npm.get(ws_path)
+                if npm_name:
+                    npms.add(npm_name)
+                    log_debug(f"Resolved: {ws_path} -> {npm_name} (from {file_path})")
+                else:
+                    log_warn(f"Entry '{ws_path}' from {file_path} could not be resolved to an npm name")
+
+        per_file_npms[file_path] = npms
+
+    # Log overlaps between files
+    file_list = list(per_file_npms.keys())
+    for i in range(len(file_list)):
+        for j in range(i + 1, len(file_list)):
+            f1, f2 = file_list[i], file_list[j]
+            overlap = per_file_npms[f1] & per_file_npms[f2]
+            if overlap:
+                for npm in sorted(overlap):
+                    log_debug(f"Overlap: npm '{npm}' found in both {f1} and {f2}")
+
+    # Build union and log summary
+    all_npms = set()
+    for npms in per_file_npms.values():
+        all_npms |= npms
+
+    if len(packages_files) > 1:
+        parts = []
+        for fp, npms in per_file_npms.items():
+            parts.append(f"{len(npms)} from {fp}")
+        total_overlap = sum(
+            len(per_file_npms[file_list[i]] & per_file_npms[file_list[j]])
+            for i in range(len(file_list))
+            for j in range(i + 1, len(file_list))
+        )
+        log_debug(f"Union: {len(all_npms)} total npm names ({', '.join(parts)}, {total_overlap} overlap)")
+    else:
+        log_debug(f"Resolved {len(all_npms)} npm names from {packages_files[0]}")
+
+    return all_npms

--- a/scripts/plugin_utils.py
+++ b/scripts/plugin_utils.py
@@ -65,26 +65,6 @@ def read_plugins_list(workspace_dir: Path) -> list[str]:
                 paths.append(path)
     return paths
 
-
-def match_metadata_to_plugin_path(metadata_name: str, plugin_paths: list[str]) -> str | None:
-    """
-    Match a metadata file stem to a plugins-list.yaml entry.
-    metadata_name: e.g., 'backstage-community-plugin-acr'
-    plugin_paths:  e.g., ['plugins/acr']
-    Returns the matching path or None.
-    """
-    sorted_paths = sorted(plugin_paths, key=lambda p: -len(p.split('/')[-1]))
-    for path in sorted_paths:
-        last_segment = path.split('/')[-1]
-        if metadata_name == last_segment:
-            return path
-        if metadata_name.endswith('-' + last_segment):
-            return path
-        if metadata_name.endswith(last_segment):
-            return path
-    return None
-
-
 def detect_file_format(file_path: str) -> str:
     """Returns 'yaml' or 'txt' based on file extension."""
     p = Path(file_path)
@@ -94,8 +74,30 @@ def detect_file_format(file_path: str) -> str:
 
 
 def load_filtered_packages_from_yaml(packages_file: str) -> set[str]:
-    """Load filtered package names from default.packages.yaml.
-    Returns set of npm package names from both enabled and disabled sections."""
+    """Load npm package names from a packages YAML file.
+
+    Reads a YAML file in the ``default.packages.yaml`` format and returns
+    the union of npm package names from both the ``enabled`` and ``disabled``
+    sections under the top-level ``packages`` key.
+
+    Args:
+        packages_file: Path to the packages YAML file.
+
+    Returns:
+        Set of npm package name strings.
+
+    Example:
+        Given a YAML file with::
+
+            packages:
+              enabled:
+                - package: "@backstage-community/plugin-techdocs"
+              disabled:
+                - package: "@backstage-community/plugin-foo"
+
+        >>> load_filtered_packages_from_yaml("default.packages.yaml")
+        {"@backstage-community/plugin-techdocs", "@backstage-community/plugin-foo"}
+    """
     path = Path(packages_file)
     if not path.exists():
         log_error(f"Packages file not found: {packages_file}")
@@ -115,8 +117,22 @@ def load_filtered_packages_from_yaml(packages_file: str) -> set[str]:
 
 
 def load_packages_from_txt(txt_file: str) -> list[str]:
-    """Load workspace paths from a txt file (e.g., rhdh-supported-packages.txt).
-    Returns list of workspace paths like 'backstage/plugins/techdocs'."""
+    """Load workspace paths from a plain-text package list file.
+
+    Reads a text file with one workspace path per line. Blank lines and
+    lines starting with ``#`` are ignored.
+
+    Args:
+        txt_file: Path to the text file (e.g.,
+            ``rhdh-supported-packages.txt``).
+
+    Returns:
+        List of workspace path strings, in file order.
+
+    Example:
+        >>> load_packages_from_txt("rhdh-supported-packages.txt")
+        ["backstage/plugins/techdocs", "backstage/plugins/catalog"]
+    """
     path = Path(txt_file)
     if not path.exists():
         log_error(f"Packages txt file not found: {txt_file}")
@@ -133,6 +149,31 @@ def load_packages_from_txt(txt_file: str) -> list[str]:
 
 @dataclass
 class WorkspaceMappings:
+    """Bidirectional lookup maps connecting workspace paths, npm names, and stems.
+
+    These four dictionaries allow resolution between the three identifier formats
+    used across the repo:
+
+    - **Workspace paths** (``ws_path``): slash-separated paths like
+      ``"backstage/plugins/techdocs"`` drawn from ``plugins-list.yaml``.
+    - **npm names**: scoped package names like
+      ``"@backstage-community/plugin-techdocs"`` from ``spec.packageName``
+      in Package entity YAMLs.
+    - **Stems**: the ``metadata.name`` field from Package entity YAMLs, e.g.
+      ``"backstage-community-plugin-techdocs"``. These are the canonical
+      identifiers used for filtering throughout catalog index generation.
+
+    Attributes:
+        ws_path_to_npm: Maps workspace path to npm package name.
+            Example: ``{"backstage/plugins/techdocs": "@backstage-community/plugin-techdocs"}``
+        ws_path_to_stem: Maps workspace path to metadata entity stem.
+            Example: ``{"backstage/plugins/techdocs": "backstage-community-plugin-techdocs"}``
+        npm_to_stem: Maps npm package name to metadata entity stem.
+            Example: ``{"@backstage-community/plugin-techdocs": "backstage-community-plugin-techdocs"}``
+        stem_to_npm: Maps metadata entity stem to npm package name.
+            Example: ``{"backstage-community-plugin-techdocs": "@backstage-community/plugin-techdocs"}``
+    """
+
     ws_path_to_npm: dict[str, str] = field(default_factory=dict)
     ws_path_to_stem: dict[str, str] = field(default_factory=dict)
     npm_to_stem: dict[str, str] = field(default_factory=dict)
@@ -146,12 +187,47 @@ def _match_workspace_metadata(
 ) -> dict[str, str]:
     """Match metadata entries to plugin paths within a single workspace.
 
-    Uses scored matching to avoid greedy collisions (e.g., two stems matching
-    the same path), then process-of-elimination for remaining unmatched pairs.
+    Resolves which ``plugins-list.yaml`` path corresponds to each Package
+    entity stem, using a two-pass heuristic:
 
-    metadata_entries: list of (stem, npm_name) pairs
-    plugin_paths: list of plugin paths from plugins-list.yaml
-    Returns: dict mapping stem -> workspace_path
+    **Pass 1 -- Scored matching:**
+    Every (stem, path) pair is scored based on how the path's last segment
+    relates to the stem:
+
+    - Exact match (``stem == last_segment``): highest score
+    - Suffix with dash (``stem.endswith("-" + last_segment)``): medium
+    - Plain suffix (``stem.endswith(last_segment)``): lowest
+
+    Scores are weighted by segment length to prefer longer (more specific)
+    matches. Pairs are then assigned greedily in descending score order,
+    ensuring no stem or path is used twice.
+
+    **Pass 2 -- Process of elimination:**
+    Remaining unmatched stems are resolved against remaining paths via:
+
+    1. Substring matching (``last_segment in stem``)
+    2. 1:1 pairing if the count of unmatched stems equals remaining paths
+
+    Any stems still unmatched fall back to ``"{ws_name}/{stem}"``.
+
+    Args:
+        ws_name: Workspace directory name (e.g., ``"backstage"``).
+        metadata_entries: List of ``(stem, npm_name)`` pairs from Package
+            entity YAMLs in ``workspaces/{ws_name}/metadata/``.
+        plugin_paths: Plugin paths from ``plugins-list.yaml`` (e.g.,
+            ``["plugins/techdocs", "plugins/catalog"]``).
+
+    Returns:
+        Dict mapping each stem to its full workspace path
+        (``"{ws_name}/{plugin_path}"``).
+
+    Example:
+        >>> _match_workspace_metadata(
+        ...     "backstage",
+        ...     [("backstage-community-plugin-techdocs", "@backstage-community/plugin-techdocs")],
+        ...     ["plugins/techdocs"],
+        ... )
+        {"backstage-community-plugin-techdocs": "backstage/plugins/techdocs"}
     """
     result: dict[str, str] = {}
 
@@ -224,8 +300,50 @@ def _match_workspace_metadata(
 
 
 def build_workspace_mappings(overlays_dir: Path) -> WorkspaceMappings:
-    """Scan workspaces/*/metadata/*.yaml and plugins-list.yaml to build
-    bidirectional maps between workspace paths, npm names, and stems."""
+    """Scan all workspaces to build bidirectional maps between workspace paths,
+    npm names, and metadata entity stems.
+
+    Iterates over every workspace in ``{overlays_dir}/workspaces/`` and reads:
+
+    - ``workspaces/{ws}/metadata/*.yaml`` -- Package entity YAMLs providing
+      ``metadata.name`` (stem) and ``spec.packageName`` (npm name)
+    - ``workspaces/{ws}/plugins-list.yaml`` -- plugin paths within the
+      upstream source repo
+
+    These are matched via ``_match_workspace_metadata`` to produce the four
+    maps in ``WorkspaceMappings``.
+
+    The directory structure consumed::
+
+        workspaces/
+          backstage/
+            metadata/
+              backstage-community-plugin-techdocs.yaml
+            plugins-list.yaml
+          rhdh/
+            metadata/
+              ...
+            plugins-list.yaml
+
+    Note:
+        This scans ALL workspaces in the repo, not just the ones being
+        filtered for a particular catalog index tier. The full mapping is
+        needed so that any package file (YAML or txt) can be resolved.
+
+    Args:
+        overlays_dir: Root of the overlays repository (the directory
+            containing the ``workspaces/`` subdirectory).
+
+    Returns:
+        A ``WorkspaceMappings`` instance with all four maps populated.
+
+    Example:
+        >>> mappings = build_workspace_mappings(Path("/path/to/rhdh-plugin-export-overlays"))
+        >>> mappings.npm_to_stem["@backstage-community/plugin-techdocs"]
+        'backstage-community-plugin-techdocs'
+        >>> mappings.ws_path_to_npm["backstage/plugins/techdocs"]
+        '@backstage-community/plugin-techdocs'
+    """
     mappings = WorkspaceMappings()
     workspaces_dir = overlays_dir / "workspaces"
     if not workspaces_dir.exists():
@@ -297,9 +415,45 @@ def load_and_resolve_to_stems(
     packages_files: list[str],
     overlays_dir: Path,
 ) -> set[str]:
-    """Takes a list of file paths (YAML or txt), auto-detects format,
-    resolves all to metadata entity stems.
-    Returns union of all resolved stems."""
+    """Load package lists from multiple files and resolve all entries to
+    metadata entity stems.
+
+    Each file is auto-detected as YAML or txt based on extension. YAML files
+    contain npm package names (resolved via ``npm_to_stem``); txt files
+    contain workspace paths (resolved via ``ws_path_to_stem``). The union
+    of all resolved stems across all files is returned.
+
+    Logs warnings for entries that cannot be resolved and debug-level
+    messages for cross-file overlaps.
+
+    Args:
+        packages_files: Paths to package list files. Supports mixed formats
+            (some YAML, some txt) in the same call.
+        overlays_dir: Root of the overlays repository (passed through to
+            ``build_workspace_mappings``).
+
+    Returns:
+        Union of resolved stems from all input files.
+
+    Example:
+        >>> # YAML file containing "@backstage-community/plugin-techdocs"
+        >>> # resolves to stem "backstage-community-plugin-techdocs"
+        >>> stems = load_and_resolve_to_stems(
+        ...     ["default.packages.yaml"],
+        ...     Path("/path/to/overlays"),
+        ... )
+        >>> "backstage-community-plugin-techdocs" in stems
+        True
+
+        >>> # txt file containing "backstage/plugins/techdocs"
+        >>> # resolves to the same stem via workspace mapping
+        >>> stems = load_and_resolve_to_stems(
+        ...     ["rhdh-supported-packages.txt"],
+        ...     Path("/path/to/overlays"),
+        ... )
+        >>> "backstage-community-plugin-techdocs" in stems
+        True
+    """
     if not packages_files:
         return set()
 
@@ -365,9 +519,44 @@ def load_and_resolve_to_npm_names(
     packages_files: list[str],
     overlays_dir: Path,
 ) -> set[str]:
-    """Takes a list of file paths (YAML or txt), auto-detects format,
-    resolves all to npm package names.
-    Returns union of all resolved npm names."""
+    """Load package lists from multiple files and resolve all entries to npm
+    package names.
+
+    Each file is auto-detected as YAML or txt based on extension. YAML files
+    already contain npm names (validated against workspace metadata); txt files
+    contain workspace paths (resolved via ``ws_path_to_npm``). The union of
+    all resolved npm names across all files is returned.
+
+    Logs warnings for entries that cannot be resolved and debug-level
+    messages for cross-file overlaps.
+
+    Args:
+        packages_files: Paths to package list files. Supports mixed formats
+            (some YAML, some txt) in the same call.
+        overlays_dir: Root of the overlays repository (passed through to
+            ``build_workspace_mappings``).
+
+    Returns:
+        Union of resolved npm package names from all input files.
+
+    Example:
+        >>> # txt file containing "backstage/plugins/techdocs"
+        >>> # resolves to npm name "@backstage-community/plugin-techdocs"
+        >>> npms = load_and_resolve_to_npm_names(
+        ...     ["rhdh-supported-packages.txt"],
+        ...     Path("/path/to/overlays"),
+        ... )
+        >>> "@backstage-community/plugin-techdocs" in npms
+        True
+
+        >>> # YAML file entries are validated and passed through directly
+        >>> npms = load_and_resolve_to_npm_names(
+        ...     ["default.packages.yaml"],
+        ...     Path("/path/to/overlays"),
+        ... )
+        >>> "@backstage-community/plugin-techdocs" in npms
+        True
+    """
     if not packages_files:
         return set()
 
@@ -431,11 +620,24 @@ def load_and_resolve_to_npm_names(
 class BuildReport:
     """Manages a build-report.json file for tracking plugin generation stages.
 
-    Usage:
-        report = BuildReport(args.report_file)  # None disables reporting
-        report.add_plugin("image-name", package="@scope/pkg", version="1.0")
-        report.set_stage("image-name", "bootstrap", "pass", oci_ref="quay.io/...")
-        report.save()  # computes overall/summary and writes to disk
+    Tracks per-plugin build progress through named stages (e.g., bootstrap,
+    export, publish), each with a pass/fail/skip status. On ``save()``,
+    computes per-plugin overall status and an aggregate summary.
+
+    Passing ``None`` as the report file disables all operations (methods
+    become no-ops). An ``atexit`` handler is registered to auto-save on
+    process exit when reporting is enabled.
+
+    Args:
+        report_file: Path to the JSON report file, or ``None`` to disable.
+
+    Example:
+        >>> report = BuildReport("build-report.json")
+        >>> report.set_metadata(backstage_version="1.45.1")
+        >>> report.add_plugin("plugin-techdocs", package="@backstage-community/plugin-techdocs")
+        >>> report.set_stage("plugin-techdocs", "bootstrap", "pass", oci_ref="quay.io/...")
+        >>> report.set_stage("plugin-techdocs", "export", "pass")
+        >>> report.save()  # writes JSON with overall="pass", summary counts
     """
 
     def __init__(self, report_file: str | None):
@@ -457,11 +659,13 @@ class BuildReport:
         return self._path is not None
 
     def set_metadata(self, **fields) -> None:
+        """Update top-level metadata fields (e.g., backstage_version, node_version)."""
         if not self.enabled:
             return
         self._data.setdefault("metadata", {}).update(fields)
 
     def add_plugin(self, plugin_name: str, **info) -> None:
+        """Register a plugin in the report with optional info fields (e.g., package, version)."""
         if not self.enabled:
             return
         plugin = self._data.setdefault("plugins", {}).setdefault(
@@ -472,6 +676,7 @@ class BuildReport:
                 plugin[k] = v
 
     def set_stage(self, plugin_name: str, stage: str, status: str, **details) -> None:
+        """Record the outcome of a build stage for a specific plugin."""
         if not self.enabled:
             return
         plugin = self._data.setdefault("plugins", {}).setdefault(
@@ -482,12 +687,14 @@ class BuildReport:
         plugin.setdefault("stages", {})[stage] = stage_data
 
     def set_stage_all(self, stage: str, status: str, **details) -> None:
+        """Apply the same stage outcome to every plugin currently in the report."""
         if not self.enabled:
             return
         for plugin_name in self._data.get("plugins", {}):
             self.set_stage(plugin_name, stage, status, **details)
 
     def save(self) -> None:
+        """Compute per-plugin overall status and summary counts, then write to disk."""
         if not self.enabled:
             return
 

--- a/scripts/plugin_utils.py
+++ b/scripts/plugin_utils.py
@@ -5,6 +5,8 @@
 # Provides logging, package file loading, workspace metadata resolution,
 # and multi-format package list handling (YAML npm names + txt workspace paths).
 
+import atexit
+import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -53,7 +55,7 @@ def read_plugins_list(workspace_dir: Path) -> list[str]:
         return []
 
     paths = []
-    with open(plugins_list_file, 'r') as f:
+    with open(plugins_list_file, 'r', encoding='utf-8') as f:
         for line in f:
             line = line.strip()
             if not line or line.startswith('#'):
@@ -99,7 +101,7 @@ def load_filtered_packages_from_yaml(packages_file: str) -> set[str]:
         log_error(f"Packages file not found: {packages_file}")
         sys.exit(1)
 
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         data = yaml.safe_load(f)
 
     packages = set()
@@ -121,7 +123,7 @@ def load_packages_from_txt(txt_file: str) -> list[str]:
         sys.exit(1)
 
     paths = []
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         for line in f:
             line = line.strip()
             if line and not line.startswith('#'):
@@ -247,7 +249,7 @@ def build_workspace_mappings(overlays_dir: Path) -> WorkspaceMappings:
 
         for yaml_file in sorted(metadata_dir.glob("*.yaml")):
             try:
-                with open(yaml_file, 'r') as f:
+                with open(yaml_file, 'r', encoding='utf-8') as f:
                     data = yaml.safe_load(f)
                 if not data or data.get('kind') != 'Package':
                     continue
@@ -424,3 +426,101 @@ def load_and_resolve_to_npm_names(
         log_debug(f"Resolved {len(all_npms)} npm names from {packages_files[0]}")
 
     return all_npms
+
+
+class BuildReport:
+    """Manages a build-report.json file for tracking plugin generation stages.
+
+    Usage:
+        report = BuildReport(args.report_file)  # None disables reporting
+        report.add_plugin("image-name", package="@scope/pkg", version="1.0")
+        report.set_stage("image-name", "bootstrap", "pass", oci_ref="quay.io/...")
+        report.save()  # computes overall/summary and writes to disk
+    """
+
+    def __init__(self, report_file: str | None):
+        self._path = Path(report_file) if report_file else None
+        self._data: dict = {}
+        if self._path and self._path.exists():
+            try:
+                with open(self._path, 'r', encoding='utf-8') as f:
+                    self._data = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                self._data = {"metadata": {}, "plugins": {}}
+        elif self._path:
+            self._data = {"metadata": {}, "plugins": {}}
+        if self._path:
+            atexit.register(self.save)
+
+    @property
+    def enabled(self) -> bool:
+        return self._path is not None
+
+    def set_metadata(self, **fields) -> None:
+        if not self.enabled:
+            return
+        self._data.setdefault("metadata", {}).update(fields)
+
+    def add_plugin(self, plugin_name: str, **info) -> None:
+        if not self.enabled:
+            return
+        plugin = self._data.setdefault("plugins", {}).setdefault(
+            plugin_name, {"stages": {}}
+        )
+        for k, v in info.items():
+            if k != "stages":
+                plugin[k] = v
+
+    def set_stage(self, plugin_name: str, stage: str, status: str, **details) -> None:
+        if not self.enabled:
+            return
+        plugin = self._data.setdefault("plugins", {}).setdefault(
+            plugin_name, {"stages": {}}
+        )
+        stage_data = {"status": status}
+        stage_data.update(details)
+        plugin.setdefault("stages", {})[stage] = stage_data
+
+    def set_stage_all(self, stage: str, status: str, **details) -> None:
+        if not self.enabled:
+            return
+        for plugin_name in self._data.get("plugins", {}):
+            self.set_stage(plugin_name, stage, status, **details)
+
+    def save(self) -> None:
+        if not self.enabled:
+            return
+
+        for plugin in self._data.get("plugins", {}).values():
+            stages = plugin.get("stages", {})
+            if any(s.get("status") == "fail" for s in stages.values()):
+                plugin["overall"] = "fail"
+            elif stages and all(
+                s.get("status") in ("pass", "skip") for s in stages.values()
+            ):
+                plugin["overall"] = "pass"
+            else:
+                plugin["overall"] = "pending"
+
+        plugins = self._data.get("plugins", {})
+        total = len(plugins)
+        succeeded = sum(1 for p in plugins.values() if p.get("overall") == "pass")
+        failed = sum(1 for p in plugins.values() if p.get("overall") == "fail")
+
+        self._data["summary"] = {
+            "total": total,
+            "succeeded": succeeded,
+            "failed": failed,
+        }
+
+        if total == 0:
+            self._data["status"] = "initial"
+        elif failed == 0:
+            self._data["status"] = "success"
+        else:
+            self._data["status"] = "partial"
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self._path, 'w', encoding='utf-8') as f:
+            json.dump(self._data, f, indent=2)
+            f.write('\n')

--- a/scripts/renderCatalogStatus.py
+++ b/scripts/renderCatalogStatus.py
@@ -296,6 +296,9 @@ def render_tier(
             requested = enrich.get("requestedTag", "")
             resolved = enrich.get("resolvedTag", "")
             oci_ref = stages.get("bootstrap", {}).get("oci_ref", "")
+            if resolved and ":" in oci_ref:
+                # Use fallback tag instead of requested tag
+                oci_ref = oci_ref.rsplit(":", 1)[0] + ":" + resolved
             name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
             oci_link = oci_ref_to_link(oci_ref, ghcr_version_ids)
             lines.append(f"| {name_link} | `{pkg}` | `{requested}` | `{resolved}` | {oci_link} |")

--- a/scripts/renderCatalogStatus.py
+++ b/scripts/renderCatalogStatus.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) Red Hat, Inc.
 #
-# Render build-report.json files into a GitHub Wiki markdown status page.
+# Render build-report.json files into a markdown status page.
 #
 # Usage:
 #   python3 renderCatalogStatus.py \
@@ -25,11 +25,27 @@ from pathlib import Path
 
 
 STAGE_LABELS = {
-    "bootstrap": "Bootstrap",
-    "registry-enrich": "Registry Enrich",
-    "dpdy": "DPDY",
-    "catalog-index": "Catalog Index",
+    "bootstrap": "Plugin Builds Bootstrap",
+    "image-metadata-fetch": "Image Metadata Fetch",
+    "dpdy": "DPDY Generation",
+    "catalog-index": "Catalog Index Generation",
 }
+
+REASON_ANCHORS = {
+    "Backstage version mismatch": "backstage-version-mismatch",
+    "Image not found in registry": "image-not-found-in-registry",
+}
+
+
+def reason_to_link(reason: str, troubleshooting_content: str) -> str:
+    """Convert a failure reason to an in-page troubleshooting anchor link if it matches a known prefix.
+    Only links if troubleshooting content is embedded in the page."""
+    if not troubleshooting_content:
+        return reason
+    for prefix, anchor in REASON_ANCHORS.items():
+        if reason.startswith(prefix):
+            return f"[{reason}](#{anchor})"
+    return reason
 
 
 def load_report(path: str) -> dict:
@@ -158,6 +174,15 @@ def oci_ref_to_link(oci_ref: str, ghcr_version_ids: dict[str, int] | None = None
         else:
             url = f"https://github.com/{org}/{repo}/pkgs/container/{encoded_pkg}"
         return f"[{ref}]({url})"
+    if ref.startswith("registry.access.redhat.com/"):
+        rest = ref[len("registry.access.redhat.com/"):]
+        if ":" in rest:
+            path_part, tag = rest.split(":", 1)
+            tag = tag.split("@", 1)[0]
+            url = f"https://quay.io/repository/{path_part}?tab=tags&tag={tag}"
+        else:
+            url = f"https://quay.io/repository/{rest}"
+        return f"[{ref}]({url})"
     return f"`{ref}`"
 
 
@@ -173,7 +198,7 @@ def workspace_link(source_repo: str, branch: str, workspace: str) -> str:
 
 def first_failed_stage(stages: dict) -> tuple[str, str]:
     """Return (stage_label, reason) for the first failed stage."""
-    for stage_key in ["bootstrap", "registry-enrich", "dpdy", "catalog-index"]:
+    for stage_key in ["bootstrap", "image-metadata-fetch", "dpdy", "catalog-index"]:
         stage = stages.get(stage_key, {})
         if stage.get("status") == "fail":
             label = STAGE_LABELS.get(stage_key, stage_key)
@@ -187,7 +212,7 @@ def render_tier(
     report: dict,
     source_repo: str,
     branch: str,
-    workflow_run_url: str,
+    troubleshooting_content: str = "",
     ghcr_version_ids: dict[str, int] | None = None,
 ) -> list[str]:
     """Render a single tier section."""
@@ -204,9 +229,10 @@ def render_tier(
         return lines
 
     failed = {k: v for k, v in plugins.items() if v.get("overall") == "fail"}
+    outdated = {k: v for k, v in plugins.items() if v.get("overall") == "outdated"}
     all_passed = {k: v for k, v in plugins.items() if v.get("overall") == "pass"}
     fallback = {k: v for k, v in all_passed.items()
-                if v.get("stages", {}).get("registry-enrich", {}).get("fallback")}
+                if v.get("stages", {}).get("image-metadata-fetch", {}).get("fallback")}
     passed = {k: v for k, v in all_passed.items() if k not in fallback}
 
     lines.append(f"## {tier_name} Catalog")
@@ -224,12 +250,38 @@ def render_tier(
             ver = p.get("version", "")
             stage_label, reason = first_failed_stage(p.get("stages", {}))
             name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
-            reason_link = f"[{reason}]({workflow_run_url})" if workflow_run_url else reason
+            reason_link = reason_to_link(reason, troubleshooting_content)
             lines.append(f"| {name_link} | `{pkg}` | {ver} | {stage_label} | {reason_link} |")
         lines.append("")
 
+    if outdated:
+        if troubleshooting_content:
+            lines.append(f"### ⚠️ [Backstage Version Mismatch](#backstage-version-mismatch) ({len(outdated)})")
+        else:
+            lines.append(f"### ⚠️ Backstage Version Mismatch ({len(outdated)})")
+        lines.append("")
+        lines.append("> These plugins were excluded because their workspace targets an older Backstage minor version.")
+        lines.append("> To resolve, try running `/update-commit` on their workspace PR (if it exists) or add a `backstage.json` override if no commit exists that updates the version.")
+        lines.append("")
+        lines.append("| Plugin | Package | Workspace | Expected | Found |")
+        lines.append("|--------|---------|-----------|----------|-------|")
+        for name in sorted(outdated):
+            p = outdated[name]
+            ws = p.get("workspace", "")
+            pkg = p.get("package", "")
+            bootstrap = p.get("stages", {}).get("bootstrap", {})
+            expected = bootstrap.get("expected_version", "")
+            found = bootstrap.get("found_version", "")
+            name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
+            ws_link = workspace_link(source_repo, branch, ws) if ws else f"`{ws}`"
+            lines.append(f"| {name_link} | `{pkg}` | {ws_link} | {expected} | {found} |")
+        lines.append("")
+
     if fallback:
-        lines.append(f"### ⚠️ Outdated ({len(fallback)})")
+        if troubleshooting_content:
+            lines.append(f"### ⚠️ [Outdated](#plugin-marked-as-outdated) ({len(fallback)})")
+        else:
+            lines.append(f"### ⚠️ Outdated ({len(fallback)})")
         lines.append("")
         lines.append("> These plugins are using an older published tag because the requested version was not found in the registry.")
         lines.append("")
@@ -240,7 +292,7 @@ def render_tier(
             ws = p.get("workspace", "")
             pkg = p.get("package", "")
             stages = p.get("stages", {})
-            enrich = stages.get("registry-enrich", {})
+            enrich = stages.get("image-metadata-fetch", {})
             requested = enrich.get("requestedTag", "")
             resolved = enrich.get("resolvedTag", "")
             oci_ref = stages.get("bootstrap", {}).get("oci_ref", "")
@@ -283,7 +335,15 @@ def count_fallbacks(report: dict) -> int:
     return sum(
         1 for p in report.get("plugins", {}).values()
         if p.get("overall") == "pass"
-        and p.get("stages", {}).get("registry-enrich", {}).get("fallback")
+        and p.get("stages", {}).get("image-metadata-fetch", {}).get("fallback")
+    )
+
+
+def count_outdated(report: dict) -> int:
+    """Count plugins excluded due to backstage version mismatch."""
+    return sum(
+        1 for p in report.get("plugins", {}).values()
+        if p.get("overall") == "outdated"
     )
 
 
@@ -318,6 +378,7 @@ def render_status_page(
     rhdh_version: str,
     workflow_run_url: str,
     target_branch: str = "",
+    troubleshooting_content: str = "",
 ) -> str:
     """Render the complete status page markdown."""
     ghcr_refs = collect_ghcr_refs(supported_report, community_report)
@@ -356,28 +417,36 @@ def render_status_page(
 
     lines.append("## Summary")
     lines.append("")
-    lines.append("| Tier | Total | Passed | Outdated | Failed | Latest Catalog Index Image | Last Successful Publish |")
-    lines.append("|------|-------|--------|----------|--------|----------------------------|-------------------------|")
+    lines.append("| Tier | Total | Passed | Outdated | Excluded | Failed | Latest Catalog Index Image | Last Successful Publish |")
+    lines.append("|------|-------|--------|----------|----------|--------|----------------------------|-------------------------|")
     if supported_report:
         sup_img = render_catalog_image(supported_report, ghcr_version_ids)
         sup_pub = render_last_publish(supported_report, source_repo)
         sup_fallback = count_fallbacks(supported_report)
-        lines.append(f"| Supported | {sup_summary.get('total', 0)} | {sup_summary.get('succeeded', 0)} | {sup_fallback} | {sup_summary.get('failed', 0)} | {sup_img} | {sup_pub} |")
+        sup_excluded = count_outdated(supported_report)
+        lines.append(f"| Supported | {sup_summary.get('total', 0)} | {sup_summary.get('succeeded', 0)} | {sup_fallback} | {sup_excluded} | {sup_summary.get('failed', 0)} | {sup_img} | {sup_pub} |")
     if community_report:
         com_img = render_catalog_image(community_report, ghcr_version_ids)
         com_pub = render_last_publish(community_report, source_repo)
         com_fallback = count_fallbacks(community_report)
-        lines.append(f"| Community | {com_summary.get('total', 0)} | {com_summary.get('succeeded', 0)} | {com_fallback} | {com_summary.get('failed', 0)} | {com_img} | {com_pub} |")
+        com_excluded = count_outdated(community_report)
+        lines.append(f"| Community | {com_summary.get('total', 0)} | {com_summary.get('succeeded', 0)} | {com_fallback} | {com_excluded} | {com_summary.get('failed', 0)} | {com_img} | {com_pub} |")
     lines.append("")
 
     # Tier details
     if supported_report:
-        lines.extend(render_tier("Supported", supported_report, source_repo, source_branch, workflow_run_url, ghcr_version_ids))
+        lines.extend(render_tier("Supported", supported_report, source_repo, source_branch, troubleshooting_content, ghcr_version_ids))
     if community_report:
-        lines.extend(render_tier("Community", community_report, source_repo, source_branch, workflow_run_url, ghcr_version_ids))
+        lines.extend(render_tier("Community", community_report, source_repo, source_branch, troubleshooting_content, ghcr_version_ids))
+
+    if troubleshooting_content:
+        lines.append("")
+        lines.append(troubleshooting_content.rstrip())
+        lines.append("")
 
     lines.append("---")
-    lines.append(f"*Auto-generated by [generate-catalog-index]({source_repo}/blob/{source_branch}/.github/workflows/generate-catalog-index.yaml) workflow*")
+    if workflow_run_url:
+        lines.append(f"*Auto-generated by the [catalog index generation pipeline]({workflow_run_url})*")
     lines.append("")
 
     return "\n".join(lines)
@@ -385,7 +454,7 @@ def render_status_page(
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Render build-report.json files into a GitHub Wiki markdown status page.',
+        description='Render build-report.json files into a markdown status page.',
     )
     parser.add_argument(
         '--supported',
@@ -442,6 +511,12 @@ def main():
         help='URL of the workflow run',
     )
     parser.add_argument(
+        '--troubleshooting-content',
+        type=str,
+        metavar='PATH',
+        help='Path to troubleshooting markdown file to embed in the status page',
+    )
+    parser.add_argument(
         '--output',
         type=str,
         metavar='PATH',
@@ -457,6 +532,14 @@ def main():
         print("Error: At least one report file must be provided", file=sys.stderr)
         sys.exit(1)
 
+    troubleshooting_content = ""
+    if args.troubleshooting_content:
+        ts_path = Path(args.troubleshooting_content)
+        if ts_path.exists():
+            troubleshooting_content = ts_path.read_text(encoding='utf-8')
+        else:
+            print(f"Warning: Troubleshooting file not found: {args.troubleshooting_content}", file=sys.stderr)
+
     markdown = render_status_page(
         supported_report=supported_report,
         community_report=community_report,
@@ -467,6 +550,7 @@ def main():
         rhdh_version=args.rhdh_version,
         workflow_run_url=args.workflow_run_url,
         target_branch=args.target_branch,
+        troubleshooting_content=troubleshooting_content,
     )
 
     if args.output:

--- a/scripts/renderCatalogStatus.py
+++ b/scripts/renderCatalogStatus.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Red Hat, Inc.
+#
+# Render build-report.json files into a GitHub Wiki markdown status page.
+#
+# Usage:
+#   python3 renderCatalogStatus.py \
+#     --supported catalog-index/supported/build-report.json \
+#     --community catalog-index/community/build-report.json \
+#     --source-repo https://github.com/redhat-developer/rhdh-plugin-export-overlays \
+#     --source-branch main \
+#     --source-commit abc1234 \
+#     --workflow-run-url https://github.com/.../actions/runs/12345 \
+#     --output status-page.md
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+import requests
+from pathlib import Path
+
+
+STAGE_LABELS = {
+    "bootstrap": "Bootstrap",
+    "registry-enrich": "Registry Enrich",
+    "dpdy": "DPDY",
+    "catalog-index": "Catalog Index",
+}
+
+
+def load_report(path: str) -> dict:
+    p = Path(path)
+    if not p.exists():
+        print(f"Warning: Report file not found: {path}", file=sys.stderr)
+        return {}
+    with open(p, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def parse_ghcr_ref(oci_ref: str) -> tuple[str, str, str] | None:
+    """Parse a GHCR OCI ref into (org, package_path, tag).
+    Returns None if not a valid GHCR ref with a tag."""
+    ref = oci_ref.replace("oci://", "")
+    if not ref.startswith("ghcr.io/"):
+        return None
+    rest = ref[len("ghcr.io/"):]
+    if ":" not in rest:
+        return None
+    path_part, tag = rest.split(":", 1)
+    tag = tag.split("@", 1)[0]
+    if not tag:
+        return None
+    segments = path_part.split("/", 1)
+    if len(segments) < 2:
+        return None
+    return segments[0], segments[1], tag
+
+
+def collect_ghcr_refs(*reports: dict) -> list[str]:
+    """Collect all unique GHCR OCI references from reports."""
+    refs = set()
+    for report in reports:
+        if not report:
+            continue
+        meta = report.get("metadata", {})
+        image = meta.get("catalog-index-image", "")
+        if image and "ghcr.io" in image:
+            refs.add(image)
+        for plugin in report.get("plugins", {}).values():
+            if plugin.get("overall") == "pass":
+                oci_ref = plugin.get("stages", {}).get("bootstrap", {}).get("oci_ref", "")
+                if oci_ref and "ghcr.io" in oci_ref:
+                    refs.add(oci_ref)
+    return list(refs)
+
+
+def resolve_ghcr_version_ids(oci_refs: list[str]) -> dict[str, int]:
+    """Resolve GHCR OCI refs to GitHub Package version IDs via the API.
+    Returns a map of original OCI ref string -> version ID.
+    Falls back to empty dict if requests is unavailable or GITHUB_TOKEN is not set."""
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("Note: GITHUB_TOKEN not set, GHCR links will use fallback format", file=sys.stderr)
+        return {}
+
+    package_tags: dict[tuple[str, str], set[str]] = {}
+    ref_parsed: dict[str, tuple[str, str, str]] = {}
+
+    for ref in oci_refs:
+        parsed = parse_ghcr_ref(ref)
+        if not parsed:
+            continue
+        org, pkg, tag = parsed
+        package_tags.setdefault((org, pkg), set()).add(tag)
+        ref_parsed[ref] = parsed
+
+    tag_to_vid: dict[tuple[str, str, str], int] = {}
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    for (owner, pkg), tags in package_tags.items():
+        encoded_pkg = pkg.replace("/", "%2F")
+        base_url = f"https://api.github.com/{{owner_type}}/{owner}/packages/container/{encoded_pkg}/versions?per_page=100"
+        versions = None
+        for owner_type in ("orgs", "users"):
+            url = base_url.format(owner_type=owner_type)
+            try:
+                resp = requests.get(url, headers=headers, timeout=15)
+                if resp.status_code == 404 and owner_type == "orgs":
+                    continue
+                resp.raise_for_status()
+                versions = resp.json()
+                break
+            except Exception as e:
+                print(f"Warning: Failed to resolve GHCR versions for {owner}/{pkg}: {e}", file=sys.stderr)
+        if versions:
+            for version in versions:
+                v_tags = version.get("metadata", {}).get("container", {}).get("tags", [])
+                v_id = version.get("id")
+                if v_id:
+                    for t in v_tags:
+                        if t in tags:
+                            tag_to_vid[(owner, pkg, t)] = v_id
+
+    result = {}
+    for ref, (org, pkg, tag) in ref_parsed.items():
+        vid = tag_to_vid.get((org, pkg, tag))
+        if vid:
+            result[ref] = vid
+    return result
+
+
+def oci_ref_to_link(oci_ref: str, ghcr_version_ids: dict[str, int] | None = None) -> str:
+    """Convert an OCI reference to a clickable registry link."""
+    if not oci_ref:
+        return ""
+    ref = oci_ref.replace("oci://", "")
+    if ref.startswith("quay.io/"):
+        tag_ref = ref.split("@", 1)[0]
+        return f"[{ref}](https://{tag_ref})"
+    if ref.startswith("ghcr.io/"):
+        parsed = parse_ghcr_ref(oci_ref)
+        if not parsed:
+            return f"`{ref}`"
+        org, pkg, tag = parsed
+        repo = pkg.split("/")[0]
+        encoded_pkg = pkg.replace("/", "%2F")
+        version_id = (ghcr_version_ids or {}).get(oci_ref)
+        if version_id:
+            url = f"https://github.com/{org}/{repo}/pkgs/container/{encoded_pkg}/{version_id}?tag={tag}"
+        else:
+            url = f"https://github.com/{org}/{repo}/pkgs/container/{encoded_pkg}"
+        return f"[{ref}]({url})"
+    return f"`{ref}`"
+
+
+def plugin_metadata_link(source_repo: str, branch: str, workspace: str, name: str) -> str:
+    """Link a plugin name to its metadata YAML in the repo."""
+    return f"[{name}]({source_repo}/blob/{branch}/workspaces/{workspace}/metadata/{name}.yaml)"
+
+
+def workspace_link(source_repo: str, branch: str, workspace: str) -> str:
+    """Link to the workspace directory."""
+    return f"[{workspace}]({source_repo}/tree/{branch}/workspaces/{workspace})"
+
+
+def first_failed_stage(stages: dict) -> tuple[str, str]:
+    """Return (stage_label, reason) for the first failed stage."""
+    for stage_key in ["bootstrap", "registry-enrich", "dpdy", "catalog-index"]:
+        stage = stages.get(stage_key, {})
+        if stage.get("status") == "fail":
+            label = STAGE_LABELS.get(stage_key, stage_key)
+            reason = stage.get("reason", "Unknown error")
+            return label, reason
+    return "Unknown", "Unknown error"
+
+
+def render_tier(
+    tier_name: str,
+    report: dict,
+    source_repo: str,
+    branch: str,
+    workflow_run_url: str,
+    ghcr_version_ids: dict[str, int] | None = None,
+) -> list[str]:
+    """Render a single tier section."""
+    lines = []
+    plugins = report.get("plugins", {})
+    status = report.get("status", "unknown")
+
+    if status == "initial":
+        lines.append(f"## {tier_name} Catalog")
+        lines.append("")
+        lines.append("> **Initial build** — No plugins have been published for this branch yet.")
+        lines.append("> This is expected for newly created release branches.")
+        lines.append("")
+        return lines
+
+    failed = {k: v for k, v in plugins.items() if v.get("overall") == "fail"}
+    passed = {k: v for k, v in plugins.items() if v.get("overall") == "pass"}
+
+    lines.append(f"## {tier_name} Catalog")
+    lines.append("")
+
+    if failed:
+        lines.append(f"### Failed ({len(failed)})")
+        lines.append("")
+        lines.append("| Plugin | Package | Version | Failed Stage | Reason |")
+        lines.append("|--------|---------|---------|--------------|--------|")
+        for name in sorted(failed):
+            p = failed[name]
+            ws = p.get("workspace", "")
+            pkg = p.get("package", "")
+            ver = p.get("version", "")
+            stage_label, reason = first_failed_stage(p.get("stages", {}))
+            name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
+            reason_link = f"[{reason}]({workflow_run_url})" if workflow_run_url else reason
+            lines.append(f"| {name_link} | `{pkg}` | {ver} | {stage_label} | {reason_link} |")
+        lines.append("")
+
+    if passed:
+        lines.append(f"### Passed ({len(passed)})")
+        lines.append("")
+        lines.append("| Plugin | Package | Version | OCI Reference |")
+        lines.append("|--------|---------|---------|---------------|")
+        for name in sorted(passed):
+            p = passed[name]
+            ws = p.get("workspace", "")
+            pkg = p.get("package", "")
+            ver = p.get("version", "")
+            stages = p.get("stages", {})
+            oci_ref = stages.get("bootstrap", {}).get("oci_ref", "")
+            name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
+            oci_link = oci_ref_to_link(oci_ref, ghcr_version_ids)
+            lines.append(f"| {name_link} | `{pkg}` | {ver} | {oci_link} |")
+        lines.append("")
+
+    return lines
+
+
+def commit_link(sha: str, source_repo: str) -> str:
+    if not sha:
+        return "—"
+    short = sha[:7]
+    if source_repo:
+        return f"[{short}]({source_repo}/commit/{sha})"
+    return short
+
+
+def render_last_publish(report: dict, source_repo: str) -> str:
+    """Render the last successful publish commit for a tier."""
+    meta = report.get("metadata", {})
+    last_ok = meta.get("last-successful-publish", "")
+    if last_ok:
+        return commit_link(last_ok, source_repo)
+    return "—"
+
+
+def render_catalog_image(report: dict, ghcr_version_ids: dict[str, int] | None = None) -> str:
+    """Render a link to the catalog index OCI image.
+    Only shows the image if the catalog has been successfully published."""
+    meta = report.get("metadata", {})
+    if not meta.get("last-successful-publish"):
+        return "—"
+    image = meta.get("catalog-index-image", "")
+    if image:
+        return oci_ref_to_link(image, ghcr_version_ids)
+    return "—"
+
+
+def render_status_page(
+    supported_report: dict,
+    community_report: dict,
+    source_repo: str,
+    source_branch: str,
+    source_commit: str,
+    backstage_version: str,
+    rhdh_version: str,
+    workflow_run_url: str,
+    target_branch: str = "",
+) -> str:
+    """Render the complete status page markdown."""
+    ghcr_refs = collect_ghcr_refs(supported_report, community_report)
+    ghcr_version_ids = resolve_ghcr_version_ids(ghcr_refs) if ghcr_refs else {}
+
+    lines = []
+
+    lines.append(f"# Plugin Catalog Index Status — {source_branch}")
+    lines.append("")
+
+    build_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    short_sha = source_commit[:7] if source_commit else ""
+    commit_link = f"[{source_branch} @ {short_sha}]({source_repo}/tree/{source_branch})" if source_repo else f"{source_branch} @ {short_sha}"
+    run_link = f"[View run]({workflow_run_url})" if workflow_run_url else ""
+
+    lines.append(f"**Build date:** {build_date}  ")
+    lines.append(f"**Source:** {commit_link}  ")
+    if backstage_version or rhdh_version:
+        version_parts = []
+        if backstage_version:
+            version_parts.append(f"**Backstage:** {backstage_version}")
+        if rhdh_version:
+            version_parts.append(f"**RHDH:** {rhdh_version}")
+        lines.append(f"{' | '.join(version_parts)}  ")
+    if target_branch and source_repo:
+        target_link = f"[{target_branch}]({source_repo}/tree/{target_branch})"
+        lines.append(f"**Catalog index branch:** {target_link}  ")
+    if run_link:
+        lines.append(f"**Workflow run:** {run_link}  ")
+
+    lines.append("")
+
+    # Summary table
+    sup_summary = supported_report.get("summary", {})
+    com_summary = community_report.get("summary", {})
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Tier | Total | Passed | Failed | Latest Catalog Index Image | Last Successful Publish |")
+    lines.append("|------|-------|--------|--------|----------------------------|-------------------------|")
+    if supported_report:
+        sup_img = render_catalog_image(supported_report, ghcr_version_ids)
+        sup_pub = render_last_publish(supported_report, source_repo)
+        lines.append(f"| Supported | {sup_summary.get('total', 0)} | {sup_summary.get('succeeded', 0)} | {sup_summary.get('failed', 0)} | {sup_img} | {sup_pub} |")
+    if community_report:
+        com_img = render_catalog_image(community_report, ghcr_version_ids)
+        com_pub = render_last_publish(community_report, source_repo)
+        lines.append(f"| Community | {com_summary.get('total', 0)} | {com_summary.get('succeeded', 0)} | {com_summary.get('failed', 0)} | {com_img} | {com_pub} |")
+    lines.append("")
+
+    # Tier details
+    if supported_report:
+        lines.extend(render_tier("Supported", supported_report, source_repo, source_branch, workflow_run_url, ghcr_version_ids))
+    if community_report:
+        lines.extend(render_tier("Community", community_report, source_repo, source_branch, workflow_run_url, ghcr_version_ids))
+
+    lines.append("---")
+    lines.append(f"*Auto-generated by [generate-catalog-index]({source_repo}/blob/{source_branch}/.github/workflows/generate-catalog-index.yaml) workflow*")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Render build-report.json files into a GitHub Wiki markdown status page.',
+    )
+    parser.add_argument(
+        '--supported',
+        type=str,
+        metavar='PATH',
+        help='Path to supported tier build-report.json',
+    )
+    parser.add_argument(
+        '--community',
+        type=str,
+        metavar='PATH',
+        help='Path to community tier build-report.json',
+    )
+    parser.add_argument(
+        '--source-repo',
+        type=str,
+        default='',
+        help='Source repository URL (e.g., https://github.com/org/repo)',
+    )
+    parser.add_argument(
+        '--source-branch',
+        type=str,
+        default='main',
+        help='Source branch name',
+    )
+    parser.add_argument(
+        '--source-commit',
+        type=str,
+        default='',
+        help='Source commit SHA',
+    )
+    parser.add_argument(
+        '--backstage-version',
+        type=str,
+        default='',
+        help='Backstage version',
+    )
+    parser.add_argument(
+        '--rhdh-version',
+        type=str,
+        default='',
+        help='RHDH version',
+    )
+    parser.add_argument(
+        '--target-branch',
+        type=str,
+        default='',
+        help='Target branch where catalog index artifacts are stored',
+    )
+    parser.add_argument(
+        '--workflow-run-url',
+        type=str,
+        default='',
+        help='URL of the workflow run',
+    )
+    parser.add_argument(
+        '--output',
+        type=str,
+        metavar='PATH',
+        help='Output file path (default: stdout)',
+    )
+
+    args = parser.parse_args()
+
+    supported_report = load_report(args.supported) if args.supported else {}
+    community_report = load_report(args.community) if args.community else {}
+
+    if not supported_report and not community_report:
+        print("Error: At least one report file must be provided", file=sys.stderr)
+        sys.exit(1)
+
+    markdown = render_status_page(
+        supported_report=supported_report,
+        community_report=community_report,
+        source_repo=args.source_repo,
+        source_branch=args.source_branch,
+        source_commit=args.source_commit,
+        backstage_version=args.backstage_version,
+        rhdh_version=args.rhdh_version,
+        workflow_run_url=args.workflow_run_url,
+        target_branch=args.target_branch,
+    )
+
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, 'w', encoding='utf-8') as f:
+            f.write(markdown)
+        print(f"Status page written to {args.output}")
+    else:
+        print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/renderCatalogStatus.py
+++ b/scripts/renderCatalogStatus.py
@@ -204,7 +204,10 @@ def render_tier(
         return lines
 
     failed = {k: v for k, v in plugins.items() if v.get("overall") == "fail"}
-    passed = {k: v for k, v in plugins.items() if v.get("overall") == "pass"}
+    all_passed = {k: v for k, v in plugins.items() if v.get("overall") == "pass"}
+    fallback = {k: v for k, v in all_passed.items()
+                if v.get("stages", {}).get("registry-enrich", {}).get("fallback")}
+    passed = {k: v for k, v in all_passed.items() if k not in fallback}
 
     lines.append(f"## {tier_name} Catalog")
     lines.append("")
@@ -223,6 +226,27 @@ def render_tier(
             name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
             reason_link = f"[{reason}]({workflow_run_url})" if workflow_run_url else reason
             lines.append(f"| {name_link} | `{pkg}` | {ver} | {stage_label} | {reason_link} |")
+        lines.append("")
+
+    if fallback:
+        lines.append(f"### ⚠️ Outdated ({len(fallback)})")
+        lines.append("")
+        lines.append("> These plugins are using an older published tag because the requested version was not found in the registry.")
+        lines.append("")
+        lines.append("| Plugin | Package | Requested Tag | Resolved Tag | OCI Reference |")
+        lines.append("|--------|---------|---------------|--------------|---------------|")
+        for name in sorted(fallback):
+            p = fallback[name]
+            ws = p.get("workspace", "")
+            pkg = p.get("package", "")
+            stages = p.get("stages", {})
+            enrich = stages.get("registry-enrich", {})
+            requested = enrich.get("requestedTag", "")
+            resolved = enrich.get("resolvedTag", "")
+            oci_ref = stages.get("bootstrap", {}).get("oci_ref", "")
+            name_link = plugin_metadata_link(source_repo, branch, ws, name) if ws else f"`{name}`"
+            oci_link = oci_ref_to_link(oci_ref, ghcr_version_ids)
+            lines.append(f"| {name_link} | `{pkg}` | `{requested}` | `{resolved}` | {oci_link} |")
         lines.append("")
 
     if passed:
@@ -252,6 +276,15 @@ def commit_link(sha: str, source_repo: str) -> str:
     if source_repo:
         return f"[{short}]({source_repo}/commit/{sha})"
     return short
+
+
+def count_fallbacks(report: dict) -> int:
+    """Count plugins using fallback tags in a report."""
+    return sum(
+        1 for p in report.get("plugins", {}).values()
+        if p.get("overall") == "pass"
+        and p.get("stages", {}).get("registry-enrich", {}).get("fallback")
+    )
 
 
 def render_last_publish(report: dict, source_repo: str) -> str:
@@ -323,16 +356,18 @@ def render_status_page(
 
     lines.append("## Summary")
     lines.append("")
-    lines.append("| Tier | Total | Passed | Failed | Latest Catalog Index Image | Last Successful Publish |")
-    lines.append("|------|-------|--------|--------|----------------------------|-------------------------|")
+    lines.append("| Tier | Total | Passed | Outdated | Failed | Latest Catalog Index Image | Last Successful Publish |")
+    lines.append("|------|-------|--------|----------|--------|----------------------------|-------------------------|")
     if supported_report:
         sup_img = render_catalog_image(supported_report, ghcr_version_ids)
         sup_pub = render_last_publish(supported_report, source_repo)
-        lines.append(f"| Supported | {sup_summary.get('total', 0)} | {sup_summary.get('succeeded', 0)} | {sup_summary.get('failed', 0)} | {sup_img} | {sup_pub} |")
+        sup_fallback = count_fallbacks(supported_report)
+        lines.append(f"| Supported | {sup_summary.get('total', 0)} | {sup_summary.get('succeeded', 0)} | {sup_fallback} | {sup_summary.get('failed', 0)} | {sup_img} | {sup_pub} |")
     if community_report:
         com_img = render_catalog_image(community_report, ghcr_version_ids)
         com_pub = render_last_publish(community_report, source_repo)
-        lines.append(f"| Community | {com_summary.get('total', 0)} | {com_summary.get('succeeded', 0)} | {com_summary.get('failed', 0)} | {com_img} | {com_pub} |")
+        com_fallback = count_fallbacks(community_report)
+        lines.append(f"| Community | {com_summary.get('total', 0)} | {com_summary.get('succeeded', 0)} | {com_fallback} | {com_summary.get('failed', 0)} | {com_img} | {com_pub} |")
     lines.append("")
 
     # Tier details

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pyyaml
+requests

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,108 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load_fixture_json(filename: str) -> dict:
+    """Load a JSON fixture file from scripts/tests/fixtures/."""
+    with open(FIXTURES_DIR / filename, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _fixture_path(filename: str) -> Path:
+    """Return the absolute path to a fixture file."""
+    return FIXTURES_DIR / filename
+
+
+@pytest.fixture
+def sample_plugin_data():
+    """Real plugin_builds JSON for a downstream quay.io/rhdh build.
+
+    Source: plugin_builds/supported/adoption-insights/
+    Downstream builds include build-date, vcs-ref, upstream, and midstream.
+    """
+    return _load_fixture_json(
+        "red-hat-developer-hub-backstage-plugin-adoption-insights.json"
+    )
+
+
+@pytest.fixture
+def sample_plugin_data_no_digest(sample_plugin_data):
+    """Plugin_builds entry stripped to pre-enrichment state.
+
+    This is what a plugin_builds JSON looks like before generatePluginBuildInfo
+    enriches it with registry metadata — only workspacePath and registryReference.
+    """
+    data = {}
+    for name, fields in sample_plugin_data.items():
+        data[name] = {
+            "workspacePath": fields["workspacePath"],
+            "registryReference": fields["registryReference"],
+        }
+    return data
+
+
+@pytest.fixture
+def sample_plugin_data_ghcr():
+    """Real plugin_builds JSON for a community ghcr.io image.
+
+    Source: plugin_builds/community/3scale/
+    Community builds do NOT have build-date, vcs-ref, upstream, or midstream —
+    those are only present in downstream quay.io/rhdh builds.
+    """
+    return _load_fixture_json(
+        "backstage-community-plugin-3scale-backend.json"
+    )
+
+
+@pytest.fixture
+def sample_package_yaml():
+    """Real Package entity YAML from workspaces/backstage/metadata/.
+
+    Source: backstage-plugin-catalog-backend-module-github.yaml
+    """
+    return _fixture_path("sample-package.yaml")
+
+
+@pytest.fixture
+def sample_packages_yaml():
+    """Trimmed default.packages.yaml with enabled and disabled sections.
+
+    Source: derived from default.packages.yaml
+    """
+    return str(_fixture_path("sample-packages.yaml"))
+
+
+@pytest.fixture
+def sample_packages_txt():
+    """Trimmed community packages txt file.
+
+    Source: derived from rhdh-community-packages.txt
+    """
+    return str(_fixture_path("sample-packages.txt"))
+
+
+@pytest.fixture
+def sample_workspace_dir():
+    """Real workspace directory structure from fixtures/workspaces/.
+
+    Contains::
+
+        workspaces/
+          backstage/
+            plugins-list.yaml
+            metadata/
+              backstage-plugin-catalog-backend-module-github.yaml
+          3scale/
+            plugins-list.yaml
+            metadata/
+              backstage-community-plugin-3scale-backend.yaml
+    """
+    return FIXTURES_DIR

--- a/scripts/tests/fixtures/backstage-community-plugin-3scale-backend.json
+++ b/scripts/tests/fixtures/backstage-community-plugin-3scale-backend.json
@@ -1,0 +1,9 @@
+{
+  "backstage-community-plugin-3scale-backend": {
+    "workspacePath": "3scale/plugins/3scale-backend",
+    "registryReference": "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-3scale-backend:bs_1.49.4__3.13.0",
+    "digest": "sha256:62810995b060834821de573af6228387c4254bc593857e02b39238f4b990b17c",
+    "support": "community",
+    "io.backstage.dynamic-packages": "W3siYmFja3N0YWdlLWNvbW11bml0eS1wbHVnaW4tM3NjYWxlLWJhY2tlbmQiOnsibmFtZSI6IkBiYWNrc3RhZ2UtY29tbXVuaXR5L3BsdWdpbi0zc2NhbGUtYmFja2VuZC1keW5hbWljIiwidmVyc2lvbiI6IjMuMTMuMCIsImJhY2tzdGFnZSI6eyJyb2xlIjoiYmFja2VuZC1wbHVnaW4tbW9kdWxlIiwicGx1Z2luSWQiOiIzc2NhbGUiLCJwbHVnaW5QYWNrYWdlIjoiQGJhY2tzdGFnZS1jb21tdW5pdHkvcGx1Z2luLTNzY2FsZS1iYWNrZW5kIiwic3VwcG9ydGVkLXZlcnNpb25zIjoiMS40OS4yIn0sInJlcG9zaXRvcnkiOnsidHlwZSI6ImdpdCIsInVybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9iYWNrc3RhZ2UvY29tbXVuaXR5LXBsdWdpbnMiLCJkaXJlY3RvcnkiOiJ3b3Jrc3BhY2VzLzNzY2FsZS9wbHVnaW5zLzNzY2FsZS1iYWNrZW5kIn0sImxpY2Vuc2UiOiJBcGFjaGUtMi4wIiwiYXV0aG9yIjoiUmVkIEhhdCIsImJ1Z3MiOiJodHRwczovL2dpdGh1Yi5jb20vYmFja3N0YWdlL2NvbW11bml0eS1wbHVnaW5zL2lzc3VlcyIsImtleXdvcmRzIjpbImJhY2tzdGFnZSIsInBsdWdpbiJdfX1d"
+  }
+}

--- a/scripts/tests/fixtures/red-hat-developer-hub-backstage-plugin-adoption-insights.json
+++ b/scripts/tests/fixtures/red-hat-developer-hub-backstage-plugin-adoption-insights.json
@@ -1,0 +1,13 @@
+{
+  "red-hat-developer-hub-backstage-plugin-adoption-insights": {
+    "workspacePath": "adoption-insights/plugins/adoption-insights",
+    "registryReference": "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-adoption-insights:1.11--0.8.2",
+    "digest": "sha256:6d534d3bb0c08f0034b00c1398891fb3393b3df87002789efdc50bcd7c0a1177",
+    "build-date": "2026-06-02T17:27:06Z",
+    "upstream": "https://github.com/redhat-developer/rhdh-plugin-export-overlays/tree/main @ 710868b6ee9c4a596c5e3b5b5988193f2b8873ec",
+    "midstream": "https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog/-/commits/rhdh-1-rhel-9",
+    "vcs-ref": "b93b7dcd7aa784d5faa9ef98d753bd9643532ce1",
+    "support": "generally-available",
+    "io.backstage.dynamic-packages": "W3sicmVkLWhhdC1kZXZlbG9wZXItaHViLWJhY2tzdGFnZS1wbHVnaW4tYWRvcHRpb24taW5zaWdodHMiOnsibmFtZSI6IkByZWQtaGF0LWRldmVsb3Blci1odWIvYmFja3N0YWdlLXBsdWdpbi1hZG9wdGlvbi1pbnNpZ2h0cy1keW5hbWljIiwidmVyc2lvbiI6IjAuOC4yIiwiYmFja3N0YWdlIjp7InJvbGUiOiJmcm9udGVuZC1wbHVnaW4iLCJwbHVnaW5JZCI6ImFkb3B0aW9uLWluc2lnaHRzIiwicGx1Z2luUGFja2FnZXMiOlsiQHJlZC1oYXQtZGV2ZWxvcGVyLWh1Yi9iYWNrc3RhZ2UtcGx1Z2luLWFkb3B0aW9uLWluc2lnaHRzIiwiQHJlZC1oYXQtZGV2ZWxvcGVyLWh1Yi9iYWNrc3RhZ2UtcGx1Z2luLWFkb3B0aW9uLWluc2lnaHRzLWJhY2tlbmQiLCJAcmVkLWhhdC1kZXZlbG9wZXItaHViL2JhY2tzdGFnZS1wbHVnaW4tYWRvcHRpb24taW5zaWdodHMtY29tbW9uIl0sInN1cHBvcnRlZC12ZXJzaW9ucyI6IjEuNDkuMyJ9LCJyZXBvc2l0b3J5Ijp7InR5cGUiOiJnaXQiLCJ1cmwiOiJodHRwczovL2dpdGh1Yi5jb20vcmVkaGF0LWRldmVsb3Blci9yaGRoLXBsdWdpbnMiLCJkaXJlY3RvcnkiOiJ3b3Jrc3BhY2VzL2Fkb3B0aW9uLWluc2lnaHRzL3BsdWdpbnMvYWRvcHRpb24taW5zaWdodHMifSwibGljZW5zZSI6IkFwYWNoZS0yLjAifX1d"
+  }
+}

--- a/scripts/tests/fixtures/sample-package.yaml
+++ b/scripts/tests/fixtures/sample-package.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-catalog-backend-module-github
+  namespace: rhdh
+  title: "Catalog Backend Module GitHub"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-github
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-github
+  tags:
+    - software-catalog
+spec:
+  packageName: "@backstage/plugin-catalog-backend-module-github"
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+  version: 0.13.0
+  backstage:
+    role: backend-plugin-module
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - backstage-plugin-catalog-backend-module-github
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        catalog:
+          providers:
+            github:
+              providerId:
+                organization: ${GITHUB_ORG}

--- a/scripts/tests/fixtures/sample-packages.txt
+++ b/scripts/tests/fixtures/sample-packages.txt
@@ -1,0 +1,3 @@
+# Trimmed from rhdh-community-packages.txt for testing
+3scale/plugins/3scale-backend
+backstage/plugins/catalog-backend-module-github

--- a/scripts/tests/fixtures/sample-packages.yaml
+++ b/scripts/tests/fixtures/sample-packages.yaml
@@ -1,0 +1,7 @@
+# Trimmed from default.packages.yaml for testing
+packages:
+  enabled:
+  - package: '@backstage/plugin-catalog-backend-module-github'
+  - package: '@backstage-community/plugin-analytics-provider-segment'
+  disabled:
+  - package: '@backstage-community/plugin-acr'

--- a/scripts/tests/fixtures/workspaces/3scale/metadata/backstage-community-plugin-3scale-backend.yaml
+++ b/scripts/tests/fixtures/workspaces/3scale/metadata/backstage-community-plugin-3scale-backend.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-3scale-backend
+  namespace: rhdh
+  title: "3Scale"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/community-plugins/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/3scale
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/3scale
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-3scale-backend"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-3scale-backend:bs_1.49.4__3.13.0!backstage-community-plugin-3scale-backend
+  version: 3.13.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: community
+  lifecycle: active
+  partOf:
+    - 3scale
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        catalog:
+          providers:
+            threeScaleApiEntity:
+              default:
+                baseUrl: ${THREESCALE_BASE_URL}
+                accessToken: ${THREESCALE_ACCESS_TOKEN}

--- a/scripts/tests/fixtures/workspaces/3scale/plugins-list.yaml
+++ b/scripts/tests/fixtures/workspaces/3scale/plugins-list.yaml
@@ -1,0 +1,1 @@
+plugins/3scale-backend:

--- a/scripts/tests/fixtures/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-github.yaml
+++ b/scripts/tests/fixtures/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-github.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-plugin-catalog-backend-module-github
+  namespace: rhdh
+  title: "Catalog Backend Module GitHub"
+  links:
+    - url: https://red.ht/rhdh
+      title: Homepage
+    - url: https://github.com/backstage/backstage/issues
+      title: Bugs
+    - title: Source Code
+      url: https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-github
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-github
+  tags:
+    - software-catalog
+spec:
+  packageName: "@backstage/plugin-catalog-backend-module-github"
+  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+  version: 0.13.0
+  backstage:
+    role: backend-plugin-module
+    supportedVersions: 1.49.4
+  author: Red Hat
+  support: generally-available
+  lifecycle: active
+  partOf:
+    - backstage-plugin-catalog-backend-module-github
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        catalog:
+          providers:
+            github:
+              providerId:
+                organization: ${GITHUB_ORG}

--- a/scripts/tests/fixtures/workspaces/backstage/plugins-list.yaml
+++ b/scripts/tests/fixtures/workspaces/backstage/plugins-list.yaml
@@ -1,0 +1,1 @@
+plugins/catalog-backend-module-github:

--- a/scripts/tests/test_bootstrapPluginBuilds.py
+++ b/scripts/tests/test_bootstrapPluginBuilds.py
@@ -1,0 +1,127 @@
+"""Tests for bootstrapPluginBuilds module."""
+
+import json
+
+import pytest
+
+from bootstrapPluginBuilds import (
+    get_outdated_workspaces,
+    versions_match_minor,
+)
+
+
+# ---------------------------------------------------------------------------
+# versions_match_minor
+# ---------------------------------------------------------------------------
+
+class TestVersionsMatchMinor:
+    def test_exact_match(self):
+        assert versions_match_minor("1.49.4", "1.49.4") is True
+
+    def test_patch_differs(self):
+        assert versions_match_minor("1.49.2", "1.49.4") is True
+
+    def test_minor_differs(self):
+        assert versions_match_minor("1.48.3", "1.49.4") is False
+
+    def test_major_differs(self):
+        assert versions_match_minor("2.49.4", "1.49.4") is False
+
+    def test_empty_first(self):
+        assert versions_match_minor("", "1.49.4") is False
+
+    def test_empty_second(self):
+        assert versions_match_minor("1.49.4", "") is False
+
+    def test_both_empty(self):
+        assert versions_match_minor("", "") is False
+
+    def test_malformed_single_segment(self):
+        assert versions_match_minor("1", "1.49.4") is False
+
+    def test_two_segments_match(self):
+        assert versions_match_minor("1.49", "1.49.4") is True
+
+
+# ---------------------------------------------------------------------------
+# get_outdated_workspaces
+# ---------------------------------------------------------------------------
+
+class TestGetOutdatedWorkspaces:
+    def _create_workspace(self, tmp_path, name, source_version=None, backstage_version=None):
+        ws_dir = tmp_path / name
+        metadata_dir = ws_dir / "metadata"
+        metadata_dir.mkdir(parents=True)
+
+        if source_version is not None:
+            (ws_dir / "source.json").write_text(json.dumps({
+                "repo": "https://github.com/example/repo",
+                "repo-ref": "abc123",
+                "repo-flat": False,
+                "repo-backstage-version": source_version,
+            }))
+
+        if backstage_version is not None:
+            (ws_dir / "backstage.json").write_text(json.dumps({
+                "version": backstage_version,
+            }))
+
+        return ws_dir
+
+    def test_matching_source_json(self, tmp_path):
+        ws = self._create_workspace(tmp_path, "my-plugin", source_version="1.49.2")
+        result = get_outdated_workspaces([ws], "1.49.4")
+        assert result == {}
+
+    def test_mismatching_source_json(self, tmp_path):
+        ws = self._create_workspace(tmp_path, "my-plugin", source_version="1.45.3")
+        result = get_outdated_workspaces([ws], "1.49.4")
+        assert "my-plugin" in result
+        assert result["my-plugin"]["expected"] == "1.49.4"
+        assert result["my-plugin"]["found"] == "1.45.3"
+
+    def test_backstage_json_override_matches(self, tmp_path):
+        ws = self._create_workspace(
+            tmp_path, "my-plugin",
+            source_version="1.45.3",
+            backstage_version="1.49.4",
+        )
+        result = get_outdated_workspaces([ws], "1.49.4")
+        assert result == {}
+
+    def test_backstage_json_override_mismatches(self, tmp_path):
+        ws = self._create_workspace(
+            tmp_path, "my-plugin",
+            source_version="1.45.3",
+            backstage_version="1.47.0",
+        )
+        result = get_outdated_workspaces([ws], "1.49.4")
+        assert "my-plugin" in result
+        assert result["my-plugin"]["found"] == "1.47.0"
+
+    def test_no_source_or_backstage_json(self, tmp_path):
+        ws = self._create_workspace(tmp_path, "my-plugin")
+        result = get_outdated_workspaces([ws], "1.49.4")
+        assert "my-plugin" in result
+        assert result["my-plugin"]["found"] == "missing"
+
+    def test_multiple_workspaces_mixed(self, tmp_path):
+        ws_good = self._create_workspace(tmp_path, "good", source_version="1.49.2")
+        ws_bad = self._create_workspace(tmp_path, "bad", source_version="1.43.1")
+        ws_override = self._create_workspace(
+            tmp_path, "override",
+            source_version="1.45.3",
+            backstage_version="1.49.0",
+        )
+        result = get_outdated_workspaces([ws_good, ws_bad, ws_override], "1.49.4")
+        assert "good" not in result
+        assert "bad" in result
+        assert "override" not in result
+
+    def test_malformed_source_json(self, tmp_path):
+        ws_dir = tmp_path / "broken"
+        (ws_dir / "metadata").mkdir(parents=True)
+        (ws_dir / "source.json").write_text("not valid json")
+        result = get_outdated_workspaces([ws_dir], "1.49.4")
+        assert "broken" in result
+        assert result["broken"]["found"] == "missing"

--- a/scripts/tests/test_generateCatalogIndex.py
+++ b/scripts/tests/test_generateCatalogIndex.py
@@ -1,0 +1,326 @@
+"""Tests for pure-logic functions in generateCatalogIndex.py."""
+
+import pytest
+
+from generateCatalogIndex import (
+    build_digest_comment_map,
+    digest_from_oci_package_line,
+    get_image_name_from_package_yaml,
+    get_query_registry_reference,
+    is_tag_comment_line,
+    parse_image_reference,
+    peek_digest_after,
+    pop_trailing_tag_comments,
+    tag_comment_for_plugin,
+    trailing_tag_comment_matches,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_image_reference
+# ---------------------------------------------------------------------------
+class TestParseImageReference:
+    @pytest.mark.parametrize(
+        "ref, expected",
+        [
+            pytest.param(
+                "quay.io/rhdh/plugin:1.11--1.5.4",
+                ("quay.io/rhdh/plugin", "1.11--1.5.4", ""),
+                id="tag_only",
+            ),
+            pytest.param(
+                "quay.io/rhdh/plugin@sha256:abc123",
+                ("quay.io/rhdh/plugin", "", "sha256:abc123"),
+                id="digest_only",
+            ),
+            pytest.param(
+                "quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123",
+                ("quay.io/rhdh/plugin", "1.11--1.5.4", "sha256:abc123"),
+                id="tag_and_digest",
+            ),
+            pytest.param(
+                "",
+                ("", "", ""),
+                id="empty_string",
+            ),
+            pytest.param(
+                "quay.io/rhdh/plugin",
+                ("quay.io/rhdh/plugin", "", ""),
+                id="no_tag_no_digest",
+            ),
+        ],
+    )
+    def test_parse(self, ref, expected):
+        assert parse_image_reference(ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# tag_comment_for_plugin
+# ---------------------------------------------------------------------------
+class TestTagCommentForPlugin:
+    def test_all_fields_present(self):
+        data = {
+            "build-date": "2025-05-01",
+            "imageTag": "1.11--1.5.4",
+            "registryReference": "quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123",
+        }
+        assert tag_comment_for_plugin(data) == "# Tag: 1.11--1.5.4, Build date: 2025-05-01"
+
+    def test_tag_from_registry_reference_fallback(self):
+        data = {
+            "build-date": "2025-05-01",
+            "registryReference": "quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123",
+        }
+        assert tag_comment_for_plugin(data) == "# Tag: 1.11--1.5.4, Build date: 2025-05-01"
+
+    def test_missing_build_date_returns_none(self):
+        data = {
+            "imageTag": "1.11--1.5.4",
+            "registryReference": "quay.io/rhdh/plugin:1.11--1.5.4@sha256:abc123",
+        }
+        assert tag_comment_for_plugin(data) is None
+
+    def test_missing_digest_returns_none(self):
+        data = {
+            "build-date": "2025-05-01",
+            "imageTag": "1.11--1.5.4",
+            "registryReference": "quay.io/rhdh/plugin:1.11--1.5.4",
+        }
+        assert tag_comment_for_plugin(data) is None
+
+
+# ---------------------------------------------------------------------------
+# build_digest_comment_map
+# ---------------------------------------------------------------------------
+class TestBuildDigestCommentMap:
+    def test_two_plugins(self):
+        index_data = {
+            "plugin-a": {
+                "registryReference": "quay.io/rhdh/plugin-a@sha256:aaa111",
+                "imageTag": "1.11--1.0.0",
+                "build-date": "2025-05-01",
+            },
+            "plugin-b": {
+                "registryReference": "quay.io/rhdh/plugin-b@sha256:bbb222",
+                "imageTag": "1.11--2.0.0",
+                "build-date": "2025-05-02",
+            },
+        }
+        result = build_digest_comment_map(index_data)
+        assert result == {
+            "sha256:aaa111": "# Tag: 1.11--1.0.0, Build date: 2025-05-01",
+            "sha256:bbb222": "# Tag: 1.11--2.0.0, Build date: 2025-05-02",
+        }
+
+    def test_skips_entries_without_digest(self):
+        index_data = {
+            "plugin-no-digest": {
+                "registryReference": "quay.io/rhdh/plugin:1.11--1.0.0",
+                "imageTag": "1.11--1.0.0",
+                "build-date": "2025-05-01",
+            },
+        }
+        assert build_digest_comment_map(index_data) == {}
+
+
+# ---------------------------------------------------------------------------
+# is_tag_comment_line
+# ---------------------------------------------------------------------------
+class TestIsTagCommentLine:
+    @pytest.mark.parametrize(
+        "line, expected",
+        [
+            pytest.param(
+                "  # Tag: 1.11--1.5.4, Build date: 2025-05-01",
+                True,
+                id="valid_tag_comment",
+            ),
+            pytest.param(
+                "  # Some other comment",
+                False,
+                id="other_comment",
+            ),
+            pytest.param(
+                "  - package: oci://quay.io/rhdh/plugin@sha256:abc",
+                False,
+                id="package_line",
+            ),
+        ],
+    )
+    def test_is_tag_comment(self, line, expected):
+        assert is_tag_comment_line(line) == expected
+
+
+# ---------------------------------------------------------------------------
+# pop_trailing_tag_comments
+# ---------------------------------------------------------------------------
+class TestPopTrailingTagComments:
+    def test_removes_trailing_tag_comment(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+        ]
+        pop_trailing_tag_comments(lines)
+        assert lines == ["  - package: oci://quay.io/rhdh/plugin@sha256:abc\n"]
+
+    def test_no_change_for_non_tag_trailing(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  some-key: value\n",
+        ]
+        original = list(lines)
+        pop_trailing_tag_comments(lines)
+        assert lines == original
+
+    def test_removes_multiple_trailing_tag_comments(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  # Tag: 1.11--1.0.0, Build date: 2025-05-01\n",
+            "  # Tag: 1.11--2.0.0, Build date: 2025-05-02\n",
+        ]
+        pop_trailing_tag_comments(lines)
+        assert lines == ["  - package: oci://quay.io/rhdh/plugin@sha256:abc\n"]
+
+
+# ---------------------------------------------------------------------------
+# trailing_tag_comment_matches
+# ---------------------------------------------------------------------------
+class TestTrailingTagCommentMatches:
+    def test_matches(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+        ]
+        assert trailing_tag_comment_matches(lines, "# Tag: 1.11--1.5.4, Build date: 2025-05-01") is True
+
+    def test_does_not_match(self):
+        lines = [
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc\n",
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+        ]
+        assert trailing_tag_comment_matches(lines, "# Tag: 9.99--9.9.9, Build date: 2099-01-01") is False
+
+    def test_none_expected_returns_false(self):
+        lines = [
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+        ]
+        assert trailing_tag_comment_matches(lines, None) is False
+
+
+# ---------------------------------------------------------------------------
+# digest_from_oci_package_line
+# ---------------------------------------------------------------------------
+class TestDigestFromOciPackageLine:
+    @pytest.mark.parametrize(
+        "line, expected",
+        [
+            pytest.param(
+                "  - package: oci://quay.io/rhdh/plugin@sha256:abc123",
+                "sha256:abc123",
+                id="active_line",
+            ),
+            pytest.param(
+                "  # - package: oci://quay.io/rhdh/plugin@sha256:abc123",
+                "sha256:abc123",
+                id="commented_line",
+            ),
+            pytest.param(
+                "  - package: ./dynamic-plugins/dist/foo",
+                None,
+                id="non_oci_line",
+            ),
+        ],
+    )
+    def test_digest_extraction(self, line, expected):
+        assert digest_from_oci_package_line(line) == expected
+
+
+# ---------------------------------------------------------------------------
+# peek_digest_after
+# ---------------------------------------------------------------------------
+class TestPeekDigestAfter:
+    def test_next_line_has_digest(self):
+        lines = [
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n",
+            "  - package: oci://quay.io/rhdh/plugin@sha256:abc123\n",
+        ]
+        assert peek_digest_after(lines, 0) == "sha256:abc123"
+
+    def test_skips_blanks_and_tag_comments(self):
+        lines = [
+            "  some: line\n",
+            "\n",
+            "  # Tag: old, Build date: 2025-01-01\n",
+            "  - package: oci://quay.io/rhdh/plugin@sha256:def456\n",
+        ]
+        assert peek_digest_after(lines, 0) == "sha256:def456"
+
+    def test_no_digest_found(self):
+        lines = [
+            "  some: line\n",
+            "  another: line\n",
+        ]
+        assert peek_digest_after(lines, 0) is None
+
+    def test_past_end_of_list(self):
+        lines = [
+            "  some: line\n",
+        ]
+        assert peek_digest_after(lines, 0) is None
+
+
+# ---------------------------------------------------------------------------
+# get_query_registry_reference
+# ---------------------------------------------------------------------------
+class TestGetQueryRegistryReference:
+    @pytest.mark.parametrize(
+        "ref, expected",
+        [
+            pytest.param(
+                "registry.access.redhat.com/rhdh/plugin:1.11--1.5.4",
+                "quay.io/rhdh/plugin:1.11--1.5.4",
+                id="rarc_to_quay",
+            ),
+            pytest.param(
+                "quay.io/rhdh/plugin:1.11--1.5.4",
+                "quay.io/rhdh/plugin:1.11--1.5.4",
+                id="quay_passthrough",
+            ),
+            pytest.param(
+                "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/plugin:bs_1.49.4__2.18.0",
+                "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/plugin:bs_1.49.4__2.18.0",
+                id="ghcr_passthrough",
+            ),
+        ],
+    )
+    def test_query_ref(self, ref, expected):
+        assert get_query_registry_reference(ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_image_name_from_package_yaml
+# ---------------------------------------------------------------------------
+class TestGetImageNameFromPackageYaml:
+    def test_with_package_name(self, sample_package_yaml):
+        result = get_image_name_from_package_yaml(sample_package_yaml)
+        assert result == "backstage-plugin-catalog-backend-module-github"
+
+    def test_fallback_to_metadata_name(self, tmp_path):
+        content = """\
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  namespace: rhdh
+  name: my-custom-plugin
+spec:
+  version: "1.0.0"
+"""
+        yaml_file = tmp_path / "my-custom-plugin.yaml"
+        yaml_file.write_text(content)
+        result = get_image_name_from_package_yaml(yaml_file)
+        assert result == "my-custom-plugin"
+
+    def test_nonexistent_file_returns_stem(self, tmp_path):
+        missing = tmp_path / "nonexistent-plugin.yaml"
+        result = get_image_name_from_package_yaml(missing)
+        assert result == "nonexistent-plugin"

--- a/scripts/tests/test_generatePluginBuildInfo.py
+++ b/scripts/tests/test_generatePluginBuildInfo.py
@@ -1,0 +1,434 @@
+"""Tests for generatePluginBuildInfo.py — parsing, tag listing, and registry reference transforms."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import generatePluginBuildInfo
+
+
+# ---------------------------------------------------------------------------
+# parse_registry_reference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "ref, expected",
+    [
+        pytest.param(
+            "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0",
+            ("ghcr.io", "org/repo/plugin", "bs_1.45.3__1.2.0"),
+            id="ghcr-with-tag",
+        ),
+        pytest.param(
+            "quay.io/rhdh/plugin:1.11--1.5.4",
+            ("quay.io", "rhdh/plugin", "1.11--1.5.4"),
+            id="quay-with-tag",
+        ),
+        pytest.param(
+            "registry.access.redhat.com/rhdh/plugin:1.11--1.5.4",
+            ("quay.io", "rhdh/plugin", "1.11--1.5.4"),
+            id="rarc-swapped-to-quay",
+        ),
+        pytest.param(
+            "quay.io/rhdh/plugin@sha256:abc123",
+            ("quay.io", "rhdh/plugin", "sha256:abc123"),
+            id="digest-reference",
+        ),
+        pytest.param(
+            "invalid",
+            None,
+            id="invalid-no-slash",
+        ),
+        pytest.param(
+            "quay.io/rhdh/plugin",
+            None,
+            id="invalid-no-tag-or-digest",
+        ),
+    ],
+)
+def test_parse_registry_reference(ref, expected):
+    assert generatePluginBuildInfo.parse_registry_reference(ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# VERSION_SUFFIX_RE
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param("2.18.0", id="three-part"),
+        pytest.param("1.5", id="two-part"),
+        pytest.param("0.1.0", id="zero-leading"),
+        pytest.param("10.20.30", id="multi-digit"),
+    ],
+)
+def test_version_suffix_re_valid(suffix):
+    assert generatePluginBuildInfo.VERSION_SUFFIX_RE.match(suffix) is not None
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        pytest.param("2.18.0.att", id="attestation-suffix"),
+        pytest.param("2.18.0.sbom", id="sbom-suffix"),
+        pytest.param("abc", id="letters-only"),
+        pytest.param("", id="empty"),
+        pytest.param("2.18.0-rc.1", id="prerelease"),
+        pytest.param("sha256:abc", id="digest-like"),
+    ],
+)
+def test_version_suffix_re_invalid(suffix):
+    assert generatePluginBuildInfo.VERSION_SUFFIX_RE.match(suffix) is None
+
+
+# ---------------------------------------------------------------------------
+# list_tags_with_prefix — mocked with REAL tag data
+#
+# Tags below are real samples from:
+#   quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator
+#   ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay
+# ---------------------------------------------------------------------------
+
+# Real tags from quay.io (Konflux builds) — mix of valid versions and build artifacts
+QUAY_REAL_TAGS = [
+    # Valid version tags
+    "1.10--1.3.2",
+    "1.10--1.3.3",
+    "1.10--1.5.3",
+    "1.10--1.5.4",
+    "1.10.0--1.3.2",
+    "1.10.0--1.3.3",
+    "1.10.0--1.5.3",
+    "1.10.0--1.5.4",
+    "1.11--1.5.4",
+    "1.11.0--1.5.4",
+    "1.9--1.1.0",
+    "1.9--1.3.1",
+    # Garbage: bare commit SHAs
+    "207c0117f535de0eccd735c458086807165a243c",
+    "2345f799f480ff5a14f72721672c196023f17f00",
+    "08ac113825206cc510c055a1a8a2cf0fb52e5947.git",
+    "19534fb5ee72171fd373729f3a90909f6ef67a6c.prefetch",
+    # Garbage: Konflux build pipeline tags
+    "rhdh-bsp-scaf059cf4428e94deaf092ef2ec86921bc6-build-image-index",
+    "rhdh-bsp-scaffo9b56ccf78578652c0a7291cccef26eaa-build-container",
+    # Garbage: on-pr- tags from Konflux
+    "on-pr-05edbdc5bbaf6059e86697042d65eaa1ab72df48.git",
+    "on-pr-05edbdc5bbaf6059e86697042d65eaa1ab72df48.prefetch",
+    "on-pr-d13a7e6d0d83b7efd8e4e3cfd7a8e092b7b131b9.git",
+    # Garbage: sha256- attestation/sbom/manifest tags
+    "sha256-000c59163f40769db932c1d4ecb2871e5cdd1e3437510776f7ad00fadaa44290",
+    "sha256-000c59163f40769db932c1d4ecb2871e5cdd1e3437510776f7ad00fadaa44290.att",
+    "sha256-000c59163f40769db932c1d4ecb2871e5cdd1e3437510776f7ad00fadaa44290.sbom",
+    "sha256-143e13c52e7e1dfbe4abc73653af76f0bac8a02bfc598ee9bffcedef829e12fb.src",
+    "sha256-143e13c52e7e1dfbe4abc73653af76f0bac8a02bfc598ee9bffcedef829e12fb.dockerfile",
+]
+
+# Real tags from ghcr.io — much cleaner, but still has pr_/next_ prefixes
+GHCR_REAL_TAGS = [
+    # Valid version tags
+    "bs_1.32.6__2.3.0",
+    "bs_1.35.1__2.5.0",
+    "bs_1.36.1__2.6.2",
+    "bs_1.39.1__2.9.1",
+    "bs_1.42.5__2.11.0",
+    "bs_1.45.3__2.11.0",
+    "bs_1.45.3__2.14.0",
+    "bs_1.49.4__2.18.0",
+    # Not matching bs_ prefix
+    "next__2.11.0",
+    "next__2.14.0",
+    "pr_1168__2.6.2",
+    "pr_2457__2.18.0",
+]
+
+
+def _mock_response(tags):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"tags": tags}
+    return resp
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_quay_prefix_filters_garbage(mock_get):
+    """Verify only clean version tags survive from real quay.io Konflux output."""
+    mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator",
+        "1.10--", None, {}
+    )
+    assert result == ["1.10--1.3.2", "1.10--1.3.3", "1.10--1.5.3", "1.10--1.5.4"]
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_quay_three_part_prefix(mock_get):
+    """Verify three-part version prefix (1.10.0--) also works."""
+    mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator",
+        "1.10.0--", None, {}
+    )
+    assert result == ["1.10.0--1.3.2", "1.10.0--1.3.3", "1.10.0--1.5.3", "1.10.0--1.5.4"]
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_ghcr_prefix_filters_other_families(mock_get):
+    """Verify only bs_1.45.3__ tags returned, not next__/pr__ tags."""
+    mock_get.return_value = _mock_response(GHCR_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "ghcr.io", "redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay",
+        "bs_1.45.3__", None, {}
+    )
+    assert result == ["bs_1.45.3__2.11.0", "bs_1.45.3__2.14.0"]
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_no_matching_prefix(mock_get):
+    """Prefix that doesn't exist in the registry returns empty list."""
+    mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/plugin", "1.12--", None, {}
+    )
+    assert result == []
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_empty_response(mock_get):
+    mock_get.return_value = _mock_response([])
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/plugin", "1.11--", None, {}
+    )
+    assert result == []
+
+
+@patch("generatePluginBuildInfo.requests.get")
+def test_list_tags_version_sort_order(mock_get):
+    """Verify ascending version sort — latest tag is last."""
+    mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+
+    result = generatePluginBuildInfo.list_tags_with_prefix(
+        "quay.io", "rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator",
+        "1.9--", None, {}
+    )
+    assert result == ["1.9--1.1.0", "1.9--1.3.1"]
+    assert result[-1] == "1.9--1.3.1"
+
+
+# ---------------------------------------------------------------------------
+# get_query_registry_reference
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "ref, expected",
+    [
+        pytest.param(
+            "registry.access.redhat.com/rhdh/plugin:1.11",
+            "quay.io/rhdh/plugin:1.11",
+            id="rarc-swaps-to-quay",
+        ),
+        pytest.param(
+            "quay.io/rhdh/plugin:1.11",
+            "quay.io/rhdh/plugin:1.11",
+            id="quay-passes-through",
+        ),
+        pytest.param(
+            "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0",
+            "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0",
+            id="ghcr-passes-through",
+        ),
+    ],
+)
+def test_get_query_registry_reference(ref, expected):
+    assert generatePluginBuildInfo.get_query_registry_reference(ref) == expected
+
+
+# ---------------------------------------------------------------------------
+# get_output_registry_reference
+# ---------------------------------------------------------------------------
+
+class TestGetOutputRegistryReference:
+    """Tests that manipulate the module-level REGISTRY_BASE global."""
+
+    def teardown_method(self):
+        generatePluginBuildInfo.REGISTRY_BASE = ""
+
+    def test_rarc_base_swaps_quay_rhdh_ref(self):
+        generatePluginBuildInfo.REGISTRY_BASE = "registry.access.redhat.com/rhdh"
+        ref = "quay.io/rhdh/plugin:1.11--1.5.4"
+        assert generatePluginBuildInfo.get_output_registry_reference(ref) == (
+            "registry.access.redhat.com/rhdh/plugin:1.11--1.5.4"
+        )
+
+    def test_rarc_base_does_not_swap_ghcr_ref(self):
+        generatePluginBuildInfo.REGISTRY_BASE = "registry.access.redhat.com/rhdh"
+        ref = "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"
+        assert generatePluginBuildInfo.get_output_registry_reference(ref) == ref
+
+    def test_quay_rhdh_base_passes_through(self):
+        generatePluginBuildInfo.REGISTRY_BASE = "quay.io/rhdh"
+        ref = "quay.io/rhdh/plugin:1.11--1.5.4"
+        assert generatePluginBuildInfo.get_output_registry_reference(ref) == ref
+
+    def test_ghcr_base_passes_through(self):
+        generatePluginBuildInfo.REGISTRY_BASE = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays"
+        ref = "ghcr.io/org/repo/plugin:bs_1.45.3__1.2.0"
+        assert generatePluginBuildInfo.get_output_registry_reference(ref) == ref
+
+
+# ---------------------------------------------------------------------------
+# _fetch_image_metadata — real HTTP calls against fixed known images
+#
+# These tests use published images with stable digests that won't change.
+# ---------------------------------------------------------------------------
+
+# Fixed known images for testing
+GHCR_KNOWN_REF = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__2.18.0"
+GHCR_KNOWN_DIGEST = "sha256:15128f76a6edca410f0aa83f48b63fbdbfc5c319404ee9cb577969a2140f2a56"
+
+QUAY_KNOWN_REF = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--1.5.4"
+QUAY_KNOWN_DIGEST = "sha256:e8cb33e40f6f846adaf5e0446049d5a2a5e93a2a12cf8b610e3e0e346f98005c"
+
+
+class TestFetchImageMetadata:
+    """Tests for _fetch_image_metadata against real registries."""
+
+    def test_ghcr_returns_digest(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(GHCR_KNOWN_REF)
+        assert metadata is not None
+        assert metadata["digest"] == GHCR_KNOWN_DIGEST
+
+    def test_ghcr_returns_dynamic_packages_annotation(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(GHCR_KNOWN_REF)
+        assert metadata is not None
+        assert "io.backstage.dynamic-packages" in metadata
+
+    def test_ghcr_community_has_no_build_date(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(GHCR_KNOWN_REF)
+        assert metadata is not None
+        assert "build-date" not in metadata
+
+    def test_quay_returns_digest(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(QUAY_KNOWN_REF)
+        assert metadata is not None
+        assert metadata["digest"] == QUAY_KNOWN_DIGEST
+
+    def test_quay_downstream_has_build_date(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(QUAY_KNOWN_REF)
+        assert metadata is not None
+        assert "build-date" in metadata
+        assert metadata["build-date"]  # non-empty
+
+    def test_quay_downstream_has_vcs_ref(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(QUAY_KNOWN_REF)
+        assert metadata is not None
+        assert "vcs-ref" in metadata
+
+    def test_quay_downstream_has_upstream_and_midstream(self):
+        metadata = generatePluginBuildInfo._fetch_image_metadata(QUAY_KNOWN_REF)
+        assert metadata is not None
+        assert "upstream" in metadata
+        assert "midstream" in metadata
+
+    def test_nonexistent_tag_returns_none(self):
+        bad_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__9999.99.9"
+        metadata = generatePluginBuildInfo._fetch_image_metadata(bad_ref)
+        assert metadata is None
+
+    def test_nonexistent_repo_returns_none(self):
+        bad_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/this-plugin-does-not-exist:bs_1.0.0__1.0.0"
+        metadata = generatePluginBuildInfo._fetch_image_metadata(bad_ref)
+        assert metadata is None
+
+
+# ---------------------------------------------------------------------------
+# get_image_metadata — fallback chain
+# ---------------------------------------------------------------------------
+
+class TestGetImageMetadata:
+    """Tests for get_image_metadata including the fallback path."""
+
+    def test_direct_hit_returns_metadata_without_fallback_fields(self):
+        """When the exact tag exists, no fallback fields are added."""
+        metadata = generatePluginBuildInfo.get_image_metadata(GHCR_KNOWN_REF)
+        assert metadata is not None
+        assert metadata["digest"] == GHCR_KNOWN_DIGEST
+        assert "fallback" not in metadata
+        assert "requestedTag" not in metadata
+
+    def test_fallback_to_older_tag(self):
+        """When the exact tag doesn't exist, falls back to latest available tag with same prefix."""
+        nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__9999.99.9"
+        metadata = generatePluginBuildInfo.get_image_metadata(nonexistent_ref)
+        assert metadata is not None
+        assert metadata.get("fallback") is True
+        assert metadata["requestedTag"] == "bs_1.49.4__9999.99.9"
+        assert "registryReference" in metadata
+        assert "bs_1.49.4__" in metadata["registryReference"]
+        assert "9999" not in metadata["registryReference"]
+        assert metadata["digest"].startswith("sha256:")
+
+    def test_fallback_no_tags_for_prefix_returns_none(self):
+        """When the prefix has zero published tags, fallback returns None."""
+        nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_9999.99.9__1.0.0"
+        metadata = generatePluginBuildInfo.get_image_metadata(nonexistent_ref)
+        assert metadata is None
+
+    def test_fallback_quay_with_nonexistent_version(self):
+        """Quay.io fallback with an nonexistent plugin version resolves to the latest real tag."""
+        nonexistent_ref = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--9999.99.9"
+        metadata = generatePluginBuildInfo.get_image_metadata(nonexistent_ref)
+        assert metadata is not None
+        assert metadata.get("fallback") is True
+        assert metadata["requestedTag"] == "1.11--9999.99.9"
+        assert "1.11--" in metadata["registryReference"]
+        assert "9999" not in metadata["registryReference"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_fallback_tag
+# ---------------------------------------------------------------------------
+
+class TestResolveFallbackTag:
+    """Tests for resolve_fallback_tag against real registries."""
+
+    def test_ghcr_nonexistent_version_resolves_to_latest(self):
+        """An nonexistent plugin version with a valid prefix resolves to the latest real tag."""
+        nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__9999.99.9"
+        result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
+        assert result is not None
+        assert "bs_1.49.4__" in result
+        assert "9999" not in result
+
+    def test_quay_nonexistent_version_resolves_to_latest(self):
+        nonexistent_ref = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--9999.99.9"
+        result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
+        assert result is not None
+        assert "1.11--" in result
+        assert "9999" not in result
+
+    def test_nonexistent_prefix_returns_none(self):
+        """When the prefix itself has no tags, returns None."""
+        nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_9999.99.9__1.0.0"
+        result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
+        assert result is None
+
+    def test_exact_tag_exists_returns_none(self):
+        """When the requested tag already exists, no fallback needed — returns None."""
+        result = generatePluginBuildInfo.resolve_fallback_tag(GHCR_KNOWN_REF)
+        assert result is None
+
+    def test_no_separator_in_tag_returns_none(self):
+        """Tags without a separator can't be split into prefix — returns None."""
+        result = generatePluginBuildInfo.resolve_fallback_tag("ghcr.io/org/repo:latest")
+        assert result is None
+
+    def test_unparseable_ref_returns_none(self):
+        result = generatePluginBuildInfo.resolve_fallback_tag("invalid")
+        assert result is None

--- a/scripts/tests/test_injectDpdyTagComments.py
+++ b/scripts/tests/test_injectDpdyTagComments.py
@@ -1,0 +1,329 @@
+"""Tests for injectDpdyTagComments.py — tag comment injection into dynamic-plugins.default.yaml."""
+
+import json
+
+import pytest
+
+import injectDpdyTagComments
+
+
+# ---------------------------------------------------------------------------
+# keys_for_package
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "pkg, expected",
+    [
+        pytest.param(
+            "rhdh-backstage-plugin-foo-dynamic",
+            [
+                "rhdh-backstage-plugin-foo-dynamic",
+                "rhdh-backstage-plugin-foo",
+                "red-hat-developer-hub-backstage-plugin-foo-dynamic",
+            ],
+            id="rhdh-prefix-and-dynamic-suffix",
+        ),
+        pytest.param(
+            "rhdh-backstage-plugin-foo",
+            [
+                "rhdh-backstage-plugin-foo",
+                "red-hat-developer-hub-backstage-plugin-foo",
+            ],
+            id="rhdh-prefix-no-dynamic",
+        ),
+        pytest.param(
+            "backstage-community-plugin-bar",
+            [
+                "backstage-community-plugin-bar",
+            ],
+            id="no-rhdh-prefix-no-dynamic",
+        ),
+        pytest.param(
+            "backstage-community-plugin-bar-dynamic",
+            [
+                "backstage-community-plugin-bar-dynamic",
+                "backstage-community-plugin-bar",
+            ],
+            id="no-rhdh-prefix-with-dynamic",
+        ),
+    ],
+)
+def test_keys_for_package(pkg, expected):
+    assert injectDpdyTagComments.keys_for_package(pkg) == expected
+
+
+# ---------------------------------------------------------------------------
+# package_name_from_oci_comment
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        pytest.param(
+            "  # - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo@sha256:abc",
+            "red-hat-developer-hub-backstage-plugin-foo",
+            id="quay-oci-comment",
+        ),
+        pytest.param(
+            "  # - package: oci://ghcr.io/org/repo/plugin-bar@sha256:def",
+            "plugin-bar",
+            id="ghcr-oci-comment-nested-path",
+        ),
+        pytest.param(
+            "  - package: ./dynamic-plugins/dist/foo",
+            None,
+            id="local-path-not-oci-comment",
+        ),
+        pytest.param(
+            "some random line",
+            None,
+            id="random-line",
+        ),
+    ],
+)
+def test_package_name_from_oci_comment(line, expected):
+    assert injectDpdyTagComments.package_name_from_oci_comment(line) == expected
+
+
+# ---------------------------------------------------------------------------
+# package_name_from_package_value
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        pytest.param(
+            "./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic",
+            "rhdh-backstage-plugin-foo-dynamic",
+            id="local-path",
+        ),
+        pytest.param(
+            "oci://quay.io/rhdh/plugin-bar@sha256:abc",
+            "plugin-bar",
+            id="oci-reference",
+        ),
+        pytest.param(
+            "simple-name",
+            "simple-name",
+            id="bare-name",
+        ),
+    ],
+)
+def test_package_name_from_package_value(val, expected):
+    assert injectDpdyTagComments.package_name_from_package_value(val) == expected
+
+
+# ---------------------------------------------------------------------------
+# comment_for_package
+# ---------------------------------------------------------------------------
+
+class TestCommentForPackage:
+    TAG_BY_KEY = {
+        "red-hat-developer-hub-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+        "rhdh-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+    }
+
+    def test_direct_match(self):
+        result = injectDpdyTagComments.comment_for_package(
+            "red-hat-developer-hub-backstage-plugin-foo", self.TAG_BY_KEY
+        )
+        assert result == "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+
+    def test_match_via_alias_expansion(self):
+        """rhdh- prefix is expanded to red-hat-developer-hub- for lookup."""
+        tag_by_key = {
+            "red-hat-developer-hub-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+        }
+        result = injectDpdyTagComments.comment_for_package(
+            "rhdh-backstage-plugin-foo", tag_by_key
+        )
+        assert result == "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+
+    def test_match_via_dynamic_strip(self):
+        """Stripping -dynamic suffix finds the base name in tag_by_key."""
+        tag_by_key = {
+            "rhdh-backstage-plugin-foo": ("1.11--1.5.4", "2025-05-01"),
+        }
+        result = injectDpdyTagComments.comment_for_package(
+            "rhdh-backstage-plugin-foo-dynamic", tag_by_key
+        )
+        assert result == "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+
+    def test_no_match(self):
+        result = injectDpdyTagComments.comment_for_package(
+            "unknown-plugin", self.TAG_BY_KEY
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# recent_has_tag
+# ---------------------------------------------------------------------------
+
+class TestRecentHasTag:
+    def test_tag_comment_is_last_line(self):
+        result = [
+            "  - package: foo\n",
+            "  # Tag: 1.0, Build date: 2025\n",
+        ]
+        assert injectDpdyTagComments.recent_has_tag(result) is True
+
+    def test_no_tag_comment_last_is_package(self):
+        result = ["  - package: foo\n"]
+        assert injectDpdyTagComments.recent_has_tag(result) is False
+
+    def test_empty_list(self):
+        assert injectDpdyTagComments.recent_has_tag([]) is False
+
+    def test_tag_comment_before_non_package_lines(self):
+        """Non-package, non-tag lines between the tag comment and current position."""
+        result = [
+            "  - package: foo\n",
+            "  # Tag: 1.0, Build date: 2025\n",
+            "    pluginConfig:\n",
+            "      key: value\n",
+        ]
+        assert injectDpdyTagComments.recent_has_tag(result) is True
+
+    def test_tag_belongs_to_earlier_package(self):
+        """A tag comment followed by another package line means the tag is not recent."""
+        result = [
+            "  # Tag: 1.0, Build date: 2025\n",
+            "  - package: earlier\n",
+            "    pluginConfig:\n",
+        ]
+        # Reverse iteration hits pluginConfig (skip), then "- package: earlier" (stop, no tag) -> False
+        assert injectDpdyTagComments.recent_has_tag(result) is False
+
+
+# ---------------------------------------------------------------------------
+# load_tag_by_key
+# ---------------------------------------------------------------------------
+
+class TestLoadTagByKey:
+    def test_loads_from_json_files(self, tmp_path):
+        workspace_dir = tmp_path / "plugin_builds" / "backstage"
+        workspace_dir.mkdir(parents=True)
+        data = {
+            "red-hat-developer-hub-backstage-plugin-foo": {
+                "registryReference": "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo:1.11--1.5.4",
+                "build-date": "2025-05-01",
+            }
+        }
+        (workspace_dir / "plugin-foo.json").write_text(json.dumps(data))
+
+        result = injectDpdyTagComments.load_tag_by_key(tmp_path / "plugin_builds")
+
+        assert result["red-hat-developer-hub-backstage-plugin-foo"] == ("1.11--1.5.4", "2025-05-01")
+        assert result["rhdh-backstage-plugin-foo"] == ("1.11--1.5.4", "2025-05-01")
+
+    def test_empty_dir(self, tmp_path):
+        empty_dir = tmp_path / "plugin_builds"
+        empty_dir.mkdir()
+        assert injectDpdyTagComments.load_tag_by_key(empty_dir) == {}
+
+    def test_nonexistent_dir(self, tmp_path):
+        assert injectDpdyTagComments.load_tag_by_key(tmp_path / "does_not_exist") == {}
+
+    def test_skips_entries_without_tag_or_build_date(self, tmp_path):
+        workspace_dir = tmp_path / "plugin_builds" / "ws"
+        workspace_dir.mkdir(parents=True)
+        data = {
+            "plugin-no-tag": {
+                "registryReference": "quay.io/rhdh/plugin-no-tag",
+                "build-date": "2025-05-01",
+            },
+            "plugin-no-date": {
+                "registryReference": "quay.io/rhdh/plugin-no-date:1.0",
+                "build-date": "",
+            },
+        }
+        (workspace_dir / "data.json").write_text(json.dumps(data))
+        assert injectDpdyTagComments.load_tag_by_key(tmp_path / "plugin_builds") == {}
+
+    def test_skips_invalid_json(self, tmp_path):
+        workspace_dir = tmp_path / "plugin_builds" / "ws"
+        workspace_dir.mkdir(parents=True)
+        (workspace_dir / "bad.json").write_text("not valid json!!!")
+        assert injectDpdyTagComments.load_tag_by_key(tmp_path / "plugin_builds") == {}
+
+
+# ---------------------------------------------------------------------------
+# inject
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def plugin_builds_dir(tmp_path):
+    """Create a plugin_builds directory with one workspace JSON file."""
+    workspace_dir = tmp_path / "plugin_builds" / "backstage"
+    workspace_dir.mkdir(parents=True)
+    data = {
+        "red-hat-developer-hub-backstage-plugin-foo": {
+            "registryReference": "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo:1.11--1.5.4",
+            "build-date": "2025-05-01",
+        }
+    }
+    (workspace_dir / "plugin-foo.json").write_text(json.dumps(data))
+    return tmp_path / "plugin_builds"
+
+
+class TestInject:
+    def test_inject_after_commented_oci_line(self, tmp_path, plugin_builds_dir):
+        dpdy = tmp_path / "dynamic-plugins.default.yaml"
+        dpdy.write_text(
+            "  # - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo@sha256:abc\n"
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+        )
+
+        changed = injectDpdyTagComments.inject(dpdy, plugin_builds_dir)
+
+        assert changed is True
+        assert dpdy.read_text() == (
+            "  # - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo@sha256:abc\n"
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+        )
+
+    def test_inject_before_file_path_package_line(self, tmp_path, plugin_builds_dir):
+        dpdy = tmp_path / "dynamic-plugins.default.yaml"
+        dpdy.write_text(
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+            "    pluginConfig:\n"
+            "      foo: bar\n"
+        )
+
+        changed = injectDpdyTagComments.inject(dpdy, plugin_builds_dir)
+
+        assert changed is True
+        assert dpdy.read_text() == (
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+            "    pluginConfig:\n"
+            "      foo: bar\n"
+        )
+
+    def test_no_change_when_tag_already_exists(self, tmp_path, plugin_builds_dir):
+        content = (
+            "  # - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-foo@sha256:abc\n"
+            "  # Tag: 1.11--1.5.4, Build date: 2025-05-01\n"
+            "  - package: ./dynamic-plugins/dist/rhdh-backstage-plugin-foo-dynamic\n"
+        )
+        dpdy = tmp_path / "dynamic-plugins.default.yaml"
+        dpdy.write_text(content)
+
+        changed = injectDpdyTagComments.inject(dpdy, plugin_builds_dir)
+
+        assert changed is False
+        assert dpdy.read_text() == content
+
+    def test_no_change_when_no_matching_plugin(self, tmp_path):
+        empty_builds = tmp_path / "plugin_builds"
+        empty_builds.mkdir()
+        dpdy = tmp_path / "dynamic-plugins.default.yaml"
+        content = "  - package: ./dynamic-plugins/dist/unknown-plugin-dynamic\n"
+        dpdy.write_text(content)
+
+        changed = injectDpdyTagComments.inject(dpdy, empty_builds)
+
+        assert changed is False
+        assert dpdy.read_text() == content

--- a/scripts/tests/test_plugin_utils.py
+++ b/scripts/tests/test_plugin_utils.py
@@ -347,3 +347,56 @@ class TestBuildReport:
 
         data = json.loads(report_path.read_text())
         assert data["status"] == "partial"
+
+    def test_overall_outdated(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "outdated",
+                         expected_version="1.49.4", found_version="1.45.3")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["p1"]["overall"] == "outdated"
+
+    def test_summary_includes_outdated_count(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "outdated")
+        report.add_plugin("p3")
+        report.set_stage("p3", "bootstrap", "fail")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["summary"]["total"] == 3
+        assert data["summary"]["succeeded"] == 1
+        assert data["summary"]["failed"] == 1
+        assert data["summary"]["outdated"] == 1
+
+    def test_outdated_does_not_count_as_failed(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "outdated")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["summary"]["failed"] == 0
+        assert data["summary"]["outdated"] == 1
+
+    def test_status_partial_when_outdated(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "outdated")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["status"] == "partial"

--- a/scripts/tests/test_plugin_utils.py
+++ b/scripts/tests/test_plugin_utils.py
@@ -1,0 +1,349 @@
+"""Tests for plugin_utils module."""
+
+import json
+
+import pytest
+
+from plugin_utils import (
+    BuildReport,
+    WorkspaceMappings,
+    _match_workspace_metadata,
+    build_workspace_mappings,
+    detect_file_format,
+    load_and_resolve_to_stems,
+    load_filtered_packages_from_yaml,
+    load_packages_from_txt,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_file_format
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "file_path, expected",
+    [
+        ("file.yaml", "yaml"),
+        ("file.yml", "yaml"),
+        ("file.txt", "txt"),
+        ("file.json", "txt"),
+    ],
+)
+def test_detect_file_format(file_path, expected):
+    assert detect_file_format(file_path) == expected
+
+
+# ---------------------------------------------------------------------------
+# load_filtered_packages_from_yaml
+# ---------------------------------------------------------------------------
+
+class TestLoadFilteredPackagesFromYaml:
+    def test_returns_all_packages_from_enabled_and_disabled(self, sample_packages_yaml):
+        result = load_filtered_packages_from_yaml(sample_packages_yaml)
+        assert result == {
+            "@backstage/plugin-catalog-backend-module-github",
+            "@backstage-community/plugin-analytics-provider-segment",
+            "@backstage-community/plugin-acr",
+        }
+
+    def test_empty_packages_section(self, tmp_path):
+        yaml_file = tmp_path / "empty.yaml"
+        yaml_file.write_text("packages:\n  enabled: []\n  disabled: []\n")
+        result = load_filtered_packages_from_yaml(str(yaml_file))
+        assert result == set()
+
+    def test_missing_file_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            load_filtered_packages_from_yaml("/nonexistent/path.yaml")
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# load_packages_from_txt
+# ---------------------------------------------------------------------------
+
+class TestLoadPackagesFromTxt:
+    def test_skips_comments_and_blank_lines(self, sample_packages_txt):
+        result = load_packages_from_txt(sample_packages_txt)
+        assert result == [
+            "3scale/plugins/3scale-backend",
+            "backstage/plugins/catalog-backend-module-github",
+        ]
+
+    def test_missing_file_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            load_packages_from_txt("/nonexistent/path.txt")
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _match_workspace_metadata
+# ---------------------------------------------------------------------------
+
+class TestMatchWorkspaceMetadata:
+    def test_exact_match(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [("plugin-techdocs", "@backstage-community/plugin-techdocs")],
+            ["plugins/techdocs"],
+        )
+        assert result == {"plugin-techdocs": "ws/plugins/techdocs"}
+
+    def test_suffix_match_with_dash(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [("backstage-community-plugin-techdocs", "@backstage-community/plugin-techdocs")],
+            ["plugins/techdocs"],
+        )
+        assert result == {"backstage-community-plugin-techdocs": "ws/plugins/techdocs"}
+
+    def test_no_plugin_paths_fallback(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [
+                ("plugin-a", "@scope/plugin-a"),
+                ("plugin-b", "@scope/plugin-b"),
+            ],
+            [],
+        )
+        assert result == {
+            "plugin-a": "ws/plugin-a",
+            "plugin-b": "ws/plugin-b",
+        }
+
+    def test_multiple_stems_multiple_paths_no_collision(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [
+                ("backstage-community-plugin-techdocs", "@backstage-community/plugin-techdocs"),
+                ("backstage-community-plugin-catalog", "@backstage-community/plugin-catalog"),
+            ],
+            ["plugins/techdocs", "plugins/catalog"],
+        )
+        assert result == {
+            "backstage-community-plugin-techdocs": "ws/plugins/techdocs",
+            "backstage-community-plugin-catalog": "ws/plugins/catalog",
+        }
+
+    def test_unmatched_stems_fallback(self):
+        result = _match_workspace_metadata(
+            "ws",
+            [
+                ("backstage-community-plugin-techdocs", "@backstage-community/plugin-techdocs"),
+                ("totally-unrelated-name", "@scope/totally-unrelated-name"),
+            ],
+            ["plugins/techdocs"],
+        )
+        assert result["backstage-community-plugin-techdocs"] == "ws/plugins/techdocs"
+        assert result["totally-unrelated-name"] == "ws/totally-unrelated-name"
+
+
+# ---------------------------------------------------------------------------
+# build_workspace_mappings
+# ---------------------------------------------------------------------------
+
+class TestBuildWorkspaceMappings:
+    def test_npm_to_stem_mapping(self, sample_workspace_dir):
+        mappings = build_workspace_mappings(sample_workspace_dir)
+        assert mappings.npm_to_stem["@backstage/plugin-catalog-backend-module-github"] == "backstage-plugin-catalog-backend-module-github"
+        assert mappings.npm_to_stem["@backstage-community/plugin-3scale-backend"] == "backstage-community-plugin-3scale-backend"
+
+    def test_stem_to_npm_mapping(self, sample_workspace_dir):
+        mappings = build_workspace_mappings(sample_workspace_dir)
+        assert mappings.stem_to_npm["backstage-plugin-catalog-backend-module-github"] == "@backstage/plugin-catalog-backend-module-github"
+        assert mappings.stem_to_npm["backstage-community-plugin-3scale-backend"] == "@backstage-community/plugin-3scale-backend"
+
+    def test_ws_path_to_npm_mapping(self, sample_workspace_dir):
+        mappings = build_workspace_mappings(sample_workspace_dir)
+        assert mappings.ws_path_to_npm["backstage/plugins/catalog-backend-module-github"] == "@backstage/plugin-catalog-backend-module-github"
+
+    def test_ws_path_to_stem_mapping(self, sample_workspace_dir):
+        mappings = build_workspace_mappings(sample_workspace_dir)
+        assert mappings.ws_path_to_stem["backstage/plugins/catalog-backend-module-github"] == "backstage-plugin-catalog-backend-module-github"
+
+    def test_empty_workspaces_dir(self, tmp_path):
+        mappings = build_workspace_mappings(tmp_path)
+        assert mappings.npm_to_stem == {}
+        assert mappings.stem_to_npm == {}
+        assert mappings.ws_path_to_npm == {}
+        assert mappings.ws_path_to_stem == {}
+
+
+# ---------------------------------------------------------------------------
+# load_and_resolve_to_stems
+# ---------------------------------------------------------------------------
+
+class TestLoadAndResolveToStems:
+    def _create_workspace(self, base_dir):
+        """Helper: create a minimal workspace for resolution tests."""
+        ws_dir = base_dir / "workspaces" / "backstage"
+        metadata_dir = ws_dir / "metadata"
+        metadata_dir.mkdir(parents=True)
+
+        (ws_dir / "plugins-list.yaml").write_text(
+            "plugins/techdocs\nplugins/catalog\n"
+        )
+
+        (metadata_dir / "backstage-community-plugin-techdocs.yaml").write_text(
+            "apiVersion: extensions.backstage.io/v1alpha1\n"
+            "kind: Package\n"
+            "metadata:\n"
+            "  name: backstage-community-plugin-techdocs\n"
+            "spec:\n"
+            '  packageName: "@backstage-community/plugin-techdocs"\n'
+        )
+
+        (metadata_dir / "backstage-community-plugin-catalog.yaml").write_text(
+            "apiVersion: extensions.backstage.io/v1alpha1\n"
+            "kind: Package\n"
+            "metadata:\n"
+            "  name: backstage-community-plugin-catalog\n"
+            "spec:\n"
+            '  packageName: "@backstage-community/plugin-catalog"\n'
+        )
+
+    def test_yaml_input_resolves_npm_to_stems(self, tmp_path):
+        self._create_workspace(tmp_path)
+
+        yaml_file = tmp_path / "packages.yaml"
+        yaml_file.write_text(
+            "packages:\n"
+            "  enabled:\n"
+            '    - package: "@backstage-community/plugin-techdocs"\n'
+        )
+
+        result = load_and_resolve_to_stems([str(yaml_file)], tmp_path)
+        assert result == {"backstage-community-plugin-techdocs"}
+
+    def test_txt_input_resolves_workspace_paths_to_stems(self, tmp_path):
+        self._create_workspace(tmp_path)
+
+        txt_file = tmp_path / "packages.txt"
+        txt_file.write_text("backstage/plugins/techdocs\n")
+
+        result = load_and_resolve_to_stems([str(txt_file)], tmp_path)
+        assert result == {"backstage-community-plugin-techdocs"}
+
+    def test_multi_file_union(self, tmp_path):
+        self._create_workspace(tmp_path)
+
+        yaml_file = tmp_path / "a.yaml"
+        yaml_file.write_text(
+            "packages:\n"
+            "  enabled:\n"
+            '    - package: "@backstage-community/plugin-techdocs"\n'
+        )
+
+        txt_file = tmp_path / "b.txt"
+        txt_file.write_text("backstage/plugins/catalog\n")
+
+        result = load_and_resolve_to_stems(
+            [str(yaml_file), str(txt_file)], tmp_path
+        )
+        assert result == {
+            "backstage-community-plugin-techdocs",
+            "backstage-community-plugin-catalog",
+        }
+
+    def test_empty_list_returns_empty(self, tmp_path):
+        result = load_and_resolve_to_stems([], tmp_path)
+        assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# BuildReport
+# ---------------------------------------------------------------------------
+
+class TestBuildReport:
+    def test_disabled_report(self):
+        report = BuildReport(None)
+        assert not report.enabled
+        # save is a no-op, should not raise
+        report.save()
+
+    def test_enabled_report_creates_file(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        assert report.enabled
+
+        report.add_plugin("plugin-a", package="@scope/plugin-a")
+        report.set_stage("plugin-a", "bootstrap", "pass")
+        report.save()
+
+        assert report_path.exists()
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["plugin-a"]["stages"]["bootstrap"]["status"] == "pass"
+
+    def test_overall_all_pass(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.set_stage("p1", "export", "pass")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["p1"]["overall"] == "pass"
+
+    def test_overall_any_fail(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.set_stage("p1", "export", "fail")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["p1"]["overall"] == "fail"
+
+    def test_overall_mixed(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.set_stage("p1", "export", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "fail")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["plugins"]["p1"]["overall"] == "pass"
+        assert data["plugins"]["p2"]["overall"] == "fail"
+
+    def test_summary_counts(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "fail")
+        report.add_plugin("p3")
+        report.set_stage("p3", "bootstrap", "pass")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["summary"]["total"] == 3
+        assert data["summary"]["succeeded"] == 2
+        assert data["summary"]["failed"] == 1
+
+    def test_status_success_when_no_failures(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["status"] == "success"
+
+    def test_status_partial_when_some_fail(self, tmp_path):
+        report_path = tmp_path / "report.json"
+        report = BuildReport(str(report_path))
+        report.add_plugin("p1")
+        report.set_stage("p1", "bootstrap", "pass")
+        report.add_plugin("p2")
+        report.set_stage("p2", "bootstrap", "fail")
+        report.save()
+
+        data = json.loads(report_path.read_text())
+        assert data["status"] == "partial"

--- a/scripts/update-index.sh
+++ b/scripts/update-index.sh
@@ -284,7 +284,7 @@ r.save()
           "$REPORT_FILE" > "${REPORT_FILE}.tmp" && mv "${REPORT_FILE}.tmp" "$REPORT_FILE"
     fi
 else
-    echo -e "\n${blue}=== Step 3: Skipped (no default.packages.yaml provided) ===${norm}"
+    echo -e "\n${blue}=== Step 3: DPDY Generation — Skipped (no default.packages.yaml provided) ===${norm}"
     if [[ -n "$REPORT_FILE" && -f "$REPORT_FILE" ]]; then
         jq '.plugins |= with_entries(.value.stages.dpdy = {status: "skip"})' \
           "$REPORT_FILE" > "${REPORT_FILE}.tmp" && mv "${REPORT_FILE}.tmp" "$REPORT_FILE"

--- a/scripts/update-index.sh
+++ b/scripts/update-index.sh
@@ -226,7 +226,7 @@ restore_metadata() {
 trap restore_metadata EXIT
 
 ##############################################
-# Step 2: Enrich plugin_builds/ with registry metadata
+# Step 2: Enrich plugin_builds/ with registry metadata (includes fallback tag resolution)
 ##############################################
 echo -e "\n${green}=== Step 2: Enrich plugin_builds/ with registry metadata ===${norm}"
 # shellcheck disable=SC2086
@@ -275,13 +275,6 @@ r.save()
 "
         fi
         exit 1
-    fi
-    cp "$DEFAULT_PACKAGES_FILE" "$OUTPUT_DIR/default.packages.yaml"
-    echo -e "${blue}Copied $DEFAULT_PACKAGES_FILE to $OUTPUT_DIR/default.packages.yaml${norm}"
-    if [[ -n "$REPORT_FILE" && -f "$REPORT_FILE" ]]; then
-        jq --arg status "$DPDY_STATUS" \
-          '.plugins |= with_entries(.value.stages.dpdy = {status: $status})' \
-          "$REPORT_FILE" > "${REPORT_FILE}.tmp" && mv "${REPORT_FILE}.tmp" "$REPORT_FILE"
     fi
     cp "$DEFAULT_PACKAGES_FILE" "$OUTPUT_DIR/default.packages.yaml"
     echo -e "${blue}Copied $DEFAULT_PACKAGES_FILE to $OUTPUT_DIR/default.packages.yaml${norm}"

--- a/scripts/update-index.sh
+++ b/scripts/update-index.sh
@@ -48,6 +48,7 @@ COMMUNITY_REGISTRY="ghcr.io/redhat-developer/rhdh-plugin-export-overlays"
 OUTPUT_DIR="catalog-index"
 PLUGIN_BUILDS_DIR="plugin_builds"
 PACKAGES_FILES=()
+REPORT_FILE=""
 DEBUG_FLAG=""
 DEBUG=0
 
@@ -82,7 +83,8 @@ Arguments:
   -p,  --packages-file         Package list file (YAML or txt). Can be specified multiple times.
                                Files are unioned. Supports default.packages.yaml (npm names)
                                and txt files with workspace paths (e.g., rhdh-supported-packages.txt).
-                               DPDY generation uses only the first .yaml file.
+                               DPDY generation runs only when a file named default.packages.yaml is provided.
+       --report-file           Path to build-report.json for tracking generation stages (optional).
        --debug                 Enable debug output
   -h,  --help                  Show this help
 USAGE
@@ -119,6 +121,10 @@ while [[ "$#" -gt 0 ]]; do
         COMMUNITY_REGISTRY="$2"
         shift 2
         ;;
+    '--report-file')
+        REPORT_FILE="$2"
+        shift 2
+        ;;
     '--debug')
         DEBUG=1
         DEBUG_FLAG="--debug"
@@ -150,7 +156,18 @@ if [[ $DEBUG -eq 1 ]]; then
     echo "OUTPUT_DIR         = $OUTPUT_DIR"
     echo "PLUGIN_BUILDS_DIR  = $PLUGIN_BUILDS_DIR"
     echo "PACKAGES_FILES     = ${PACKAGES_FILES[*]:-<none>}"
+    echo "REPORT_FILE        = ${REPORT_FILE:-<none>}"
     echo "#################################"
+fi
+
+# Build --report-file arg
+REPORT_FILE_ARG=""
+if [[ -n "$REPORT_FILE" ]]; then
+    if ! command -v jq >/dev/null 2>&1; then
+        echo -e "${red}[ERROR] jq is required when --report-file is used${norm}" >&2
+        exit 1
+    fi
+    REPORT_FILE_ARG="--report-file $REPORT_FILE"
 fi
 
 # Build --packages-file args for bootstrapPluginBuilds.py
@@ -181,6 +198,7 @@ if ! python3 "$SCRIPT_DIR/bootstrapPluginBuilds.py" \
     $RHDH_VERSION_ARG \
     $BOOTSTRAP_FILTER_ARGS \
     $COMMUNITY_REGISTRY_ARG \
+    $REPORT_FILE_ARG \
     $DEBUG_FLAG; then
     echo -e "${red}[ERROR] bootstrapPluginBuilds.py failed!${norm}" >&2; exit 1
 fi
@@ -216,6 +234,7 @@ if ! python3 "$SCRIPT_DIR/generatePluginBuildInfo.py" \
     --overlays-dir "$OVERLAYS_DIR" \
     --plugin-builds-dir "$PLUGIN_BUILDS_DIR" \
     --registry "$REGISTRY" \
+    $REPORT_FILE_ARG \
     $DEBUG_FLAG; then
     echo -e "${red}[ERROR] generatePluginBuildInfo.py failed!${norm}" >&2; exit 1
 fi
@@ -223,28 +242,60 @@ fi
 ##############################################
 # Step 3: Generate dynamic-plugins.default.yaml
 ##############################################
-# DPDY only uses the first .yaml file (needs enabled/disabled structure)
-DPDY_PACKAGES_FILE=""
+# Find the default.packages.yaml file among the provided --packages-file args
+DEFAULT_PACKAGES_FILE=""
 for pf in "${PACKAGES_FILES[@]+"${PACKAGES_FILES[@]}"}"; do
-    if [[ "$pf" == *.yaml ]] || [[ "$pf" == *.yml ]]; then
-        DPDY_PACKAGES_FILE="$pf"
+    if [[ "$(basename "$pf")" == "default.packages.yaml" ]]; then
+        DEFAULT_PACKAGES_FILE="$pf"
         break
     fi
 done
 
-if [[ -n "$DPDY_PACKAGES_FILE" ]]; then
+if [[ -n "$DEFAULT_PACKAGES_FILE" ]]; then
     echo -e "\n${green}=== Step 3: Generate dynamic-plugins.default.yaml ===${norm}"
+    echo -e "${blue}Using default packages file: $DEFAULT_PACKAGES_FILE${norm}"
     mkdir -p "$OUTPUT_DIR"
+    DPDY_STATUS="pass"
     # shellcheck disable=SC2086
     if ! "$SCRIPT_DIR/generateDynamicPluginsDefaultYaml.sh" \
-        --packages-file "$DPDY_PACKAGES_FILE" \
+        --packages-file "$DEFAULT_PACKAGES_FILE" \
         --output-file "$OUTPUT_DIR/dynamic-plugins.default.yaml" \
         --overlays-dir "$OVERLAYS_DIR" \
+        --plugin-builds-dir "$PLUGIN_BUILDS_DIR" \
         $DEBUG_FLAG; then
-        echo -e "${red}[ERROR] generateDynamicPluginsDefaultYaml.sh failed!${norm}" >&2; exit 1
+        DPDY_STATUS="fail"
+        echo -e "${red}[ERROR] generateDynamicPluginsDefaultYaml.sh failed!${norm}" >&2
+        if [[ -n "$REPORT_FILE" && -f "$REPORT_FILE" ]]; then
+            python3 -c "
+import sys; sys.path.insert(0, '$SCRIPT_DIR')
+from plugin_utils import BuildReport
+r = BuildReport('$REPORT_FILE')
+r.set_stage_all('dpdy', 'fail')
+r.save()
+"
+        fi
+        exit 1
+    fi
+    cp "$DEFAULT_PACKAGES_FILE" "$OUTPUT_DIR/default.packages.yaml"
+    echo -e "${blue}Copied $DEFAULT_PACKAGES_FILE to $OUTPUT_DIR/default.packages.yaml${norm}"
+    if [[ -n "$REPORT_FILE" && -f "$REPORT_FILE" ]]; then
+        jq --arg status "$DPDY_STATUS" \
+          '.plugins |= with_entries(.value.stages.dpdy = {status: $status})' \
+          "$REPORT_FILE" > "${REPORT_FILE}.tmp" && mv "${REPORT_FILE}.tmp" "$REPORT_FILE"
+    fi
+    cp "$DEFAULT_PACKAGES_FILE" "$OUTPUT_DIR/default.packages.yaml"
+    echo -e "${blue}Copied $DEFAULT_PACKAGES_FILE to $OUTPUT_DIR/default.packages.yaml${norm}"
+    if [[ -n "$REPORT_FILE" && -f "$REPORT_FILE" ]]; then
+        jq --arg status "$DPDY_STATUS" \
+          '.plugins |= with_entries(.value.stages.dpdy = {status: $status})' \
+          "$REPORT_FILE" > "${REPORT_FILE}.tmp" && mv "${REPORT_FILE}.tmp" "$REPORT_FILE"
     fi
 else
-    echo -e "\n${blue}=== Step 3: Skipped (no .yaml packages file provided) ===${norm}"
+    echo -e "\n${blue}=== Step 3: Skipped (no default.packages.yaml provided) ===${norm}"
+    if [[ -n "$REPORT_FILE" && -f "$REPORT_FILE" ]]; then
+        jq '.plugins |= with_entries(.value.stages.dpdy = {status: "skip"})' \
+          "$REPORT_FILE" > "${REPORT_FILE}.tmp" && mv "${REPORT_FILE}.tmp" "$REPORT_FILE"
+    fi
 fi
 
 ##############################################
@@ -262,6 +313,7 @@ if ! python3 "$SCRIPT_DIR/generateCatalogIndex.py" \
     --plugin-builds-dir "$PLUGIN_BUILDS_DIR" \
     --registry "$REGISTRY" \
     $PACKAGES_FILE_ARGS \
+    $REPORT_FILE_ARG \
     $DEBUG_FLAG; then
     echo -e "${red}[ERROR] generateCatalogIndex.py failed!${norm}" >&2; exit 1
 fi

--- a/scripts/update-index.sh
+++ b/scripts/update-index.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Red Hat, Inc.
+#
+# Orchestrator script to generate plugin_builds/ and catalog-index/ directories.
+#
+# Usage examples (defaults: --overlays-dir=. --output-dir=catalog-index --plugin-builds-dir=plugin_builds):
+#
+#   # Supported index (union of default.packages.yaml + rhdh-supported-packages.txt)
+#   scripts/update-index.sh \
+#     --overlays-dir . \
+#     --registry quay.io/rhdh-community \
+#     --output-dir catalog-index/supported \
+#     --plugin-builds-dir plugin_builds/supported \
+#     --packages-file catalog-index/default.packages.yaml \
+#     --packages-file rhdh-supported-packages.txt
+#
+#   # Community index (from rhdh-community-packages.txt)
+#   scripts/update-index.sh \
+#     --overlays-dir . \
+#     --registry ghcr.io/redhat-developer/rhdh-plugin-export-overlays \
+#     --output-dir catalog-index/community \
+#     --plugin-builds-dir plugin_builds/community \
+#     --packages-file rhdh-community-packages.txt
+#
+#   # Midstream (quay.io/rhdh → registry.access.redhat.com)
+#   scripts/update-index.sh \
+#     --overlays-dir /path/to/overlay-repo \
+#     --registry quay.io/rhdh \
+#     --output-dir /path/to/catalog-index \
+#     --plugin-builds-dir /path/to/plugin_builds \
+#     --packages-file /path/to/catalog-index/default.packages.yaml \
+#     --packages-file /path/to/rhdh-supported-packages.txt
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+norm="\033[0;39m"
+green="\033[1;32m"
+red="\033[1;31m"
+blue="\033[1;34m"
+
+OVERLAYS_DIR="."
+REGISTRY=""
+RHDH_VERSION=""
+COMMUNITY_REGISTRY="ghcr.io/redhat-developer/rhdh-plugin-export-overlays"
+OUTPUT_DIR="catalog-index"
+PLUGIN_BUILDS_DIR="plugin_builds"
+PACKAGES_FILES=()
+DEBUG_FLAG=""
+DEBUG=0
+
+usage() {
+    cat <<'USAGE'
+Orchestrator script to generate plugin_builds/ and catalog-index/.
+
+Usage:
+    update-index.sh \
+        -r|--registry BASE \
+        [-d|--overlays-dir PATH] \
+        [-o|--output-dir PATH] \
+        [-b|--plugin-builds-dir PATH] \
+        [-v|--rhdh-version VERSION] \
+        [-p|--packages-file PATH ...] \
+        [-cr|--community-registry BASE] \
+        [--debug] \
+        [-h|--help]
+
+Arguments:
+  -r,  --registry              Registry base (e.g., ghcr.io/redhat-developer/rhdh-plugin-export-overlays)
+  -d,  --overlays-dir          Path to overlays repo root (contains workspaces/)
+                               (default: .)
+  -o,  --output-dir            Output directory for catalog-index
+                               (default: catalog-index)
+  -b,  --plugin-builds-dir     Directory for plugin_builds/ JSON files
+                               (default: plugin_builds)
+  -v,  --rhdh-version          RHDH version for non-ghcr.io tag convention (e.g., 1.5).
+                               Required when registry is not ghcr.io.
+  -cr, --community-registry    Registry base for community-tier plugins
+                               (default: ghcr.io/redhat-developer/rhdh-plugin-export-overlays)
+  -p,  --packages-file         Package list file (YAML or txt). Can be specified multiple times.
+                               Files are unioned. Supports default.packages.yaml (npm names)
+                               and txt files with workspace paths (e.g., rhdh-supported-packages.txt).
+                               DPDY generation uses only the first .yaml file.
+       --debug                 Enable debug output
+  -h,  --help                  Show this help
+USAGE
+    exit 1
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+    '-d' | '--overlays-dir')
+        OVERLAYS_DIR="$2"
+        shift 2
+        ;;
+    '-r' | '--registry')
+        REGISTRY="$2"
+        shift 2
+        ;;
+    '-v' | '--rhdh-version')
+        RHDH_VERSION="$2"
+        shift 2
+        ;;
+    '-o' | '--output-dir')
+        OUTPUT_DIR="$2"
+        shift 2
+        ;;
+    '-b' | '--plugin-builds-dir')
+        PLUGIN_BUILDS_DIR="$2"
+        shift 2
+        ;;
+    '-p' | '--packages-file')
+        PACKAGES_FILES+=("$2")
+        shift 2
+        ;;
+    '-cr' | '--community-registry')
+        COMMUNITY_REGISTRY="$2"
+        shift 2
+        ;;
+    '--debug')
+        DEBUG=1
+        DEBUG_FLAG="--debug"
+        shift 1
+        ;;
+    '-h' | '--help')
+        usage
+        ;;
+    *)
+        echo -e "${red}[ERROR] Invalid parameter: $1${norm}" >&2
+        echo
+        usage
+        ;;
+    esac
+done
+
+# Validate required args
+if [[ -z "$REGISTRY" ]]; then
+    echo -e "${red}[ERROR] Missing required argument: --registry${norm}\n" >&2
+    usage
+fi
+
+if [[ $DEBUG -eq 1 ]]; then
+    echo "#################################"
+    echo "OVERLAYS_DIR       = $OVERLAYS_DIR"
+    echo "REGISTRY           = $REGISTRY"
+    echo "RHDH_VERSION       = $RHDH_VERSION"
+    echo "COMMUNITY_REGISTRY = $COMMUNITY_REGISTRY"
+    echo "OUTPUT_DIR         = $OUTPUT_DIR"
+    echo "PLUGIN_BUILDS_DIR  = $PLUGIN_BUILDS_DIR"
+    echo "PACKAGES_FILES     = ${PACKAGES_FILES[*]:-<none>}"
+    echo "#################################"
+fi
+
+# Build --packages-file args for bootstrapPluginBuilds.py
+BOOTSTRAP_FILTER_ARGS=""
+COMMUNITY_REGISTRY_ARG=""
+if [[ ${#PACKAGES_FILES[@]} -gt 0 ]]; then
+    for pf in "${PACKAGES_FILES[@]}"; do
+        BOOTSTRAP_FILTER_ARGS="$BOOTSTRAP_FILTER_ARGS --packages-file $pf"
+    done
+    if [[ "$COMMUNITY_REGISTRY" != "$REGISTRY" ]]; then
+        COMMUNITY_REGISTRY_ARG="--community-registry $COMMUNITY_REGISTRY"
+    fi
+fi
+
+##############################################
+# Step 1: Bootstrap plugin_builds/ from metadata
+##############################################
+echo -e "\n${green}=== Step 1: Bootstrap plugin_builds/ from metadata ===${norm}"
+RHDH_VERSION_ARG=""
+if [[ -n "$RHDH_VERSION" ]]; then
+    RHDH_VERSION_ARG="--rhdh-version $RHDH_VERSION"
+fi
+# shellcheck disable=SC2086
+if ! python3 "$SCRIPT_DIR/bootstrapPluginBuilds.py" \
+    --overlays-dir "$OVERLAYS_DIR" \
+    --plugin-builds-dir "$PLUGIN_BUILDS_DIR" \
+    --registry "$REGISTRY" \
+    $RHDH_VERSION_ARG \
+    $BOOTSTRAP_FILTER_ARGS \
+    $COMMUNITY_REGISTRY_ARG \
+    $DEBUG_FLAG; then
+    echo -e "${red}[ERROR] bootstrapPluginBuilds.py failed!${norm}" >&2; exit 1
+fi
+
+##############################################
+# Backup metadata files before Step 2 modifies them (write-back adds sha256 digests).
+# Restored on exit so digests don't persist in source for future runs.
+##############################################
+METADATA_BACKUP=""
+OVERLAYS_DIR_ABS=$(cd "$OVERLAYS_DIR" && pwd)
+if [[ -d "$OVERLAYS_DIR_ABS/workspaces" ]]; then
+    METADATA_BACKUP=$(mktemp -d)
+    echo -e "${blue}Backing up workspaces/*/metadata/ to $METADATA_BACKUP${norm}"
+    (cd "$OVERLAYS_DIR_ABS" && find workspaces -path "*/metadata/*.yaml" -print0 | tar cf "$METADATA_BACKUP/metadata.tar" --null -T -)
+fi
+
+restore_metadata() {
+    if [[ -n "$METADATA_BACKUP" && -f "$METADATA_BACKUP/metadata.tar" ]]; then
+        echo -e "\n${blue}Restoring original metadata files...${norm}"
+        (cd "$OVERLAYS_DIR_ABS" && tar xf "$METADATA_BACKUP/metadata.tar")
+        rm -rf "$METADATA_BACKUP"
+        echo -e "${blue}Metadata restored.${norm}"
+    fi
+}
+trap restore_metadata EXIT
+
+##############################################
+# Step 2: Enrich plugin_builds/ with registry metadata
+##############################################
+echo -e "\n${green}=== Step 2: Enrich plugin_builds/ with registry metadata ===${norm}"
+# shellcheck disable=SC2086
+if ! python3 "$SCRIPT_DIR/generatePluginBuildInfo.py" \
+    --overlays-dir "$OVERLAYS_DIR" \
+    --plugin-builds-dir "$PLUGIN_BUILDS_DIR" \
+    --registry "$REGISTRY" \
+    $DEBUG_FLAG; then
+    echo -e "${red}[ERROR] generatePluginBuildInfo.py failed!${norm}" >&2; exit 1
+fi
+
+##############################################
+# Step 3: Generate dynamic-plugins.default.yaml
+##############################################
+# DPDY only uses the first .yaml file (needs enabled/disabled structure)
+DPDY_PACKAGES_FILE=""
+for pf in "${PACKAGES_FILES[@]+"${PACKAGES_FILES[@]}"}"; do
+    if [[ "$pf" == *.yaml ]] || [[ "$pf" == *.yml ]]; then
+        DPDY_PACKAGES_FILE="$pf"
+        break
+    fi
+done
+
+if [[ -n "$DPDY_PACKAGES_FILE" ]]; then
+    echo -e "\n${green}=== Step 3: Generate dynamic-plugins.default.yaml ===${norm}"
+    mkdir -p "$OUTPUT_DIR"
+    # shellcheck disable=SC2086
+    if ! "$SCRIPT_DIR/generateDynamicPluginsDefaultYaml.sh" \
+        --packages-file "$DPDY_PACKAGES_FILE" \
+        --output-file "$OUTPUT_DIR/dynamic-plugins.default.yaml" \
+        --overlays-dir "$OVERLAYS_DIR" \
+        $DEBUG_FLAG; then
+        echo -e "${red}[ERROR] generateDynamicPluginsDefaultYaml.sh failed!${norm}" >&2; exit 1
+    fi
+else
+    echo -e "\n${blue}=== Step 3: Skipped (no .yaml packages file provided) ===${norm}"
+fi
+
+##############################################
+# Step 4: Generate catalog index
+##############################################
+echo -e "\n${green}=== Step 4: Generate catalog index ===${norm}"
+PACKAGES_FILE_ARGS=""
+for pf in "${PACKAGES_FILES[@]+"${PACKAGES_FILES[@]}"}"; do
+    PACKAGES_FILE_ARGS="$PACKAGES_FILE_ARGS --packages-file $pf"
+done
+# shellcheck disable=SC2086
+if ! python3 "$SCRIPT_DIR/generateCatalogIndex.py" \
+    --overlays-dir "$OVERLAYS_DIR" \
+    --output-dir "$OUTPUT_DIR" \
+    --plugin-builds-dir "$PLUGIN_BUILDS_DIR" \
+    --registry "$REGISTRY" \
+    $PACKAGES_FILE_ARGS \
+    $DEBUG_FLAG; then
+    echo -e "${red}[ERROR] generateCatalogIndex.py failed!${norm}" >&2; exit 1
+fi
+
+echo -e "\n${green}=== Done ===${norm}"
+echo -e "${blue}Output: $OUTPUT_DIR${norm}"
+echo -e "${blue}Plugin builds: $PLUGIN_BUILDS_DIR${norm}"

--- a/user-guide/07-plugin-catalog-index.md
+++ b/user-guide/07-plugin-catalog-index.md
@@ -52,14 +52,14 @@ The core orchestrator script is `[scripts/update-index.sh](../scripts/update-ind
 
 ```mermaid
 flowchart TB
-    subgraph "Step 1: Bootstrap"
+    subgraph "Step 1: Plugin Builds Bootstrap"
         S1_IN["workspaces/{name}/metadata/{plugin}.yaml<br/>plugins-list.yaml<br/>versions.json<br/>Package list files"]
         S1["bootstrapPluginBuilds.py"]
         S1_OUT["plugin_builds/{ws}/{plugin}.json<br/>(workspace path, OCI ref, support level)"]
         S1_IN --> S1 --> S1_OUT
     end
 
-    subgraph "Step 2: Registry Enrichment"
+    subgraph "Step 2: Image Metadata Fetch"
         S2["generatePluginBuildInfo.py"]
         S2_OUT["plugin_builds/{ws}/{plugin}.json<br/>(+ digest, build-date, vcs-ref)"]
         S1_OUT --> S2
@@ -76,7 +76,7 @@ flowchart TB
         S3 --> S3_OUT
     end
 
-    subgraph "Step 4: Catalog Index"
+    subgraph "Step 4: Catalog Index Generation"
         S4["generateCatalogIndex.py"]
         S4_OUT["index.json<br/>catalog-entities/<br/>build-report.json"]
         S2_OUT --> S4
@@ -88,7 +88,7 @@ flowchart TB
 
 
 
-### Step 1: Bootstrap (`bootstrapPluginBuilds.py`)
+### Step 1: Plugin Builds Bootstrap (`bootstrapPluginBuilds.py`)
 
 Reads each `workspaces/*/metadata/*.yaml` file and constructs initial `plugin_builds/<workspace>/<image-name>.json` entries. Each entry includes the workspace path, support level, and a constructed OCI tag reference based on the registry type:
 
@@ -97,7 +97,7 @@ Reads each `workspaces/*/metadata/*.yaml` file and constructs initial `plugin_bu
 
 Plugins are filtered to only those matching the provided `--packages-file` list(s).
 
-### Step 2: Registry Enrichment (`generatePluginBuildInfo.py`)
+### Step 2: Image Metadata Fetch (`generatePluginBuildInfo.py`)
 
 Queries the container registry for each plugin's OCI image to retrieve:
 
@@ -105,6 +105,7 @@ Queries the container registry for each plugin's OCI image to retrieve:
 - **Build date** and **VCS ref** from container labels
 - **Upstream/midstream** repo refs from container env vars
 
+Then updates `plugin_builds` with the relevant metadata.
 Images that don't exist in the registry are logged as warnings.
 
 ### Step 3: DPDY Generation (`generateDynamicPluginsDefaultYaml.sh`)
@@ -136,7 +137,7 @@ plugins:
     disabled: true
 ```
 
-### Step 4: Catalog Index (`generateCatalogIndex.py`)
+### Step 4: Catalog Index Generation (`generateCatalogIndex.py`)
 
 The final step that produces the catalog index:
 

--- a/user-guide/07-plugin-catalog-index.md
+++ b/user-guide/07-plugin-catalog-index.md
@@ -1,0 +1,241 @@
+# Plugin Catalog Index
+
+The **plugin catalog index** is the collection of community and supported plugins of this repository. It contains all the metadata, OCI image references, and default configuration needed for RHDH to discover and load dynamic plugins. This page explains how the catalog index is built, what it contains, and where it is published.
+
+---
+
+## Overview
+
+The catalog index generation pipeline reads workspace metadata, queries container registries, and produces a self-contained directory of catalog entities and an `index.json` file. This directory is then packaged as an OCI image and pushed to a container registry, where RHDH consumes it.
+
+### High-Level Flow
+
+```mermaid
+flowchart LR
+    subgraph Inputs
+        META["workspaces/{name}/metadata/{plugin}.yaml<br/>(Package entities)"]
+        CATS["catalog-entities/extensions/<br/>(Plugin entities, Collections)"]
+        PKGS["Package list files<br/>(default.packages.yaml,<br/>rhdh-supported-packages.txt,<br/>rhdh-community-packages.txt)"]
+        VERS["versions.json"]
+    end
+
+    subgraph Pipeline
+        GEN["generate-catalog-index<br/>workflow"]
+    end
+
+    subgraph Outputs
+        IDX["catalog-index/<br/>(index.json, entities, DPDY)"]
+        OCI["OCI images<br/>(quay.io, ghcr.io)"]
+        BRANCH["catalog-index-{branch}<br/>git branch"]
+        WIKI["Wiki status page"]
+    end
+
+    META --> GEN
+    CATS --> GEN
+    PKGS --> GEN
+    VERS --> GEN
+    GEN --> IDX
+    IDX --> OCI
+    IDX --> BRANCH
+    GEN --> WIKI
+```
+
+
+
+---
+
+## Build Pipeline
+
+The pipeline runs via the `[generate-catalog-index.yaml](../.github/workflows/generate-catalog-index.yaml)` workflow, triggered on pushes to `main` and `release-*` branches when relevant files change, or manually via `workflow_dispatch`.
+
+The core orchestrator script is `[scripts/update-index.sh](../scripts/update-index.sh)`, which runs four steps in sequence:
+
+```mermaid
+flowchart TB
+    subgraph "Step 1: Bootstrap"
+        S1_IN["workspaces/{name}/metadata/{plugin}.yaml<br/>plugins-list.yaml<br/>versions.json<br/>Package list files"]
+        S1["bootstrapPluginBuilds.py"]
+        S1_OUT["plugin_builds/{ws}/{plugin}.json<br/>(workspace path, OCI ref, support level)"]
+        S1_IN --> S1 --> S1_OUT
+    end
+
+    subgraph "Step 2: Registry Enrichment"
+        S2["generatePluginBuildInfo.py"]
+        S2_OUT["plugin_builds/{ws}/{plugin}.json<br/>(+ digest, build-date, vcs-ref)"]
+        S1_OUT --> S2
+        REG["Container registries<br/>(quay.io, ghcr.io)"] --> S2
+        S2 --> S2_OUT
+    end
+
+    subgraph "Step 3: DPDY Generation"
+        S3_IN["default.packages.yaml<br/>metadata appConfigExamples"]
+        S3["generateDynamicPluginsDefaultYaml.sh<br/>+ injectDpdyTagComments.py"]
+        S3_OUT["dynamic-plugins.default.yaml"]
+        S3_IN --> S3
+        S2_OUT -- "tag & build-date<br/>for comments" --> S3
+        S3 --> S3_OUT
+    end
+
+    subgraph "Step 4: Catalog Index"
+        S4["generateCatalogIndex.py"]
+        S4_OUT["index.json<br/>catalog-entities/<br/>build-report.json"]
+        S2_OUT --> S4
+        S3_OUT -- "OCI ref updates &<br/>tag comments" --> S4
+        CATS2["catalog-entities/extensions/"] --> S4
+        S4 --> S4_OUT
+    end
+```
+
+
+
+### Step 1: Bootstrap (`bootstrapPluginBuilds.py`)
+
+Reads each `workspaces/*/metadata/*.yaml` file and constructs initial `plugin_builds/<workspace>/<image-name>.json` entries. Each entry includes the workspace path, support level, and a constructed OCI tag reference based on the registry type:
+
+- **ghcr.io**: `bs_{backstage_version}__{plugin_version}` (e.g., `bs_1.49.4__0.8.2`)
+- **quay.io/rhdh**: `{rhdh_version}--{plugin_version}` (e.g., `1.10--0.8.2`)
+
+Plugins are filtered to only those matching the provided `--packages-file` list(s).
+
+### Step 2: Registry Enrichment (`generatePluginBuildInfo.py`)
+
+Queries the container registry for each plugin's OCI image to retrieve:
+
+- **Digest** (`sha256:...`) for immutable references
+- **Build date** and **VCS ref** from container labels
+- **Upstream/midstream** repo refs from container env vars
+
+Images that don't exist in the registry are logged as warnings.
+
+### Step 3: DPDY Generation (`generateDynamicPluginsDefaultYaml.sh`)
+
+Generates `dynamic-plugins.default.yaml` — the default plugin configuration shipped with RHDH. This step only runs for the **supported** tier (requires a YAML-format packages file with enabled/disabled structure).
+
+After generating the DPDY, the script calls `injectDpdyTagComments.py` to insert `# Tag: <tag>, Build date: <date>` comments from `plugin_builds/*.json` (produced by Steps 1-2). Each plugin's `registryReference` tag and `build-date` label are extracted from the enriched JSON files and placed as comments above the corresponding `- package:` lines. This provides traceability from each plugin entry back to the specific OCI image tag and build date, without requiring live registry API calls (which previously caused Quay API timeouts).
+
+Inputs:
+
+- `default.packages.yaml` — lists which plugins are enabled vs disabled by default
+- `workspaces/*/metadata/*.yaml` — `spec.appConfigExamples[0].content` provides the `pluginConfig` for each plugin
+- `plugin_builds/*.json` — provides tag and build-date metadata for comment injection
+
+Output structure (truncated):
+
+```yaml
+plugins:
+  # Tag: 1.10--0.8.2, Build date: 2026-05-20T13:45:25Z
+  - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-adoption-insights:1.10--0.8.2
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          red-hat-developer-hub.backstage-plugin-adoption-insights:
+            # ... frontend wiring config
+  # Tag: 1.10--1.2.0, Build date: 2026-05-19T09:12:00Z
+  - package: oci://quay.io/rhdh/backstage-community-plugin-acr:1.10--1.2.0
+    disabled: true
+```
+
+### Step 4: Catalog Index (`generateCatalogIndex.py`)
+
+The final step that produces the catalog index:
+
+1. Copies `catalog-entities/extensions/` (Plugin entities, collections) to the output directory
+2. Copies `workspaces/*/metadata/*.yaml` (Package entities) to the `packages` directory of the catalog index output directory
+3. Scrubs entities to only include packages matching the package list filter
+4. Verifies each plugin's OCI image exists in the registry
+5. Generates `index.json` with digest-based references
+6. Updates Package entity files and DPDY with OCI references and Tag/Build date comments
+7. Regenerates `all.yaml` location files
+
+---
+
+## Output Artifacts
+
+The generated `catalog-index/<tier>/` directory contains:
+
+
+| File                                             | Purpose                                                                                   |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `index.json`                                     | Main index mapping plugin image names to OCI refs with digests                            |
+| `catalog-entities/extensions/packages/*.yaml`    | Package entity definitions with resolved OCI references                                   |
+| `catalog-entities/extensions/plugins/*.yaml`     | Plugin entity definitions (descriptions, icons, categories)                               |
+| `catalog-entities/extensions/collections/*.yaml` | Collection groupings (featured, recommended, etc.)                                        |
+| `dynamic-plugins.default.yaml`                   | Default plugin configuration (supported tier only)                                        |
+| `build-info.json`                                | Build metadata (date, versions, source commit)                                            |
+| `build-report.json`                              | Detailed per-plugin build status with stage tracking (not included in final OCI artifact) |
+
+
+---
+
+## Support Tiers
+
+The pipeline runs twice per build — once for each tier:
+
+### Supported Catalog
+
+Plugins with Red Hat support (GA or Tech Preview heading to GA).
+
+- **Filter**: Union of `default.packages.yaml` + `rhdh-supported-packages.txt`
+- **Registry**: `quay.io/rhdh` (plugins registry) / `quay.io/rhdh-community` (catalog index image registry)
+- **Published to**: `quay.io/rhdh-community/plugin-catalog-index`
+- **Tags**: `bs_{backstage_version}-{short_sha}`, `bs_{backstage_version}`, `latest`
+- **Includes DPDY**: Yes
+
+### Community Catalog
+
+Community-supported plugins.
+
+- **Filter**: `rhdh-community-packages.txt`
+- **Registry**: `ghcr.io/redhat-developer/rhdh-plugin-export-overlays`
+- **Published to**: `ghcr.io/redhat-developer/rhdh-plugin-export-overlays/plugin-catalog-index`
+- **Tags**: `bs_{backstage_version}-{short_sha}`, `bs_{backstage_version}`, `latest`
+- **Includes DPDY**: No
+
+---
+
+## Where to Find Status
+
+After each build, a status page is automatically pushed to the GitHub Wiki:
+
+- **Index page**: [Plugin Catalog Index Status](https://github.com/redhat-developer/rhdh-plugin-export-overlays/wiki/Plugin-Catalog-Index-Status) — links to all branch status pages
+- **Per-branch pages**: `Plugin-Catalog-Status-{branch}` — shows which plugins passed/failed and why
+
+The status page includes:
+
+- Build metadata (date, commit, versions)
+- Summary counts per tier (total, passed, failed)
+- Per-plugin tables with links to metadata files, OCI references, and failure reasons
+- Links to the workflow run for debugging failures
+
+The raw `build-report.json` files are also available on the `catalog-index-{branch}` git branch in `catalog-index/supported/build-report.json` and `catalog-index/community/build-report.json`.
+
+---
+
+## Triggering a Build
+
+### Automatic
+
+Pushes to `main` or `release-*` branches that modify any of these paths trigger the workflow:
+
+- `workspaces/*/metadata/*.yaml`
+- `catalog-entities/extensions/**`
+- `default.packages.yaml`, `rhdh-supported-packages.txt`, `rhdh-community-packages.txt`
+- `scripts/**`
+- `versions.json`
+
+### Manual
+
+```bash
+# Build from main, push to catalog-index-main
+gh workflow run generate-catalog-index.yaml
+
+# Build from a specific branch
+gh workflow run generate-catalog-index.yaml -f source-branch=release-1.9
+
+# Build from one branch, push catalog to a custom target branch
+gh workflow run generate-catalog-index.yaml \
+  -f source-branch=main \
+  -f target-branch=catalog-index-custom
+```
+

--- a/user-guide/README.md
+++ b/user-guide/README.md
@@ -12,6 +12,7 @@ This guide covers the essential workflows for using the **rhdh-plugin-export-ove
 | [04 - Metadata Synchronization](./04-metadata-synchronization.md) | Keeping source and overlay metadata in sync |
 | [05 - Version Updates](./05-version-updates.md) | Updating Backstage target/minimum versions |
 | [06 - Patch Management](./06-patch-management.md) | Creating, updating, and retiring patches |
+| [07 - Plugin Catalog Index](./07-plugin-catalog-index.md) | How the catalog index is built, published, and monitored |
 
 ---
 

--- a/user-guide/troubleshooting-catalog-index.md
+++ b/user-guide/troubleshooting-catalog-index.md
@@ -1,0 +1,51 @@
+## Troubleshooting
+
+Common issues reported on the status page and how to resolve them.
+
+### Backstage version mismatch
+
+**What it means:** The plugin's workspace targets an older Backstage minor version than the one expected by the current branch.
+
+**Common cause:** The upstream plugin repository has not yet released a version compatible with the latest Backstage version, or the workspace's `source.json` `repo-ref` points to an older tag.
+
+**What to do:**
+
+1. Check if a newer tag or commit exists in the upstream repo that supports the required Backstage version.
+2. If a workspace update PR exists in the overlays, try commenting `/update-commit` to pull the latest compatible ref.
+3. If no compatible version exists upstream, add a `backstage.json` override in the workspace to pin the version.
+
+### Plugin marked as outdated
+
+**What it means:** The exact requested image tag couldn't be found. Instead the latest published tag for the same Backstage/RHDH version line is being used as a fallback. The plugin is still included in the catalog index rather than being removed entirely.
+
+**When this happens:**
+
+- The plugin version in metadata was bumped (e.g., `1.2.0` → `1.3.0`) but the export/publish workflow hasn't run yet for the new plugin version.
+- For example:
+  - The requested tag is `bs_1.49.4__1.3.0` but only `bs_1.49.4__1.2.0` is published — the older tag is used.
+  - The requested tag is `1.11-0.5.2` but only `1.11-0.4.6` and `1.11-0.4.5` are published, then `1.11-0.4.6` is used.
+
+**What to do:**
+
+1. Check whether the publish workflow has run successfully for this plugin.
+2. Trigger the export/publish workflow for the plugin to publish the plugin with the updated tag.
+
+If this fallback also fails (no older tag exists), the plugin will instead appear as [Image not found in registry](#image-not-found-in-registry).
+
+### Image not found in registry
+
+**What it means:** No OCI image exists in the container registry for *any* tag matching the plugin's Backstage or RHDH version. The pipeline has no image to use — not even an older one to fall back to (see [Outdated](#plugin-marked-as-outdated)) — so the plugin is excluded from the catalog index entirely.
+
+**When this happens:**
+
+- A plugin is newly onboarded for the specified backstage/RHDH version and the export/publish workflow has never run for it yet.
+- For example, a plugin may have been updated from `bs_1.45.3` to `bs_1.49.4` and now expects `bs_1.49.4__1.2.0` and it might not have been published yet as no `bs_1.49.4_*` tags exist yet. Even if a tag like `bs_1.45.3__1.1.1` exists, it will not be considered for the fallback.
+
+**What to do:**
+
+1. Check whether the publish workflow has run successfully for this plugin.
+2. Trigger the export/publish workflow for the plugin to publish the plugin with the updated tag.
+
+### Image not found during catalog index generation
+
+> **Note:** This is the same "Image not found" error as above, but detected during the final Catalog Index Generation step rather than during Image Metadata Fetch. It serves as a redundancy check which normally should never happen— if you see this, the image was likely deleted or became unavailable after the metadata fetch stage. Re-run the workflow to see if this persists, as it may be a transient registry issue. The resolution steps are the same as [Image not found in registry](#image-not-found-in-registry).


### PR DESCRIPTION
### Description

Cherrypicks the following into `release-1.10`
- https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2431
- https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2570
- https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2565
- https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2547
- https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2509