### PR TITLE
fix: collect and report E2E plugin coverage end-to-end

### DIFF
--- a/scripts/instrument-plugin.sh
+++ b/scripts/instrument-plugin.sh
@@ -40,6 +40,19 @@ echo ""
 INSTRUMENTED_COUNT=0
 SKIPPED_COUNT=0
 
+# Count *.js files under $2 whose contents match grep pattern $1. The `|| true`
+# keeps a no-match grep (exit 1) from tripping set -e / pipefail.
+count_files_matching() {
+  { grep -rl "$1" "$2" --include="*.js" 2>/dev/null || true; } | wc -l | tr -d ' '
+}
+
+# Drop the current plugin's work dir and count it as skipped. Only call this
+# after WORK_DIR has been created for the current iteration.
+cleanup_and_skip() {
+  rm -rf "$WORK_DIR"
+  SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+}
+
 # Process each published image (format: plain image refs, one per line)
 while IFS= read -r PROD_IMAGE; do
   [[ -z "$PROD_IMAGE" ]] && continue
@@ -148,17 +161,19 @@ while IFS= read -r PROD_IMAGE; do
     # Fix NYC's global access pattern for modern browsers.
     # NYC emits `new Function("return this")()`, which RHDH's CSP (no unsafe-eval)
     # blocks — leaving coverage uncollected. Replace it with `globalThis`.
+    # `|| true` so a single sed failure doesn't abort the whole job (set -e); the
+    # UNFIXED_COUNT check below still catches any file the fix missed.
     find "$WORK_DIR/inst-$BUNDLE" -name "*.js" -type f -exec sed -i \
-      's/var global=new Function("return this")();/var global=globalThis;/g' {} \;
+      's/var global=new Function("return this")();/var global=globalThis;/g' {} \; || true
 
     # Loudly flag any file where the global-scope fix did not apply: a silent miss
     # means coverage runs but never reaches window.__coverage__.
-    UNFIXED_COUNT=$({ grep -rl 'new Function("return this")' "$WORK_DIR/inst-$BUNDLE/" --include="*.js" 2>/dev/null || true; } | wc -l | tr -d ' ')
+    UNFIXED_COUNT=$(count_files_matching 'new Function("return this")' "$WORK_DIR/inst-$BUNDLE")
     if [[ "$UNFIXED_COUNT" -ne 0 ]]; then
       echo "  ⚠️  $UNFIXED_COUNT file(s) in $BUNDLE/ still use new Function(\"return this\") after the fix"
     fi
 
-    BUNDLE_JS_COUNT=$({ grep -rl "__coverage__" "$WORK_DIR/inst-$BUNDLE/" --include="*.js" 2>/dev/null || true; } | wc -l | tr -d ' ')
+    BUNDLE_JS_COUNT=$(count_files_matching "__coverage__" "$WORK_DIR/inst-$BUNDLE")
     if [[ "$BUNDLE_JS_COUNT" -eq 0 ]]; then
       echo "  ❌ No __coverage__ found in instrumented $BUNDLE/ - skipping that bundle"
       continue
@@ -174,8 +189,7 @@ while IFS= read -r PROD_IMAGE; do
 
   if [[ "$TOTAL_JS_COUNT" -eq 0 ]]; then
     echo "  ❌ No bundles could be instrumented - skipping"
-    rm -rf "$WORK_DIR"
-    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    cleanup_and_skip
     continue
   fi
   echo "  ✓ Instrumented $TOTAL_JS_COUNT JS files total"
@@ -202,8 +216,7 @@ while IFS= read -r PROD_IMAGE; do
   # the instrumentation that actually reaches the browser.
   if ! podman build --squash-all -t "$COVERAGE_IMAGE" -f "$WORK_DIR/Containerfile" "$WORK_DIR"; then
     echo "  ❌ Failed to build coverage image - skipping"
-    rm -rf "$WORK_DIR"
-    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    cleanup_and_skip
     continue
   fi
 
@@ -214,8 +227,7 @@ while IFS= read -r PROD_IMAGE; do
   LAYER_COUNT=$(podman inspect "$COVERAGE_IMAGE" --format '{{len .RootFS.Layers}}' 2>/dev/null || echo "?")
   if [[ "$LAYER_COUNT" != "1" ]]; then
     echo "  ❌ Coverage image has $LAYER_COUNT layers (expected 1); RHDH only reads layers[0] so coverage would not load - refusing to push"
-    rm -rf "$WORK_DIR"
-    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    cleanup_and_skip
     continue
   fi
   echo "  ✓ Coverage image squashed to a single layer"
@@ -223,8 +235,7 @@ while IFS= read -r PROD_IMAGE; do
   # Push coverage image
   if ! podman push "$COVERAGE_IMAGE"; then
     echo "  ❌ Failed to push coverage image"
-    rm -rf "$WORK_DIR"
-    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    cleanup_and_skip
     continue
   fi
 

--- a/scripts/instrument-plugin.sh
+++ b/scripts/instrument-plugin.sh
@@ -82,10 +82,12 @@ while IFS= read -r PROD_IMAGE; do
 
   PLUGIN_PATH=""
   if [[ -n "$PACKAGES_LABEL" && "$PACKAGES_LABEL" != "<no value>" ]]; then
-    # Decode base64 and extract first plugin name
-    # Expected JSON: [{"name":"backstage-community-plugin-acs","version":"0.2.0",...}]
-    # The "name" field is the directory path inside the container
-    PLUGIN_PATH=$(echo "$PACKAGES_LABEL" | base64 -d 2>/dev/null | jq -r '.[0].name // empty' 2>/dev/null || echo "")
+    # Decode base64 and extract the plugin directory path inside the container.
+    # Actual JSON shape: [{"<dir-name>": {"name":"@scope/pkg-dynamic","version":...}}]
+    # The directory path is the OBJECT KEY, not a "name" field. (An older `.[0].name`
+    # read returned empty and only worked because of the metadata fallback below.)
+    # Fall back to `.[0].name` for any legacy flat-shaped labels.
+    PLUGIN_PATH=$(echo "$PACKAGES_LABEL" | base64 -d 2>/dev/null | jq -r '.[0] as $p | (if ($p.name | type) == "string" then $p.name else ($p | keys[0]) end) // empty' 2>/dev/null || echo "")
     if [[ -n "$PLUGIN_PATH" ]]; then
       echo "  Plugin path (from OCI label): $PLUGIN_PATH"
     fi
@@ -113,46 +115,74 @@ while IFS= read -r PROD_IMAGE; do
     continue
   fi
 
-  # Create temp container and extract plugin bundle
+  # Create temp container to extract the plugin bundle(s)
   WORK_DIR=$(mktemp -d)
   # Plugin images are static bundles with no CMD/ENTRYPOINT, so we provide a dummy command
   CID=$(podman create "$PROD_IMAGE" /bin/true)
 
-  if ! podman cp "$CID:$PLUGIN_PATH/dist" "$WORK_DIR/dist-original"; then
-    echo "  ❌ Failed to extract plugin bundle from container - skipping"
-    podman rm "$CID" || true
-    rm -rf "$WORK_DIR"
-    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
-    continue
-  fi
+  # RHDH ships up to two frontend bundles per plugin and which one it actually
+  # serves/executes at runtime depends on the deployment: the Module Federation
+  # bundle (`dist/`) for the new frontend system and the Scalprum bundle
+  # (`dist-scalprum/`) for the legacy loader. Instrumenting only `dist/` leaves
+  # `window.__coverage__` undefined whenever the browser runs the Scalprum bundle,
+  # so we instrument every bundle that exists and overlay them all.
+  BUNDLE_DIRS=(dist dist-scalprum)
+  COPY_LINES=""
+  TOTAL_JS_COUNT=0
+
+  for BUNDLE in "${BUNDLE_DIRS[@]}"; do
+    # Not every plugin ships every bundle; quietly skip the absent ones.
+    if ! podman cp "$CID:$PLUGIN_PATH/$BUNDLE" "$WORK_DIR/orig-$BUNDLE" 2>/dev/null; then
+      echo "  No $BUNDLE/ in image - skipping that bundle"
+      continue
+    fi
+
+    # Instrument with nyc (pinned version for reproducibility).
+    # Must run from work directory to avoid "outside project root" errors.
+    echo "  Instrumenting $BUNDLE/ with Istanbul/nyc..."
+    if ! (cd "$WORK_DIR" && npx --yes nyc@18.0.0 instrument "orig-$BUNDLE" "inst-$BUNDLE" --source-map); then
+      echo "  ❌ Instrumentation of $BUNDLE/ failed - skipping that bundle"
+      continue
+    fi
+
+    # Fix NYC's global access pattern for modern browsers.
+    # NYC emits `new Function("return this")()`, which RHDH's CSP (no unsafe-eval)
+    # blocks — leaving coverage uncollected. Replace it with `globalThis`.
+    find "$WORK_DIR/inst-$BUNDLE" -name "*.js" -type f -exec sed -i \
+      's/var global=new Function("return this")();/var global=globalThis;/g' {} \;
+
+    # Loudly flag any file where the global-scope fix did not apply: a silent miss
+    # means coverage runs but never reaches window.__coverage__.
+    UNFIXED_COUNT=$({ grep -rl 'new Function("return this")' "$WORK_DIR/inst-$BUNDLE/" --include="*.js" 2>/dev/null || true; } | wc -l | tr -d ' ')
+    if [[ "$UNFIXED_COUNT" -ne 0 ]]; then
+      echo "  ⚠️  $UNFIXED_COUNT file(s) in $BUNDLE/ still use new Function(\"return this\") after the fix"
+    fi
+
+    BUNDLE_JS_COUNT=$({ grep -rl "__coverage__" "$WORK_DIR/inst-$BUNDLE/" --include="*.js" 2>/dev/null || true; } | wc -l | tr -d ' ')
+    if [[ "$BUNDLE_JS_COUNT" -eq 0 ]]; then
+      echo "  ❌ No __coverage__ found in instrumented $BUNDLE/ - skipping that bundle"
+      continue
+    fi
+    echo "  ✓ Instrumented $BUNDLE_JS_COUNT JS files in $BUNDLE/"
+    TOTAL_JS_COUNT=$((TOTAL_JS_COUNT + BUNDLE_JS_COUNT))
+    COPY_LINES+="COPY inst-$BUNDLE/ $PLUGIN_PATH/$BUNDLE/"$'\n'
+  done
 
   podman rm "$CID"
 
-  # Instrument with nyc (pinned version for reproducibility)
-  # Must run from work directory to avoid "outside project root" errors
-  echo "  Instrumenting with Istanbul/nyc..."
-  if ! (cd "$WORK_DIR" && npx --yes nyc@18.0.0 instrument dist-original dist-instrumented --source-map); then
-    echo "  ❌ Instrumentation failed - skipping"
+  if [[ "$TOTAL_JS_COUNT" -eq 0 ]]; then
+    echo "  ❌ No bundles could be instrumented - skipping"
     rm -rf "$WORK_DIR"
     SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
     continue
   fi
+  echo "  ✓ Instrumented $TOTAL_JS_COUNT JS files total"
 
-  # Verify instrumentation
-  JS_COUNT=$(grep -r "__coverage__" "$WORK_DIR/dist-instrumented/" --include="*.js" -l 2>/dev/null | wc -l | tr -d ' ')
-  if [[ "$JS_COUNT" -eq 0 ]]; then
-    echo "  ❌ No __coverage__ found in instrumented files - skipping"
-    rm -rf "$WORK_DIR"
-    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
-    continue
-  fi
-  echo "  ✓ Instrumented $JS_COUNT JS files"
-
-  # Build coverage image (copy instrumented files over production image)
-  cat > "$WORK_DIR/Containerfile" <<EOF
-FROM $PROD_IMAGE
-COPY dist-instrumented/ $PLUGIN_PATH/dist/
-EOF
+  # Build coverage image (overlay every instrumented bundle over the production image)
+  {
+    echo "FROM $PROD_IMAGE"
+    printf '%s' "$COPY_LINES"
+  } > "$WORK_DIR/Containerfile"
 
   # Generate coverage image tag: append __coverage suffix to tag
   # Example: plugin:pr_123__1.2.3 → plugin:pr_123__1.2.3__coverage
@@ -160,11 +190,28 @@ EOF
   IMAGE_TAG="${PROD_IMAGE##*:}"
   COVERAGE_IMAGE="${IMAGE_BASE}:${IMAGE_TAG}__coverage"
 
-  if ! podman build -t "$COVERAGE_IMAGE" -f "$WORK_DIR/Containerfile" "$WORK_DIR"; then
+  # CRITICAL: --squash-all flattens the result into a SINGLE layer.
+  # RHDH's install-dynamic-plugins (image-cache.ts: downloadAndLocateTarball)
+  # only ever extracts manifest.layers[0] — it assumes dynamic-plugin images are
+  # single-layer. A plain `FROM prod + COPY` produces a multi-layer image whose
+  # FIRST layer is the original (uninstrumented) base, so RHDH would serve the
+  # original code and ignore our instrumented overlay layers. Squashing merges
+  # the overlays into one layer (instrumented files win), so layers[0] carries
+  # the instrumentation that actually reaches the browser.
+  if ! podman build --squash-all -t "$COVERAGE_IMAGE" -f "$WORK_DIR/Containerfile" "$WORK_DIR"; then
     echo "  ❌ Failed to build coverage image - skipping"
     rm -rf "$WORK_DIR"
     SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
     continue
+  fi
+
+  # Verify the image is single-layer so RHDH's layers[0]-only extraction sees
+  # the instrumented filesystem. Warn loudly if squashing did not collapse it.
+  LAYER_COUNT=$(podman inspect "$COVERAGE_IMAGE" --format '{{len .RootFS.Layers}}' 2>/dev/null || echo "?")
+  if [[ "$LAYER_COUNT" != "1" ]]; then
+    echo "  ⚠️  Coverage image has $LAYER_COUNT layers (expected 1) — RHDH only reads layers[0], coverage may not load"
+  else
+    echo "  ✓ Coverage image squashed to a single layer"
   fi
 
   # Push coverage image

--- a/scripts/instrument-plugin.sh
+++ b/scripts/instrument-plugin.sh
@@ -168,7 +168,9 @@ while IFS= read -r PROD_IMAGE; do
     COPY_LINES+="COPY inst-$BUNDLE/ $PLUGIN_PATH/$BUNDLE/"$'\n'
   done
 
-  podman rm "$CID"
+  # `|| true` so a podman hiccup removing the throwaway container never aborts
+  # the whole job (set -e) and loses instrumentation for the remaining plugins.
+  podman rm "$CID" || true
 
   if [[ "$TOTAL_JS_COUNT" -eq 0 ]]; then
     echo "  ❌ No bundles could be instrumented - skipping"
@@ -205,14 +207,18 @@ while IFS= read -r PROD_IMAGE; do
     continue
   fi
 
-  # Verify the image is single-layer so RHDH's layers[0]-only extraction sees
-  # the instrumented filesystem. Warn loudly if squashing did not collapse it.
+  # Verify the image is single-layer so RHDH's layers[0]-only extraction sees the
+  # instrumented filesystem. Refuse to push a multi-layer image: it would deploy
+  # and run fine but silently serve the ORIGINAL (uninstrumented) base layer —
+  # exactly the failure mode this script exists to avoid — so fail loudly instead.
   LAYER_COUNT=$(podman inspect "$COVERAGE_IMAGE" --format '{{len .RootFS.Layers}}' 2>/dev/null || echo "?")
   if [[ "$LAYER_COUNT" != "1" ]]; then
-    echo "  ⚠️  Coverage image has $LAYER_COUNT layers (expected 1) — RHDH only reads layers[0], coverage may not load"
-  else
-    echo "  ✓ Coverage image squashed to a single layer"
+    echo "  ❌ Coverage image has $LAYER_COUNT layers (expected 1); RHDH only reads layers[0] so coverage would not load - refusing to push"
+    rm -rf "$WORK_DIR"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    continue
   fi
+  echo "  ✓ Coverage image squashed to a single layer"
 
   # Push coverage image
   if ! podman push "$COVERAGE_IMAGE"; then

--- a/scripts/remap-coverage.cjs
+++ b/scripts/remap-coverage.cjs
@@ -22,7 +22,7 @@
 // Requires istanbul-lib-coverage, istanbul-lib-source-maps, istanbul-lib-report,
 // istanbul-reports to be resolvable (installed by report-coverage.sh).
 
-const fs = require("fs");
+const fs = require("node:fs");
 const libCoverage = require("istanbul-lib-coverage");
 const libSourceMaps = require("istanbul-lib-source-maps");
 const libReport = require("istanbul-lib-report");
@@ -69,7 +69,7 @@ function normalizeSourcePath(file) {
   for (const file of sourceMap.files()) {
     const path = normalizeSourcePath(file);
     if (!path) continue;
-    const data = JSON.parse(JSON.stringify(sourceMap.fileCoverageFor(file).data));
+    const data = structuredClone(sourceMap.fileCoverageFor(file).data);
     data.path = path;
     normalized.addFileCoverage(data);
   }

--- a/scripts/remap-coverage.cjs
+++ b/scripts/remap-coverage.cjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // Remap browser E2E coverage from instrumented plugin BUNDLES back to the
 // original plugin SOURCE, then emit lcov + a text summary.
@@ -61,17 +60,29 @@ function normalizeSourcePath(file) {
   const transformed = await store.transformCoverage(
     libCoverage.createCoverageMap(raw),
   );
-  const sourceMap = transformed.map || transformed;
+  const remappedCoverage = transformed.map || transformed;
 
   // Re-key onto normalized source paths. addFileCoverage merges by location, so
   // the same source covered by both the MF and Scalprum builds combines safely.
   const normalized = libCoverage.createCoverageMap({});
-  for (const file of sourceMap.files()) {
+  for (const file of remappedCoverage.files()) {
     const path = normalizeSourcePath(file);
     if (!path) continue;
-    const data = structuredClone(sourceMap.fileCoverageFor(file).data);
+    const data = structuredClone(remappedCoverage.fileCoverageFor(file).data);
     data.path = path;
     normalized.addFileCoverage(data);
+  }
+
+  // Fail loudly (and let report-coverage.sh skip the upload) rather than write an
+  // empty lcov: zero source files means the source maps or path normalization
+  // broke, and silently uploading nothing is the failure mode this whole pipeline
+  // exists to avoid.
+  if (normalized.files().length === 0) {
+    console.error(
+      "[remap] no source files after remap — coverage is empty. " +
+        "Check that the bundles were instrumented with --source-map.",
+    );
+    process.exit(1);
   }
 
   fs.mkdirSync(reportDir, { recursive: true });
@@ -90,12 +101,6 @@ function normalizeSourcePath(file) {
   console.log(
     `[remap] ${normalized.files().length} source file(s), lines ${lines.covered}/${lines.total} (${lines.pct}%)`,
   );
-  if (normalized.files().length === 0) {
-    console.log(
-      "[remap] WARNING: no source files after remap — coverage will be empty. " +
-        "Check that bundles were instrumented with --source-map.",
-    );
-  }
 })().catch((err) => {
   console.error("[remap] failed:", err && err.stack ? err.stack : err);
   process.exit(1);

--- a/scripts/remap-coverage.cjs
+++ b/scripts/remap-coverage.cjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+//
+// Remap browser E2E coverage from instrumented plugin BUNDLES back to the
+// original plugin SOURCE, then emit lcov + a text summary.
+//
+// Why this exists:
+//   scripts/instrument-plugin.sh instruments the already-built plugin bundles
+//   (`dist/` and `dist-scalprum/`) with nyc, so the coverage collected in the
+//   browser is keyed by bundle paths that only existed in the publish job's temp
+//   dir (e.g. `/tmp/tmp.XXXX/orig-dist/static/foo.chunk.js`). `nyc report` cannot
+//   resolve those paths on the test runner and reports 0/0.
+//
+//   nyc instruments with `--source-map`, so every coverage entry carries an
+//   embedded `inputSourceMap` (with `sourcesContent`). This script applies those
+//   maps to remap coverage onto the original source files, normalizes the
+//   `webpack://<remote>/...` paths to repo-relative ones (e.g. `src/foo.tsx`),
+//   drops node_modules and bundler runtime, and writes lcov for Codecov.
+//
+// Usage:
+//   node scripts/remap-coverage.cjs <nyc-output-json> [report-dir]
+//
+// Requires istanbul-lib-coverage, istanbul-lib-source-maps, istanbul-lib-report,
+// istanbul-reports to be resolvable (installed by report-coverage.sh).
+
+const fs = require("fs");
+const libCoverage = require("istanbul-lib-coverage");
+const libSourceMaps = require("istanbul-lib-source-maps");
+const libReport = require("istanbul-lib-report");
+const reports = require("istanbul-reports");
+
+const inputJson = process.argv[2];
+const reportDir = process.argv[3] || "coverage";
+
+if (!inputJson) {
+  console.error("Usage: remap-coverage.cjs <nyc-output-json> [report-dir]");
+  process.exit(1);
+}
+
+// Turn a remapped source identifier into a clean repo-relative path, or null if
+// it is not real plugin source (node_modules, webpack/MF runtime, synthetic).
+function normalizeSourcePath(file) {
+  if (/node_modules/.test(file)) return null;
+
+  // Strip everything up to and including the `webpack:/<remote>/` scheme that
+  // istanbul prepends, leaving e.g. `src/foo.tsx` or `tech-radar-common/src/x.ts`.
+  const stripped = file.replace(/^.*?webpack:\/+[^/]+\//, "");
+  if (stripped === file) return null; // no source-map origin → not real source
+
+  // Drop webpack/module-federation runtime modules and anything that is not a
+  // source file (synthetic entries like `==void 0`, css, etc.).
+  if (/^(webpack|module_federation)\//.test(stripped)) return null;
+  if (!/\.[cm]?[jt]sx?$/.test(stripped)) return null;
+
+  // `../tech-radar-common/src/x.ts` → `tech-radar-common/src/x.ts`
+  return stripped.replace(/^(\.\.\/)+/, "");
+}
+
+(async () => {
+  const raw = JSON.parse(fs.readFileSync(inputJson, "utf8"));
+  const store = libSourceMaps.createSourceMapStore();
+  const transformed = await store.transformCoverage(
+    libCoverage.createCoverageMap(raw),
+  );
+  const sourceMap = transformed.map || transformed;
+
+  // Re-key onto normalized source paths. addFileCoverage merges by location, so
+  // the same source covered by both the MF and Scalprum builds combines safely.
+  const normalized = libCoverage.createCoverageMap({});
+  for (const file of sourceMap.files()) {
+    const path = normalizeSourcePath(file);
+    if (!path) continue;
+    const data = JSON.parse(JSON.stringify(sourceMap.fileCoverageFor(file).data));
+    data.path = path;
+    normalized.addFileCoverage(data);
+  }
+
+  fs.mkdirSync(reportDir, { recursive: true });
+  const context = libReport.createContext({
+    dir: reportDir,
+    coverageMap: normalized,
+  });
+  reports.create("lcovonly").execute(context);
+  reports.create("text-summary").execute(context);
+
+  const summary = libCoverage.createCoverageSummary();
+  normalized.files().forEach((f) =>
+    summary.merge(normalized.fileCoverageFor(f).toSummary()),
+  );
+  const lines = summary.data.lines;
+  console.log(
+    `[remap] ${normalized.files().length} source file(s), lines ${lines.covered}/${lines.total} (${lines.pct}%)`,
+  );
+  if (normalized.files().length === 0) {
+    console.log(
+      "[remap] WARNING: no source files after remap — coverage will be empty. " +
+        "Check that bundles were instrumented with --source-map.",
+    );
+  }
+})().catch((err) => {
+  console.error("[remap] failed:", err && err.stack ? err.stack : err);
+  process.exit(1);
+});

--- a/scripts/remap-coverage.cjs
+++ b/scripts/remap-coverage.cjs
@@ -102,6 +102,6 @@ function normalizeSourcePath(file) {
     `[remap] ${normalized.files().length} source file(s), lines ${lines.covered}/${lines.total} (${lines.pct}%)`,
   );
 })().catch((err) => {
-  console.error("[remap] failed:", err && err.stack ? err.stack : err);
+  console.error("[remap] failed:", err?.stack ? err.stack : err);
   process.exit(1);
 });

--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -40,7 +40,33 @@ echo ""
 echo "[INFO] Merging coverage data with nyc..."
 mkdir -p "$REPO_ROOT/.nyc_output"
 npx nyc@18.0.0 merge "$REPO_ROOT/$COVERAGE_JSON_DIR" "$REPO_ROOT/.nyc_output/out.json"
-(cd "$REPO_ROOT" && npx nyc@18.0.0 report --reporter=lcov --reporter=text-summary --report-dir coverage)
+
+# Remap bundle coverage back to source and emit lcov.
+#
+# Plugins are instrumented post-build (on the `dist/` and `dist-scalprum/`
+# bundles), so the collected coverage is keyed by bundle paths that only existed
+# in the publish job's temp dir. `nyc report` cannot resolve those paths here and
+# would report 0/0. remap-coverage.cjs applies the source maps nyc embedded
+# (`--source-map`) to map coverage onto the original source files and write lcov.
+#
+# The istanbul libraries are installed into a throwaway prefix so they never land
+# in the repo or a workspace's node_modules.
+echo "[INFO] Remapping bundle coverage to source and generating lcov..."
+REMAP_DEPS_DIR=$(mktemp -d)
+if npm install --prefix "$REMAP_DEPS_DIR" --no-save --no-audit --no-fund --loglevel=error \
+    istanbul-lib-coverage@3.2.2 \
+    istanbul-lib-source-maps@5.0.6 \
+    istanbul-lib-report@3.0.1 \
+    istanbul-reports@3.2.0 \
+  && (cd "$REPO_ROOT" && NODE_PATH="$REMAP_DEPS_DIR/node_modules" \
+      node "$SCRIPT_DIR/remap-coverage.cjs" "$REPO_ROOT/.nyc_output/out.json" coverage); then
+  :
+else
+  echo "[WARN] Coverage remap/report failed (non-fatal); skipping upload" >&2
+  rm -rf "$REMAP_DEPS_DIR"
+  exit 0
+fi
+rm -rf "$REMAP_DEPS_DIR"
 
 if [[ ${#WORKSPACES[@]} -gt 1 ]]; then
   echo "[WARN] Multi-workspace coverage upload is not supported." >&2

--- a/scripts/report-coverage.sh
+++ b/scripts/report-coverage.sh
@@ -50,18 +50,17 @@ npx nyc@18.0.0 merge "$REPO_ROOT/$COVERAGE_JSON_DIR" "$REPO_ROOT/.nyc_output/out
 # (`--source-map`) to map coverage onto the original source files and write lcov.
 #
 # The istanbul libraries are installed into a throwaway prefix so they never land
-# in the repo or a workspace's node_modules.
+# in the repo or a workspace's node_modules. Keep these pins in sync with the
+# istanbul API that remap-coverage.cjs relies on.
 echo "[INFO] Remapping bundle coverage to source and generating lcov..."
 REMAP_DEPS_DIR=$(mktemp -d)
-if npm install --prefix "$REMAP_DEPS_DIR" --no-save --no-audit --no-fund --loglevel=error \
+if ! { npm install --prefix "$REMAP_DEPS_DIR" --no-save --no-audit --no-fund --loglevel=error \
     istanbul-lib-coverage@3.2.2 \
     istanbul-lib-source-maps@5.0.6 \
     istanbul-lib-report@3.0.1 \
     istanbul-reports@3.2.0 \
   && (cd "$REPO_ROOT" && NODE_PATH="$REMAP_DEPS_DIR/node_modules" \
-      node "$SCRIPT_DIR/remap-coverage.cjs" "$REPO_ROOT/.nyc_output/out.json" coverage); then
-  :
-else
+      node "$SCRIPT_DIR/remap-coverage.cjs" "$REPO_ROOT/.nyc_output/out.json" coverage); }; then
   echo "[WARN] Coverage remap/report failed (non-fatal); skipping upload" >&2
   rm -rf "$REMAP_DEPS_DIR"
   exit 0


### PR DESCRIPTION
Makes E2E coverage for dynamic plugins actually work: instrumentation now reaches the browser, and the collected coverage is remapped back to source so the generated lcov is meaningful.

## Problems fixed

### 1. `__coverage__` was always undefined (instrumentation never reached the browser)
RHDH's `install-dynamic-plugins` ([`image-cache.ts` → `downloadAndLocateTarball`](https://github.com/redhat-developer/rhdh/blob/main/scripts/install-dynamic-plugins/src/image-cache.ts)) extracts **only `manifest.layers[0]`** — it assumes dynamic-plugin OCI images are single-layer (the code comment says *"keeps each OCI image's single-layer tarball"*).

`instrument-plugin.sh` built the coverage image with `FROM prod + COPY`, producing a **multi-layer** image whose **first layer is the original, uninstrumented base**. RHDH read layer 0 and served original code; the instrumented overlay layers were silently ignored. Confirmed by pulling the deployed image: its `dist-scalprum` bundle was 290 KB (instrumented), but the browser was served the byte-identical 24 KB original.

### 2. Coverage report was always `0/0` (no source remap)
Plugins are instrumented post-build on the bundles, so coverage is keyed by bundle paths that only existed in the publish job's temp dir. `nyc report` can't resolve them on the test runner → `0/0`, empty lcov — even though real coverage was collected.

## Fix

`scripts/instrument-plugin.sh`:
1. **Build single-layer** — `podman build --squash-all` + a single-layer assertion (refuses to push a multi-layer image), so `layers[0]` carries the instrumentation RHDH actually extracts.
2. **Instrument both `dist/` and `dist-scalprum/`** — both are executed depending on the deployment (new MF frontend vs legacy Scalprum), so both need instrumenting.
3. **Fix the OCI `io.backstage.dynamic-packages` label parse** — the directory path is the object key, not a top-level `name` field.
4. Harden container cleanup (`podman rm || true`) so a hiccup can't abort the whole job.

`scripts/report-coverage.sh` + `scripts/remap-coverage.cjs` (new):
5. **Remap bundle coverage to source** — apply the embedded source maps (nyc `--source-map`) to map coverage onto the original `src/*.tsx` files, normalize `webpack://` paths to repo-relative, drop node_modules/runtime, and emit source-level lcov instead of `nyc report`.

## Verification

End-to-end on a `/publish` + E2E run for `tech-radar`:
```
[coverage-probe] instrumented=true __coverage__=true bytes=290957  (was 24008, instrumented=false)
    globalThis.__coverage__: FOUND (8 files)
[_coverageCollector] Coverage result: 8 files → merged into .nyc_output/out.json
```
Deployed coverage image manifest: **1 layer**, `io.backstage.dynamic-packages` annotation preserved.

Remap validated against that run's merged coverage: **24 source files, 86.93% lines (193/222)**, clean `SF:src/...` paths that Codecov matches against the upstream source repo by suffix.

> Note: the Codecov upload still requires `CODECOV_TOKEN` to be configured in the OpenShift CI (Prow) job environment (in `openshift/release`) — that is infrastructure config outside this repo and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)