### PR TITLE
chore(tech-radar): bump e2e-test-utils to 2.1.0 to enable E2E coverage

### DIFF
--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.45",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.45":
-  version: 1.1.45
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
+  checksum: 10/060567ca547c612d4565dad005d8ddd63faad941db1df5362ad598b5827eeac9e937cbacb8c26f62f59b7b1479e6b3614e29afd9bdf95832ebd1691d77f198e6
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.45"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
Bumps the tech-radar e2e-tests from `@red-hat-developer-hub/e2e-test-utils@1.1.45` to `2.1.0` (latest) — the consumer half of E2E coverage collection.

## Why

2.1.0 ships the coverage support the pipeline needs:
- the `_coverageCollector` fixture that reads `window.__coverage__` after each test and writes per-test JSON
- the automatic swap to `__coverage` plugin images when `E2E_COLLECT_COVERAGE=true` and the plugin is a frontend plugin

The instrumentation half (single-layer `__coverage` images + source-remapped lcov) landed on main in #2574. With this bump, tech-radar's PR-check e2e run actually collects coverage and `report-coverage.sh` produces a real lcov instead of nothing.

## Scope

Pilot only. The PR-check job (`e2e-ocp-helm`) runs the changed workspace alone, so tech-radar can move to 2.1.0 independently. The fleet-wide bump — required for the nightly all-in-one `run-e2e.sh`, which needs a single hoisted `e2e-test-utils` across all workspaces — is a separate migration.

## Validation

- Peer `@playwright/test ^1.57.0` met by the pinned `1.59.1`
- `tsc:check`, `lint:check`, `prettier:check` all pass on 2.1.0
- `yarn install --immutable` confirms the lockfile is consistent (CI-safe)
- The remaining peer warnings are deep transitive ones inside e2e-test-utils' own tree (`plugin-rbac-common`, `@axe-core/playwright`) — not used by these tests

## Not included (tracked separately)

Codecov upload still needs `CODECOV_TOKEN` in the OpenShift CI (Prow) job environment via `openshift/release` — infra config outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)