### PR TITLE
chore: accept VAULT_CODECOV_TOKEN fallback for Codecov upload

### DIFF
--- a/scripts/upload-coverage.sh
+++ b/scripts/upload-coverage.sh
@@ -13,9 +13,16 @@
 # then uploads the lcov coverage to Codecov attributed to that repo.
 #
 # Required environment:
-#   CODECOV_TOKEN  - Codecov upload token (org-level for cross-repo uploads)
+#   CODECOV_TOKEN  - Codecov upload token (org-level for cross-repo uploads).
+#                    Falls back to VAULT_CODECOV_TOKEN (see below).
 
 set -euo pipefail
+
+# OpenShift CI auto-exports Vault secret keys prefixed with VAULT_ (the
+# rhdh-plugin-export-overlays ocp-helm step mounts the test-credentials secret
+# and exports every VAULT_* key). Accept VAULT_CODECOV_TOKEN as a fallback so the
+# token only has to be added to that Vault secret — no openshift/release change.
+: "${CODECOV_TOKEN:=${VAULT_CODECOV_TOKEN:-}}"
 
 readonly AWK_FIRST_FIELD='{print $1}'
 


### PR DESCRIPTION
Wires up the Codecov upload token with no `openshift/release` change required.

## Context

`upload-coverage.sh` skips the upload when `CODECOV_TOKEN` is unset — which is why E2E coverage is generated but never uploaded today.

The OpenShift CI e2e step (`ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm`) already mounts the `rhdh-plugin-export-overlays` Vault secret (namespace `test-credentials`) at `/tmp/secrets` and auto-exports every key prefixed with `VAULT_` as an env var — the same mechanism already used for `VAULT_GITHUB_TEST_REPORTER_TOKEN`.

## Change

`upload-coverage.sh` now falls back to `VAULT_CODECOV_TOKEN` when `CODECOV_TOKEN` isn't already set:

```bash
: "${CODECOV_TOKEN:=${VAULT_CODECOV_TOKEN:-}}"
```

A directly-set `CODECOV_TOKEN` still wins (local dev). Verified: neither set -> empty (upload skipped as before); only `VAULT_CODECOV_TOKEN` set -> used; both set -> direct value wins.

## Remaining action (infra, one-time)

Add a `VAULT_CODECOV_TOKEN` key (value = a Codecov org-level upload token) to the `rhdh-plugin-export-overlays` secret in the CI Vault that syncs to `test-credentials`. After that, the e2e job uploads coverage to Codecov (attributed to each plugin's upstream source repo, flag `e2e-<workspace>`). No change to `openshift/release` is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)