### PR TITLE
feat: only upload E2E coverage for plugins owned by redhat-developer/rhdh-plugins

### DIFF
--- a/scripts/upload-coverage.sh
+++ b/scripts/upload-coverage.sh
@@ -9,12 +9,17 @@
 #   E2E_COLLECT_COVERAGE=true ./run-e2e.sh -w tech-radar
 #   ./scripts/upload-coverage.sh tech-radar
 #
-# The script reads source.json to determine the upstream repo and SHA,
-# then uploads the lcov coverage to Codecov attributed to that repo.
+# The script reads source.json to determine the upstream repo and SHA, and only
+# uploads when that repo is the Codecov project we own (CODECOV_UPLOAD_SLUG,
+# default redhat-developer/rhdh-plugins). Plugins sourced from other orgs are
+# skipped — see the gate below for why.
 #
 # Required environment:
-#   CODECOV_TOKEN  - Codecov upload token (org-level for cross-repo uploads).
-#                    Falls back to VAULT_CODECOV_TOKEN (see below).
+#   CODECOV_TOKEN       - Codecov upload token for the owned project.
+#                         Falls back to VAULT_CODECOV_TOKEN (see below).
+# Optional environment:
+#   CODECOV_UPLOAD_SLUG - GitHub slug of the owned Codecov project to upload to.
+#                         Default: redhat-developer/rhdh-plugins.
 
 set -euo pipefail
 
@@ -86,6 +91,20 @@ fi
 
 # Extract GitHub slug from repo URL (e.g., "redhat-developer/rhdh-plugins")
 SLUG=$(echo "$REPO_URL" | sed 's|https://github.com/||; s|\.git$||')
+
+# Only upload coverage for plugins whose source repo we can attribute it to.
+# Codecov anchors every report to a repo + commit + file tree, so the metric is
+# only accurate when uploaded to the repo where those source files and commits
+# actually live. We own the Codecov project for redhat-developer/rhdh-plugins;
+# plugins sourced from other orgs (e.g. backstage/community-plugins) can't be
+# reported accurately without that org's token, so skip them for now. Override
+# the owned slug with CODECOV_UPLOAD_SLUG if the target project ever changes.
+UPLOAD_SLUG="${CODECOV_UPLOAD_SLUG:-redhat-developer/rhdh-plugins}"
+if [[ "$SLUG" != "$UPLOAD_SLUG" ]]; then
+  echo "[INFO] Skipping Codecov upload for '$WORKSPACE': source repo '$SLUG' is not the owned project '$UPLOAD_SLUG'."
+  echo "[INFO] Cross-org coverage attribution isn't supported; lcov is available locally at $LCOV_FILE."
+  exit 0
+fi
 
 echo "=== Uploading E2E coverage to Codecov ==="
 echo "  Workspace:  $WORKSPACE"


### PR DESCRIPTION
Adds a guard so the E2E coverage upload only runs for plugins whose source repo is the Codecov project we own. Plugins sourced from `backstage/community-plugins` and other orgs are skipped for now.

## Why

Codecov anchors every report to a **repo + commit + file tree**. A report is only accurate when uploaded to the repo where those source files and that commit actually exist. `upload-coverage.sh` derives the target per workspace from `source.json`, which spans ~10 repos across 9 GitHub orgs:

| Source repo | Workspaces | Owned by us? |
|-------------|-----------:|--------------|
| `backstage/community-plugins` | 36 | no (org `backstage`) |
| `redhat-developer/rhdh-plugins` | 18 | yes |
| `proberaum/...`, `RoadieHQ/...`, `PagerDuty/...`, `Dynatrace/...`, etc. | 1–4 each | no |

We can only obtain a Codecov upload token for repos we own. Uploading e.g. tech-radar's coverage (files `src/...`, a `backstage/community-plugins` commit) to a project we don't own produces an orphaned, inaccurate report — the commit and files don't exist there.

## Change

After deriving `SLUG` from `source.json`, skip the upload unless it matches the owned project:

```bash
UPLOAD_SLUG="${CODECOV_UPLOAD_SLUG:-redhat-developer/rhdh-plugins}"
if [[ "$SLUG" != "$UPLOAD_SLUG" ]]; then
  echo "[INFO] Skipping Codecov upload for '$WORKSPACE': source repo '$SLUG' is not the owned project '$UPLOAD_SLUG'."
  exit 0
fi
```

- The 18 `redhat-developer/rhdh-plugins` workspaces upload (with the rhdh-plugins token + their own source commit, which exists there).
- The other 47 are skipped with a clear log line. The lcov is still generated locally.
- `CODECOV_UPLOAD_SLUG` overrides the owned slug if the target project ever changes.

Verified: gate passes `redhat-developer/rhdh-plugins`, skips `backstage/community-plugins` and `RoadieHQ/...`; override works; `shellcheck` clean (the one SC2016 is a pre-existing awk literal).

## Known follow-up (not in this PR)

For the rhdh-plugins workspaces, the remapped lcov paths are reduced to `src/...`. If two rhdh-plugins-sourced workspaces ever upload to the same commit, `src/index.ts`-style paths could collide. A follow-up should emit the full repo-relative path (`workspaces/<ws>/plugins/<plugin>/src/...`) so Codecov matches each plugin's files uniquely. Tracked separately; this PR is just the upload gate.

> Depends on the Vault secret holding a `redhat-developer/rhdh-plugins` upload token (being updated separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)