### PR TITLE
chore: bump e2e-test-utils to 1.10.0 across all workspaces

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -63,7 +63,7 @@ E2E_TEST_UTILS_PATH="${E2E_TEST_UTILS_PATH:-}"
 # Pin specific e2e-test-utils version.
 E2E_TEST_UTILS_VERSION="${E2E_TEST_UTILS_VERSION:-}"
 # Git ref for e2e-test-utils: "owner/repo#branch" — clones and sets E2E_TEST_UTILS_PATH
-E2E_TEST_UTILS_GIT_REF="${E2E_TEST_UTILS_GIT_REF:-subhashkhileri/rhdh-e2e-test-utils#fix/default-packages-url-release-1.10}"
+E2E_TEST_UTILS_GIT_REF="${E2E_TEST_UTILS_GIT_REF:-}"
 
 if [[ -n "$E2E_TEST_UTILS_GIT_REF" ]]; then
     CLONE_DIR="/tmp/rhdh-e2e-test-utils-${E2E_TEST_UTILS_GIT_REF##*#}"

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -63,7 +63,7 @@ E2E_TEST_UTILS_PATH="${E2E_TEST_UTILS_PATH:-}"
 # Pin specific e2e-test-utils version.
 E2E_TEST_UTILS_VERSION="${E2E_TEST_UTILS_VERSION:-}"
 # Git ref for e2e-test-utils: "owner/repo#branch" — clones and sets E2E_TEST_UTILS_PATH
-E2E_TEST_UTILS_GIT_REF="${E2E_TEST_UTILS_GIT_REF:-}"
+E2E_TEST_UTILS_GIT_REF="${E2E_TEST_UTILS_GIT_REF:-subhashkhileri/rhdh-e2e-test-utils#fix/default-packages-url-release-1.10}"
 
 if [[ -n "$E2E_TEST_UTILS_GIT_REF" ]]; then
     CLONE_DIR="/tmp/rhdh-e2e-test-utils-${E2E_TEST_UTILS_GIT_REF##*#}"

--- a/workspaces/acr/e2e-tests/package.json
+++ b/workspaces/acr/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/acr/e2e-tests/yarn.lock
+++ b/workspaces/acr/e2e-tests/yarn.lock
@@ -282,9 +282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -307,7 +307,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -551,7 +551,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/adoption-insights/e2e-tests/package.json
+++ b/workspaces/adoption-insights/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "1.57.0",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/adoption-insights/e2e-tests/yarn.lock
+++ b/workspaces/adoption-insights/e2e-tests/yarn.lock
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -379,7 +379,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -765,7 +765,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:1.57.0"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/analytics/e2e-tests/package.json
+++ b/workspaces/analytics/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/analytics/e2e-tests/yarn.lock
+++ b/workspaces/analytics/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -577,7 +577,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/argocd/e2e-tests/package.json
+++ b/workspaces/argocd/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/argocd/e2e-tests/yarn.lock
+++ b/workspaces/argocd/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -572,7 +572,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/backstage/e2e-tests/package.json
+++ b/workspaces/backstage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/backstage/e2e-tests/yarn.lock
+++ b/workspaces/backstage/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -626,7 +626,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/extensions/e2e-tests/package.json
+++ b/workspaces/extensions/e2e-tests/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "dotenv": "17.4.1",
     "eslint": "10.2.0",

--- a/workspaces/extensions/e2e-tests/yarn.lock
+++ b/workspaces/extensions/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1021,7 +1021,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:17.4.1"
     eslint: "npm:10.2.0"

--- a/workspaces/github/e2e-tests/package.json
+++ b/workspaces/github/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/github/e2e-tests/yarn.lock
+++ b/workspaces/github/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1187,7 +1187,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/global-header/e2e-tests/package.json
+++ b/workspaces/global-header/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/global-header/e2e-tests/yarn.lock
+++ b/workspaces/global-header/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1246,7 +1246,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/homepage/e2e-tests/package.json
+++ b/workspaces/homepage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/homepage/e2e-tests/yarn.lock
+++ b/workspaces/homepage/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1312,7 +1312,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/keycloak/e2e-tests/package.json
+++ b/workspaces/keycloak/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/keycloak/e2e-tests/yarn.lock
+++ b/workspaces/keycloak/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1482,7 +1482,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/lightspeed/e2e-tests/package.json
+++ b/workspaces/lightspeed/e2e-tests/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "^1.1.45",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/lightspeed/e2e-tests/yarn.lock
+++ b/workspaces/lightspeed/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:^1.1.45":
-  version: 1.1.45
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.45"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/32353ca9f259b9c5b025164ec13763cffb7dc3a54621d2f1db3e29808adea66219ad0b6aa04abb879e622478cf3c368dbeb3b028e99538199bdb58b3e0f63e11
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1415,7 +1415,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:^1.1.45"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/orchestrator/e2e-tests/package.json
+++ b/workspaces/orchestrator/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.44",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "dotenv": "16.6.1",
     "eslint": "10.2.0",

--- a/workspaces/orchestrator/e2e-tests/yarn.lock
+++ b/workspaces/orchestrator/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.44":
-  version: 1.1.44
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.44"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/530f63e45c5ed712c9960ad80c13592f8f09b50c0d7d8c045b0d2c1d0203f189986f9378be03f16a336b114cfd92444ef3f7051623348dbf3bcaa095d5d5f000
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1771,7 +1771,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.44"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:16.6.1"
     eslint: "npm:10.2.0"

--- a/workspaces/quay/e2e-tests/package.json
+++ b/workspaces/quay/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quay/e2e-tests/yarn.lock
+++ b/workspaces/quay/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/quickstart/e2e-tests/package.json
+++ b/workspaces/quickstart/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quickstart/e2e-tests/yarn.lock
+++ b/workspaces/quickstart/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1955,7 +1955,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/rbac/e2e-tests/package.json
+++ b/workspaces/rbac/e2e-tests/package.json
@@ -26,7 +26,7 @@
     "@backstage-community/plugin-rbac-common": "1.26.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/rbac/e2e-tests/yarn.lock
+++ b/workspaces/rbac/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1933,7 +1933,7 @@ __metadata:
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/roadie-backstage-plugins/e2e-tests/package.json
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10c0/6efa834364be2fc969e81a68df8e565c33545afc6a3b03c47cead46774a620e32ecdc5a23ffe9dbc92a7ce5b489f68bdff4c43f4aaaf8f5884d8ec6798b7de1a
+  checksum: 10c0/bf7b56c3eb75a2ba1da29dfc25d8da4c742b8d1287f6fd0626ea253afaeba7c36a5523044015b932ab8713c24f7746712d239666b84b19dd52c4646208d56a0e
   languageName: node
   linkType: hard
 
@@ -1936,7 +1936,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scorecard/e2e-tests/package.json
+++ b/workspaces/scorecard/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scorecard/e2e-tests/yarn.lock
+++ b/workspaces/scorecard/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tekton/e2e-tests/package.json
+++ b/workspaces/tekton/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tekton/e2e-tests/yarn.lock
+++ b/workspaces/tekton/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -2097,7 +2097,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/theme/e2e-tests/package.json
+++ b/workspaces/theme/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/theme/e2e-tests/yarn.lock
+++ b/workspaces/theme/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -2106,7 +2106,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/topology/e2e-tests/package.json
+++ b/workspaces/topology/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.1.43",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/topology/e2e-tests/yarn.lock
+++ b/workspaces/topology/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.1.43":
-  version: 1.1.43
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.1.43"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c7bfb421f1532a48fe2688e218efedfc2da6f95b84175939c771dae2c53c4cf375edf60a7b0735d4463f4713dac4f707333e1fac714db8d1cc325b3d82e7b19
+  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
   languageName: node
   linkType: hard
 
@@ -2133,7 +2133,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.1.43"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
## Summary

- Bump `@red-hat-developer-hub/e2e-test-utils` from `1.1.43`/`1.1.44` to `1.10.0` across all 22 workspace `e2e-tests/package.json` files + lock files.
- Revert temporary `E2E_TEST_UTILS_GIT_REF` override in `run-e2e.sh` — no longer needed now that `1.10.0` is published to npm (dist-tag: `1.10`).

### Context

`e2e-test-utils@1.10.0` fixes `default.packages.yaml` URL resolution for `release-1.10` — the file was removed from the `rhdh` repo ([PR #4932](https://github.com/redhat-developer/rhdh/pull/4932)) and the legacy fallback URL was broken. All branches now fetch from `rhdh-plugin-export-overlays`.

See: [rhdh-e2e-test-utils PR #113](https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/113)

## Test plan

- [ ] Comment `/test e2e-tests` to verify nightly tests pass with the fix

Assisted-by: Claude Code