### PR TITLE
fix: clarify publish comment sections for failures and images

### DIFF
--- a/.github/workflows/auto-publish-pr.yaml
+++ b/.github/workflows/auto-publish-pr.yaml
@@ -504,15 +504,15 @@ jobs:
                   body += '\n\n#### Publishing process\n';
                   body += `❌ Plugins with errors during export or container image publishing:`;
                   failedExports.forEach(line => {
-                    body += `\n  - ${line}`;
+                    body += `\n- ${line}`;
                   });
                 } else {
                   body += '\n\n#### Publishing process\n✅ Finished successfully.';
                 }
                 if (publishedExports.length > 0) {
-                  body += `\n- Published container images:`;
+                  body += `\n\n✅ Published container images:`;
                   publishedExports.forEach(line => {
-                    body += `\n  - ${line}`;
+                    body += `\n- ${line}`;
                   });
                 }
               }


### PR DESCRIPTION
Issue seen here:
<img width="704" height="263" alt="image" src="https://github.com/user-attachments/assets/4e898d4d-ee4e-4e29-aff4-220181b5e20f" />
Separated failed plugin exports from published image section and added checkmark for visible separation.
