### PR TITLE
fix(e2e): support 'unsupported' scan result in quay tab

### DIFF
--- a/workspaces/quay/e2e-tests/tests/utils/image-registry.ts
+++ b/workspaces/quay/e2e-tests/tests/utils/image-registry.ts
@@ -10,8 +10,7 @@ export class ImageRegistry {
       /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}, \d{4}, \d{1,2}:\d{2} [APM]{2}$/; // Example: Feb 2, 2026 4:01 PM
 
     const manifest = /^sha256/;
-    const securityScan =
-      /^(?:Critical:\s\d+)?(?:,\s)?(?:High:\s\d+)?(?:,\s)?(?:Medium:\s\d+)?(?:,\s)?(?:Low:\s\d+)?(?:,\s)?(?:Unknown:\s\d+)?$|^Queued$/i;
+    const securityScan = this.securityScanRegex();
     return [tagText, lastModifiedDate, securityScan, size, expires, manifest];
   }
 
@@ -31,7 +30,7 @@ export class ImageRegistry {
       (i) => `(${i}:\\s\\d+[^\\w]*)`,
     );
     return new RegExp(
-      `^(Passed|unsupported|Queued|Medium|Low|(?:${securityScan.join("|")})+)$`,
+      `^(Passed|unsupported|Queued|(?:${securityScan.join("|")})+)$`,
       "i", // Case-insensitive flag to match "Unsupported" or "unsupported"
     );
   }


### PR DESCRIPTION
use the exhaustive regex for security scan results, to avoid errors like https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-redhat-developer-rhdh-plugin-export-overlays-main-e2e-ocp-helm-nightly/2064921035702013952/artifacts/e2e-ocp-helm-nightly/redhat-developer-rhdh-plugin-export-overlays-ocp-helm/artifacts/playwright-report/index.html#?testId=eb275cf9f0e9eb2b9d46-f3a6ef836140a9905b89