### PR TITLE
fix: resolve coverage metadata by packageName, not filename

### DIFF
--- a/scripts/instrument-plugin.sh
+++ b/scripts/instrument-plugin.sh
@@ -63,15 +63,32 @@ while IFS= read -r PROD_IMAGE; do
   PLUGIN_NAME=$(basename "${PROD_IMAGE%%:*}")
   echo "  Plugin: $PLUGIN_NAME"
 
-  # Find metadata file for this plugin
-  # The metadata filename matches the OCI image name (e.g., backstage-community-plugin-acs.yaml)
-  METADATA_FILE="${WORKSPACE}/metadata/${PLUGIN_NAME}.yaml"
+  # Find the metadata file for this plugin by matching its packageName to the
+  # image name, NOT by assuming the filename matches the image. The published
+  # image name is the packageName with '@' stripped and '/' replaced by '-'
+  # (e.g. @red-hat-developer-hub/backstage-plugin-quickstart ->
+  # red-hat-developer-hub-backstage-plugin-quickstart). Some workspaces name
+  # their metadata files differently (e.g. rhdh-bsp-quickstart.yaml), so a
+  # filename-based lookup silently skipped them and never built the __coverage
+  # image — the e2e run then failed pulling a manifest that doesn't exist.
+  METADATA_FILE=""
+  for candidate in "${WORKSPACE}"/metadata/*.yaml; do
+    [[ -f "$candidate" ]] || continue
+    candidate_pkg=$(yq -r '.spec.packageName // ""' "$candidate")
+    [[ -z "$candidate_pkg" ]] && continue
+    candidate_image=$(echo "$candidate_pkg" | sed 's|^@||; s|/|-|g')
+    if [[ "$candidate_image" == "$PLUGIN_NAME" ]]; then
+      METADATA_FILE="$candidate"
+      break
+    fi
+  done
 
-  if [[ ! -f "$METADATA_FILE" ]]; then
-    echo "  ⚠️  No metadata file found at $METADATA_FILE - skipping"
+  if [[ -z "$METADATA_FILE" ]]; then
+    echo "  ⚠️  No metadata file with packageName matching '$PLUGIN_NAME' in ${WORKSPACE}/metadata/ - skipping"
     SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
     continue
   fi
+  echo "  Metadata: $METADATA_FILE"
 
   # Check if this is a frontend plugin (only frontend plugins need instrumentation)
   PLUGIN_ROLE=$(yq -r '.spec.backstage.role // ""' "$METADATA_FILE")


### PR DESCRIPTION
## Problem

`scripts/instrument-plugin.sh` located each plugin's metadata by assuming the file is named after the OCI image: `metadata/<image-name>.yaml`. That assumption holds for some workspaces but breaks for those whose metadata files follow the `rhdh-bsp-*` convention. For those, the lookup missed the file → the plugin was **skipped** → the `__coverage` image was **never built** → the e2e run later failed pulling a manifest that doesn't exist:

```
manifest unknown ... Init:Error (exit 1)
```

This is what broke the batch-1 rollout PRs **#2595 (quickstart)** and **#2596 (adoption-insights)**.

## Affected workspaces (6)

Frontend plugins whose metadata filename ≠ image name:

| Workspace | Metadata file | Image name |
|---|---|---|
| quickstart | `rhdh-bsp-quickstart.yaml` | `…-plugin-quickstart` |
| adoption-insights | `rhdh-bsp-adoption-insights.yaml` | `…-plugin-adoption-insights` |
| extensions | `rhdh-bsp-extensions.yaml` | `…-plugin-extensions` |
| lightspeed | `rhdh-bsp-lightspeed.yaml` | `…-plugin-lightspeed` |
| orchestrator | `rhdh-bsp-orchestrator.yaml` | `…-plugin-orchestrator` |
| scorecard | `rhdh-backstage-plugin-scorecard.yaml` | `…-plugin-scorecard` |

## Fix

Match by `spec.packageName` instead of filename. The published image name is the packageName with `@` stripped and `/` replaced by `-` (e.g. `@red-hat-developer-hub/backstage-plugin-quickstart` → `red-hat-developer-hub-backstage-plugin-quickstart`), which is stable regardless of how the metadata file is named.

## Validation

Simulated the resolver against all frontend images:
- 6 mismatched workspaces above → now resolve to the correct file
- previously-working (`global-header`, `homepage`, `bulk-import`, `theme`) → still resolve correctly (no regression)

After merge, re-running `/publish` on #2595/#2596 (and the other 4 affected workspaces when they roll out) will build the `__coverage` images and the e2e run will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)