### PR TITLE
feat(fullsend): add e2e-failure-analysis skill for nightly E2E pipeline

### DIFF
--- a/.fullsend/skills/e2e-failure-analysis/SKILL.md
+++ b/.fullsend/skills/e2e-failure-analysis/SKILL.md
@@ -1,0 +1,470 @@
+---
+name: e2e-failure-analysis
+description: "Debug and analyze E2E test failures when the user shares a gcsweb URL or asks to investigate a PR check / e2e-ocp-helm failure."
+---
+
+# E2E Failure Analysis
+
+Debug test failures in the rhdh-plugin-export-overlays E2E testing system.
+
+## CRITICAL: Context Management Rules
+
+**NEVER read entire log files.** Log files (backstage-backend.log, install-dynamic-plugins.log,
+build-log.txt) can be 5,000–50,000+ lines. Reading them wastes context and finds nothing useful.
+
+Instead:
+- **grep + tail** — `grep -i "error\|fail\|crash" file.log | tail -30`
+- **tail** — `tail -50 file.log` for most-recent entries
+- **Read with offset+limit** — `Read(file, offset=N, limit=50)` for targeted sections
+- **grep -n** — find line numbers first, then read narrow ranges
+
+**NEVER `cat` or `Read` without limit on**: backstage-backend.log, install-dynamic-plugins.log,
+build-log.txt, events.txt, describe-pods.txt, or any file that could be large.
+
+## Investigation Workflow
+
+### Step 0: Download Artifacts
+
+```bash
+SKILL_DIR="$HOME/.claude/skills/e2e-failure-analysis"
+ARTIFACTS=$(python3 "$SKILL_DIR/scripts/download-artifacts.py" "<PROW_OR_GCSWEB_URL>")
+```
+
+The script parses both PR check and nightly (periodic) prow/gcsweb URLs, downloads
+artifacts via `gcloud storage cp`, caches them locally, and prints the `ARTIFACTS` path.
+Subsequent runs with the same URL skip the download.
+
+### Step 1: Diagnostic Summary
+
+Run the diagnostics script from the skill's scripts directory:
+
+```bash
+SKILL_DIR="$HOME/.claude/skills/e2e-failure-analysis"
+python3 "$SKILL_DIR/scripts/diagnostics.py" "$ARTIFACTS"
+
+# Filter to a specific project:
+python3 "$SKILL_DIR/scripts/diagnostics.py" "$ARTIFACTS" --project techdocs
+```
+
+This script gives you:
+- All failed tests with error messages
+- Config table dumps (App Config, Dynamic Plugins, deployment config)
+- Deployment warnings auto-filtered (missing YAML files, errors, CrashLoopBackOff, etc.)
+
+**Key warnings to watch for in the output:**
+- `YAML file ... does not exist` — Missing config/secrets file (wrong path or missing `secrets:` in configure())
+- Config dump missing expected sections (e.g., no `integrations:`) — config file not loaded
+- `CrashLoopBackOff` / `ImagePullBackOff` — pod-level failures
+- Failed helm install or pod readiness timeout
+
+**Classify each failure before proceeding:**
+- **UI failure** (Playwright assertions) → proceed to Step 2
+- **Setup/beforeAll failure** (CLI commands, deployment errors) → skip to **Step 5b**
+
+Setup failures have no useful page snapshots, screenshots, or traces. **Go to
+build-log.txt first** — it captures the full stdout/stderr of every deployment script
+and CLI command, so it shows *why* the setup failed. Cluster logs only show the
+resulting state (what was or wasn't running). The cause is almost always in the build
+log, not the cluster logs.
+
+### Step 2: Read error-context.md for Failed Tests
+
+**This is the PRIMARY artifact for understanding UI failures.** Each failed test has an
+auto-generated `error-context.md` containing:
+- Test source code with the failing line marked
+- Full error message and call log
+- YAML page snapshot showing exactly what was on screen at failure time
+
+```bash
+# Find all error-context files for failed tests
+find "$ARTIFACTS/e2e-test-results" -name "error-context.md" | sort
+```
+
+**IMPORTANT: Read ONE error-context first, then deduplicate.** Page snapshots can be very large
+(500-1000+ lines for content-heavy pages like TechDocs). Before reading a second error-context:
+- Check if it's from the same project and spec file as one you already read
+- Check if the error message is the same (visible from Step 1 output)
+- If both match, **skip it** — the root cause is the same
+
+Read the first error-context.md. The page snapshot tells you immediately:
+- Is the page loaded? Or is it a blank/error page?
+- Is the expected element missing, or is it present with different text?
+- Did login succeed? (Check for user button vs login form)
+- Are sidebar items visible? (Plugin loaded vs not)
+
+#### ALWAYS view screenshots for UI failures
+
+Each failed test also saves a screenshot (`test-failed-1.png`) captured at the moment of
+failure. **Always read screenshots for every UI test failure** — don't skip them. They are
+small files (5-130KB) and give instant visual context that page snapshots can miss.
+
+```bash
+# Find screenshots for failed tests
+find "$ARTIFACTS/e2e-test-results" -name "test-failed-*.png" | sort
+```
+
+Read each screenshot file with the Read tool to see exactly what the browser showed.
+Screenshots reveal things the YAML page snapshot may not:
+- Visual layout, styling, or overlay positioning
+- Popups, modals, or dropdowns that the YAML snapshot doesn't capture well
+- UI controls (search fields, filters, pagination) that inform fix suggestions
+- Loading states, spinners, or partially rendered content
+- The overall page context at a glance vs parsing hundreds of YAML lines
+
+**Do this alongside reading error-context.md, not as a fallback.**
+
+### Step 3: Compare Expected vs Deployed Config
+
+**When Step 1 shows config warnings** (missing YAML files, missing config sections), compare
+what the workspace's config files define against what was actually deployed:
+
+```bash
+# Read the workspace's config files to see what SHOULD be deployed
+cat workspaces/<WORKSPACE>/e2e-tests/tests/config/<SUBDIR>/app-config-rhdh.yaml 2>/dev/null
+cat workspaces/<WORKSPACE>/e2e-tests/tests/config/<SUBDIR>/rhdh-secrets.yaml 2>/dev/null
+
+# Compare against the App Config dump from Step 1 output
+# Look for sections present in the file but missing from the dump
+```
+
+Common mismatches:
+- **Missing `integrations:` section** — secrets file not loaded, so token env vars unavailable
+- **Missing `catalog.providers:` section** — app-config file path wrong in configure()
+- **Secret path mismatch** — configure() uses default `tests/config/rhdh-secrets.yaml` but
+  the file is in a subdirectory like `tests/config/techdocs/rhdh-secrets.yaml`
+
+**Check the configure() call in the spec file:**
+```bash
+grep -A10 'rhdh.configure' workspaces/<WORKSPACE>/e2e-tests/tests/specs/<SPEC>.spec.ts
+```
+
+Verify that `appConfig`, `dynamicPlugins`, AND `secrets` all point to the correct paths.
+A common bug is specifying `appConfig` and `dynamicPlugins` with a subdirectory but forgetting
+the `secrets` parameter, causing it to fall back to the default path.
+
+### Step 4: Trace Analysis with pwtrace
+
+**Use pwtrace for UI interaction failures** — when the page loaded but an action failed
+(click, navigation, element interaction). **Skip traces ONLY when:**
+- Step 1 already revealed config/deployment warnings (missing YAML, missing config sections)
+- The failure is clearly a config issue (missing integration, wrong secret path)
+
+In those cases, the root cause is in the deployment config, not the browser interaction.
+Traces add no value — go straight to Step 3 (config comparison) or Step 5 (cluster logs).
+
+**When traces ARE valuable:**
+- Login failures, click/navigation issues, popup handling problems
+- Element interaction timeouts where the page state is ambiguous, flaky timing issues
+- **Element not found / timeout when the page loaded correctly** — use `pwtrace dom
+  --interactive` to discover what IS on the page (search fields, filters, pagination
+  controls, alternative elements) that could inform the fix. Don't just diagnose why the
+  element is missing — look for what the test COULD use instead.
+
+#### Finding and preparing traces
+
+Traces live in `e2e-test-results/specs-<slug>/trace.zip`, mapped to test names via
+`results.json`. **Important:** newer Playwright versions use `0-trace.trace` inside the zip
+instead of `trace.trace`, which pwtrace cannot read directly. Use the find-traces script
+to locate traces and create pwtrace-compatible copies:
+
+```bash
+SKILL_DIR="$HOME/.claude/skills/e2e-failure-analysis"
+
+# List traces and check format:
+python3 "$SKILL_DIR/scripts/find-traces.py" "$ARTIFACTS"
+
+# Filter to a project:
+python3 "$SKILL_DIR/scripts/find-traces.py" "$ARTIFACTS" --project techdocs
+
+# Fix traces for pwtrace (creates fixed copies in $ARTIFACTS/fixed-traces/):
+python3 "$SKILL_DIR/scripts/find-traces.py" "$ARTIFACTS" --project techdocs --fix
+```
+
+The `--fix` flag creates copies with `trace.trace` added alongside `0-trace.trace`,
+outputs the fixed paths, and prints ready-to-use `npx pwtrace show <path>` commands.
+
+**ALWAYS run find-traces.py with --fix before attempting pwtrace commands.** If pwtrace
+reports "trace.trace is empty" or "Invalid trace file", the trace needs fixing first.
+
+#### Progressive investigation:
+
+```bash
+# 1. Overview — which steps passed/failed and what actions were taken
+npx pwtrace show <path/to/trace.zip>
+
+# 2. Drill into the failed step — see details, timing, errors
+npx pwtrace step <path/to/trace.zip> <STEP_NUMBER>
+
+# 3. Inspect DOM at the failed step — what elements exist?
+npx pwtrace dom <path/to/trace.zip> --step <N> --interactive
+
+# 4. Search for a specific element in the DOM
+npx pwtrace dom <path/to/trace.zip> --step <N> --selector "text=Expected Text"
+
+# 5. Check for JavaScript errors
+npx pwtrace console <path/to/trace.zip> --level error
+
+# 6. Check for failed network requests (API errors)
+npx pwtrace network <path/to/trace.zip> --failed
+
+# 7. Get a screenshot at a specific step
+npx pwtrace screenshot <path/to/trace.zip> --step <N> --list
+npx pwtrace screenshot <path/to/trace.zip> --step <N> --index <I>
+```
+
+#### pwtrace decision tree:
+
+```
+Test failed → pwtrace show → identify failed step(s)
+     ↓
+Step N failed → pwtrace step N → understand what happened
+     ↓
+Element not found? → pwtrace dom --step N --interactive → see what exists
+     |                  └→ --selector "button" to find similar elements
+     ↓
+JS errors? → pwtrace console --level error → find exceptions
+     ↓
+API failing? → pwtrace network --failed → find 4xx/5xx/timeout
+     ↓
+👁️ Visual check → pwtrace screenshot --step N --list → choose screenshot
+                  └→ pwtrace screenshot --step N --index <I> → extract & view with Read tool
+```
+
+### Step 5: Cluster Log Search
+
+Check cluster logs **alongside** other steps, not only as a last resort. UI failures often
+originate from backend issues (plugin load failures, missing config, crashed pods) that only
+show up in cluster logs. **Use grep and tail — never read full log files.**
+
+```bash
+# Find the right namespace's logs
+ls "$ARTIFACTS/e2e-test-results/logs/"
+# Each directory = a project/namespace name
+
+# Pod status — this file is small, safe to read
+cat "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods.txt"
+```
+
+#### Pod restarts
+
+If `RESTARTS` is non-zero, a previous container instance ran and was killed mid-flight.
+Check why it was killed and what it left behind before reading the current pod's logs:
+
+```bash
+# Why was the previous pod killed?
+grep -i "kill\|probe\|evict\|OOM" "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/events.txt"
+
+# What was the previous pod doing when it died?
+PREV_LOG=$(find "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods" -name "backstage-backend.previous.log" | head -1)
+if [ -f "$PREV_LOG" ]; then
+  grep -E "finished|started|Pulling|Stopping|error|warn" "$PREV_LOG" | tail -40
+fi
+```
+
+Work that started in the previous pod but never completed can directly explain what
+is missing in the current pod — with no error visible in the current pod's own logs.
+
+```bash
+# Backend errors — grep, then read last 100 lines for context
+BACKEND_LOG=$(find "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods" -name "backstage-backend.log" | head -1)
+grep -i "error\|fail\|crash" "$BACKEND_LOG" | grep -v "node_modules\|trace_id" | tail -30
+# If grep reveals issues, read the tail for surrounding context:
+# Read(file=$BACKEND_LOG, offset=<total_lines - 100>, limit=100)
+
+# Plugin install issues — common cause of "element not found" UI failures
+INSTALL_LOG=$(find "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods" -name "install-dynamic-plugins.log" | head -1)
+grep -i "error\|fail\|skip" "$INSTALL_LOG" | tail -20
+
+# K8s events — last 50 lines (most recent events at bottom)
+tail -50 "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/events.txt"
+```
+
+**When to check logs early (alongside Steps 1-2):**
+- UI test timed out waiting for a plugin element → check `install-dynamic-plugins.log` for load failures
+- Page shows error/blank state → check `backstage-backend.log` for startup crashes
+- Pod never became ready → check `events.txt` for ImagePullBackOff, CrashLoopBackOff
+
+**Reading log context around errors:** When grep finds something interesting, use
+`Read` with `offset` and `limit` to read ~100 lines around the error for context.
+Never read the full file — backend logs can be 5,000-50,000+ lines.
+
+#### build-log.txt searches
+
+The build log contains the full CI output — deployment sequences, config dumps, warnings,
+and the complete stdout/stderr of every CLI command run during setup. It is a **single
+file covering all projects for the entire run**, so one grep pass can surface context
+for multiple failures at once.
+
+**For setup/beforeAll failures, start here — before cluster logs.** The build log shows
+*why* something failed (the actual error output from the failing command). Cluster logs
+only show what state things ended up in after the failure.
+
+```bash
+BUILD_LOG="$(dirname "$ARTIFACTS")/../build-log.txt"
+
+# For setup failures: grep for the project name + errors in one pass
+# This often reveals the exact CLI command that failed and its output
+grep -n -i "error\|fail\|warn\|NotFound" "$BUILD_LOG" | grep -i "${PROJECT}" | head -20
+
+# If multiple projects have setup failures, scan all at once
+grep -n -i "error\|fail\|warn\|NotFound" "$BUILD_LOG" | grep -i "proj1\|proj2\|proj3" | head -30
+
+# Find the deployment sequence / config table for a project
+grep -n "${PROJECT}" "$BUILD_LOG" | head -20
+# Then Read with offset+limit around those line numbers to see surrounding context
+
+# Find env vars / mode
+grep -E "GIT_PR_NUMBER|E2E_NIGHTLY|VAULT_" "$BUILD_LOG" | head -10
+
+# Find config dump — look for "App Config" section near project mention
+grep -n "App Config\|${PROJECT}" "$BUILD_LOG" | head -20
+```
+
+After the build log explains the cause, confirm the resulting cluster state:
+```bash
+cat "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods.txt"
+cat "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/deployments.txt"
+tail -50 "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/events.txt"
+```
+
+## Architecture Reference
+
+### e2e-test-utils
+
+All E2E tests use `@red-hat-developer-hub/e2e-test-utils` — a shared package that provides
+fixtures (`rhdh`, `uiHelper`, `loginHelper`), RHDH deployment logic, K8s helpers, and
+Playwright configuration. When debugging unexpected deployment behavior, config merging,
+or fixture internals, consult the source and docs:
+- **Repo**: https://github.com/redhat-developer/rhdh-e2e-test-utils
+- **Docs**: https://github.com/redhat-developer/rhdh-e2e-test-utils/tree/main/docs
+
+To check which version a failing run used:
+```bash
+grep -i "e2e-test-utils" "$BUILD_LOG" | head -5
+```
+
+### Project = Namespace = RHDH Deployment
+
+Each Playwright project creates a separate K8s namespace. Project name = namespace name.
+The project name tells you which log directory to check.
+
+### Deployment Modes
+
+| Mode | Detection | Plugins | Config Injection |
+|------|-----------|---------|-----------------|
+| PR check | `GIT_PR_NUMBER` set | OCI `pr_{N}__{version}` | Yes — metadata appConfigExamples |
+| Nightly | `E2E_NIGHTLY_MODE=true` | Released OCI refs | No |
+| Local | Neither | Local paths | Yes |
+
+### Deployment Flow (rhdh.deploy())
+
+```
+1. Config Merge: Package defaults → Auth config → Workspace overrides (deep merge)
+2. Secrets: envsubst on rhdh-secrets.yaml only ($VAR → value)
+3. Dynamic Plugins: auto-generate from metadata or use explicit file; resolve OCI URLs
+4. Helm Install: helm upgrade -i
+5. Readiness: Pod Ready + HTTP health check → sets RHDH_BASE_URL
+```
+
+### Secret Flow
+
+```
+CI env ($VAULT_TOKEN=abc) → rhdh-secrets.yaml (TOKEN: $VAULT_TOKEN) → app-config (token: ${TOKEN})
+                                ↓ envsubst                                ↓ K8s Secret reference
+                            TOKEN: abc                                token: abc (runtime)
+```
+
+## Common Failure Patterns
+
+### Plugin Not Loading
+**Grep for**: `grep -i "error\|fail" install-dynamic-plugins.log | tail -20`
+**Causes**: OCI not published (`/publish` not run), version mismatch, wrapper not disabled
+
+### Deployment Failure (CrashLoopBackOff)
+**Grep for**: `tail -50 events.txt` + `grep -i "error\|crash" backstage-backend.log | tail -20`
+**Causes**: Bad plugin config, missing env var, image pull failure
+
+### Login Failure
+**Check**: error-context.md page snapshot — is it login page or error?
+**Causes**: Keycloak not deployed, wrong secret, RHDH not ready
+
+### Timeout Waiting for Element
+**Check**: error-context.md → screenshot → pwtrace dom --interactive → adjacent tests in spec file
+**Causes**: Data not loaded, backend failing, wrong selector, element not on visible page
+**Before suggesting a fix**: `grep -A5 '<element text>' <spec-file>` — check if sibling
+tests already handle this element.
+
+### Config/Secret Mismatch
+**Detected in Step 1**: `YAML file ... does not exist` warning or missing config sections in dump
+**Causes**: Inconsistent paths in `rhdh.configure()` — one param points to a subdirectory
+while another falls back to the default path, or secrets file not loaded at all
+**Fix pattern**: Verify `appConfig`, `dynamicPlugins`, and `secrets` all use consistent paths
+
+### Worker Restart Lost State
+**Symptom**: Retry fails differently than first attempt
+**Check**: Was env var set inside runOnce? It's lost on worker restart.
+
+## Artifact Directory Structure
+
+```
+artifacts/
+├── playwright-report/
+│   ├── results.json             # Test results with stdout/stderr + trace attachment mappings
+│   └── data/                    # Hash-named trace/screenshot data (same content as e2e-test-results)
+│       └── <sha1-hash>.zip      # Trace files (may use 0-trace.trace format)
+├── e2e-test-results/
+│   ├── logs/<project>/          # Per-namespace cluster diagnostics
+│   │   ├── events.txt
+│   │   ├── pods.txt
+│   │   └── pods/<pod>/
+│   │       ├── backstage-backend.log
+│   │       └── install-dynamic-plugins.log
+│   └── specs-<slug>-<project>/  # Per-test failure artifacts
+│       ├── error-context.md     # Page snapshot (START HERE)
+│       ├── trace.zip            # Playwright trace (may need --fix for pwtrace)
+│       ├── test-failed-1.png    # Screenshot
+│       └── video.webm           # Recording
+└── fixed-traces/                # Created by find-traces.py --fix
+    └── specs-<slug>.zip         # pwtrace-compatible copies
+```
+
+**Trace locations:** Both `e2e-test-results/specs-*/trace.zip` and `playwright-report/data/*.zip`
+contain traces. The `e2e-test-results` traces are named by test slug (easier to identify).
+The `playwright-report/data` traces are hash-named (mapped via results.json attachments).
+Use `find-traces.py` to find and fix them — don't manually search for traces.
+
+**Trace format:** Newer Playwright uses `0-trace.trace` (not `trace.trace`) inside the zip.
+pwtrace expects `trace.trace`. Run `find-traces.py --fix` to create compatible copies.
+
+## Discovery Commands
+
+```bash
+# Workspaces with e2e tests
+ls -d workspaces/*/e2e-tests 2>/dev/null | cut -d'/' -f2
+
+# What config a project uses
+grep -A10 'rhdh.configure' workspaces/<name>/e2e-tests/tests/specs/*.spec.ts
+
+# What secrets a workspace needs
+cat workspaces/<name>/e2e-tests/.env.sample 2>/dev/null
+```
+
+## When the structured steps don't resolve the RCA
+
+If after following the steps above you still don't have a clear root cause — or your
+conclusion feels uncertain — set aside the hypothesis you've formed and reason freely.
+
+Keep the context of what you've already looked at: it tells you what's been ruled out
+and where the answer isn't. What you discard is the conclusion drawn from those steps,
+not the investigation history.
+
+1. **Re-read only the original error message** from Step 1.
+2. **Reason from the error outward**: what has to be true for this error to occur? Work
+   forward from the error itself, not backward from what the steps led you to look at.
+3. **Use what you've already seen to eliminate paths** — if you've checked cluster logs
+   and they were clean, the cause is upstream of runtime. If error-context showed the
+   page loaded fine, the issue isn't deployment. Let ruled-out evidence narrow the space.
+4. **Identify what you haven't checked yet** that could still explain the error, and go
+   there directly.
+5. **Confirm with one cross-check** before concluding — a single additional artifact that
+   either supports or contradicts the new hypothesis.

--- a/.fullsend/skills/e2e-failure-analysis/scripts/diagnostics.py
+++ b/.fullsend/skills/e2e-failure-analysis/scripts/diagnostics.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Extract test results, deployment warnings, and config dumps from results.json.
+
+Usage:
+    python3 diagnostics.py <ARTIFACTS_DIR> [--project <name>]
+
+Arguments:
+    ARTIFACTS_DIR   Path to the artifacts directory containing playwright-report/results.json
+    --project       Filter output to a specific Playwright project name (case-insensitive substring match)
+
+Output sections:
+    1. TEST RESULTS — pass/fail/skip counts and failed test details
+    2. DIAGNOSTICS PER FAILED PROJECT — config table dumps and filtered warnings/errors
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def walk_suites(suite, specs=None):
+    if specs is None:
+        specs = []
+    for spec in suite.get("specs", []):
+        specs.append(spec)
+    for child in suite.get("suites", []):
+        walk_suites(child, specs)
+    return specs
+
+
+WARNING_PATTERNS = re.compile(
+    r"YAML file.*does not exist|"
+    r"error|Error|ERROR|"
+    r"WARN|warn|Warning|"
+    r"does not exist|not found|"
+    r"missing|Missing|"
+    r"failed|Failed|FAILED|"
+    r"CrashLoopBackOff|ImagePullBackOff|"
+    r"secret.*not|Secret.*not",
+    re.IGNORECASE,
+)
+NOISE = re.compile(r"node_modules|trace_id|Download|Extracting|integrity checksum")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <ARTIFACTS_DIR> [--project <name>]", file=sys.stderr)
+        sys.exit(1)
+
+    artifacts = Path(sys.argv[1])
+    project_filter = None
+    if "--project" in sys.argv:
+        idx = sys.argv.index("--project")
+        if idx + 1 < len(sys.argv):
+            project_filter = sys.argv[idx + 1].lower()
+
+    results_file = artifacts / "playwright-report" / "results.json"
+    if not results_file.exists():
+        print(f"ERROR: {results_file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    r = json.loads(results_file.read_text())
+    stats = r.get("stats", {})
+    all_specs = []
+    for s in r.get("suites", []):
+        walk_suites(s, all_specs)
+
+    # Section 1: Test Results
+    print("=" * 70)
+    print("TEST RESULTS")
+    print("=" * 70)
+    print(
+        f"Passed: {stats.get('expected', 0)}  "
+        f"Failed: {stats.get('unexpected', 0)}  "
+        f"Skipped: {stats.get('skipped', 0)}  "
+        f"Flaky: {stats.get('flaky', 0)}"
+    )
+    print()
+
+    failed_projects = set()
+    for spec in all_specs:
+        for test in spec.get("tests", []):
+            proj = test.get("projectName", "?")
+            if project_filter and project_filter not in proj.lower():
+                continue
+            for result in test.get("results", []):
+                status = result["status"]
+                if status not in ("passed", "skipped"):
+                    failed_projects.add(proj)
+                    err = result.get("error", {}).get("message", "no error")
+                    print(f"FAILED [{proj}] {spec['title']}")
+                    print(f"  {err[:400]}")
+                    print()
+                elif project_filter:
+                    print(f"{status.upper()} [{proj}] {spec['title']}")
+
+    # Section 2: Diagnostics per failed project
+    for proj in sorted(failed_projects):
+        print("=" * 70)
+        print(f"DIAGNOSTICS FOR PROJECT: {proj}")
+        print("=" * 70)
+        for spec in all_specs:
+            for test in spec.get("tests", []):
+                if test.get("projectName") != proj:
+                    continue
+                for result in test.get("results", []):
+                    stdout = "".join(
+                        s.get("text", "") for s in result.get("stdout", [])
+                    )
+                    if not stdout:
+                        continue
+
+                    title = spec["title"][:50]
+
+                    # Config tables
+                    for match in re.finditer(
+                        r"(┌─[^\n]*(?:Config|Plugins|Deployment)[^\n]*\n)(.*?)(└─+)",
+                        stdout,
+                        re.DOTALL,
+                    ):
+                        header = match.group(1).strip()
+                        body = match.group(2)
+                        if len(body) < 5000:
+                            print(f"--- {header} [{title}] ---")
+                            print(body.rstrip())
+                            print()
+
+                    # Warnings and errors
+                    warnings = []
+                    for line in stdout.split("\n"):
+                        if WARNING_PATTERNS.search(line) and not NOISE.search(line):
+                            warnings.append(line.rstrip())
+                    if warnings:
+                        print(f"--- Warnings/Errors [{title}] ---")
+                        for w in warnings[-40:]:
+                            print(w)
+                        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.fullsend/skills/e2e-failure-analysis/scripts/download-artifacts.py
+++ b/.fullsend/skills/e2e-failure-analysis/scripts/download-artifacts.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Download E2E test artifacts from a prow URL.
+
+Usage:
+    python3 download-artifacts.py <PROW_URL>
+
+Accepts prow or gcsweb URLs for both PR checks and nightly (periodic) runs.
+Downloads artifacts via gcloud storage and prints the ARTIFACTS path.
+
+Examples:
+    python3 download-artifacts.py https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-...-nightly/123456
+    python3 download-artifacts.py https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/redhat-developer_.../42/pull-ci-.../123456
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def parse_url(url: str) -> dict:
+    """Parse a prow or gcsweb URL into its components."""
+    parsed = urlparse(url.rstrip("/"))
+    path = parsed.path
+
+    # Normalize: strip gcsweb prefix or prow /view/gs/ prefix to get the GCS-relative path
+    # prow:   /view/gs/test-platform-results/...
+    # gcsweb: /gcs/test-platform-results/...
+    for prefix in ["/view/gs/", "/gcs/"]:
+        if path.startswith(prefix):
+            path = path[len(prefix):]
+            break
+
+    parts = path.split("/")
+
+    # PR check: test-platform-results/pr-logs/pull/{org_repo}/{PR}/{job_name}/{job_id}
+    if "pr-logs" in parts:
+        try:
+            pr_idx = parts.index("pull") + 1
+            org_repo = parts[pr_idx]  # noqa: F841
+            pr_number = parts[pr_idx + 1]
+            job_name = parts[pr_idx + 2]
+            job_id = parts[pr_idx + 3]
+            return {
+                "type": "pr",
+                "pr": pr_number,
+                "job_name": job_name,
+                "job_id": job_id,
+                "artifact_subdir": job_name.split("-main-")[-1] if "-main-" in job_name else "e2e-ocp-helm",
+                "gcs_path": f"gs://test-platform-results/pr-logs/pull/redhat-developer_rhdh-plugin-export-overlays/{pr_number}/{job_name}/{job_id}",
+            }
+        except (IndexError, ValueError):
+            pass
+
+    # Nightly: test-platform-results/logs/{job_name}/{job_id}
+    if "/logs/" in "/" + "/".join(parts):
+        try:
+            logs_idx = parts.index("logs")
+            job_name = parts[logs_idx + 1]
+            job_id = parts[logs_idx + 2]
+            return {
+                "type": "nightly",
+                "job_name": job_name,
+                "job_id": job_id,
+                "artifact_subdir": "e2e-ocp-helm-nightly",
+                "gcs_path": f"gs://test-platform-results/logs/{job_name}/{job_id}",
+            }
+        except (IndexError, ValueError):
+            pass
+
+    return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 download-artifacts.py <PROW_URL>", file=sys.stderr)
+        sys.exit(1)
+
+    url = sys.argv[1]
+    info = parse_url(url)
+    if not info:
+        print(f"ERROR: Could not parse URL: {url}", file=sys.stderr)
+        sys.exit(1)
+
+    if info["type"] == "pr":
+        cache_dir = Path("node_modules/.cache/e2e-artifacts") / info["pr"] / info["job_id"]
+    else:
+        cache_dir = Path("node_modules/.cache/e2e-artifacts/nightly") / info["job_id"]
+
+    artifacts_dir = cache_dir / "redhat-developer-rhdh-plugin-export-overlays-ocp-helm" / "artifacts"
+
+    # Skip download if already cached
+    if artifacts_dir.exists():
+        print(f"Artifacts already downloaded, using cache.", file=sys.stderr)
+        print(artifacts_dir)
+        sys.exit(0)
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    gcs_src = (
+        f"{info['gcs_path']}/artifacts/{info['artifact_subdir']}"
+        f"/redhat-developer-rhdh-plugin-export-overlays-ocp-helm/"
+    )
+
+    print(f"Downloading from {gcs_src}", file=sys.stderr)
+
+    result = subprocess.run(
+        ["gcloud", "storage", "cp", "-r", gcs_src, str(cache_dir) + "/"],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        print(f"ERROR: gcloud storage cp failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    if not artifacts_dir.exists():
+        print(f"ERROR: Expected artifacts dir not found: {artifacts_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Download complete.", file=sys.stderr)
+    print(artifacts_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/.fullsend/skills/e2e-failure-analysis/scripts/find-traces.py
+++ b/.fullsend/skills/e2e-failure-analysis/scripts/find-traces.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Find, map, and fix Playwright trace files for pwtrace analysis.
+
+Traces live in two locations (same content, different naming):
+  1. e2e-test-results/specs-<slug>/trace.zip — named by test, easy to identify
+  2. playwright-report/data/<hash>.zip — hash-named, referenced by results.json
+
+Newer Playwright versions use `0-trace.trace` instead of `trace.trace` inside the zip,
+which pwtrace can't read. This script identifies traces, maps them to test names,
+and creates fixed copies that pwtrace can consume.
+
+Usage:
+    python3 find-traces.py <ARTIFACTS_DIR> [--project <name>] [--fix]
+
+Arguments:
+    ARTIFACTS_DIR   Path to the artifacts directory containing playwright-report/ and e2e-test-results/
+    --project       Filter to a specific project name (case-insensitive substring)
+    --fix           Create pwtrace-compatible copies in <ARTIFACTS_DIR>/fixed-traces/
+
+Without --fix, shows trace locations and whether they need fixing.
+With --fix, creates fixed copies and prints ready-to-use pwtrace commands.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def check_trace_format(zip_path: Path) -> tuple[str, bool]:
+    """Check trace format. Returns (format_description, needs_fix)."""
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+            if "trace.trace" in names:
+                return "standard", False
+            if "0-trace.trace" in names:
+                return "0-trace.trace (needs fix for pwtrace)", True
+            trace_files = [n for n in names if "trace" in n.lower()]
+            if trace_files:
+                return f"non-standard: {trace_files}", True
+            return "no trace data found", True
+    except zipfile.BadZipFile:
+        return "INVALID ZIP", True
+
+
+def fix_trace(zip_path: Path, output_path: Path) -> bool:
+    """Create a pwtrace-compatible copy by adding trace.trace alongside 0-trace.trace."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        try:
+            with zipfile.ZipFile(zip_path) as zf:
+                zf.extractall(tmp)
+        except zipfile.BadZipFile:
+            return False
+
+        src = tmp / "0-trace.trace"
+        dst = tmp / "trace.trace"
+        if src.exists() and not dst.exists():
+            shutil.copy2(src, dst)
+        elif not src.exists():
+            return False
+
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _dirs, files in os.walk(tmp):
+                for f in files:
+                    file_path = Path(root) / f
+                    arcname = file_path.relative_to(tmp)
+                    zf.write(file_path, arcname)
+
+    return True
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <ARTIFACTS_DIR> [--project <name>] [--fix]", file=sys.stderr)
+        sys.exit(1)
+
+    artifacts = Path(sys.argv[1])
+    project_filter = None
+    do_fix = "--fix" in sys.argv
+    if "--project" in sys.argv:
+        idx = sys.argv.index("--project")
+        if idx + 1 < len(sys.argv):
+            project_filter = sys.argv[idx + 1].lower()
+
+    results_file = artifacts / "playwright-report" / "results.json"
+    if not results_file.exists():
+        print(f"ERROR: {results_file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    r = json.loads(results_file.read_text())
+
+    # Collect all specs from results.json
+    all_specs = []
+    def walk(suite):
+        for spec in suite.get("specs", []):
+            all_specs.append(spec)
+        for child in suite.get("suites", []):
+            walk(child)
+    for s in r.get("suites", []):
+        walk(s)
+
+    fixed_dir = artifacts / "fixed-traces"
+    if do_fix:
+        fixed_dir.mkdir(exist_ok=True)
+
+    # Map each failed test to its trace file
+    print("=" * 70)
+    print("TRACE FILES FOR FAILED TESTS")
+    print("=" * 70)
+
+    traces_found = 0
+    for spec in all_specs:
+        for test in spec.get("tests", []):
+            proj = test.get("projectName", "?")
+            if project_filter and project_filter not in proj.lower():
+                continue
+
+            for result in test.get("results", []):
+                status = result.get("status", "?")
+                if status in ("passed", "skipped"):
+                    continue
+
+                title = spec["title"]
+                print(f"\nFAILED [{proj}] {title}")
+
+                # Find trace from attachment
+                attachments = result.get("attachments", [])
+                trace_att = [a for a in attachments if a.get("name") == "trace"]
+                if not trace_att:
+                    print("  No trace attachment recorded")
+                    continue
+
+                ci_path = trace_att[0].get("path", "")
+                if not ci_path:
+                    print("  Trace attachment has no path")
+                    continue
+
+                # Find local trace via the CI slug
+                slug = Path(ci_path).parent.name
+                local_trace = artifacts / "e2e-test-results" / slug / "trace.zip"
+
+                if not local_trace.exists():
+                    print(f"  Trace not found at: {local_trace}")
+                    continue
+
+                size = local_trace.stat().st_size
+                if size < 1000:
+                    print(f"  Trace stub ({size} bytes) — no usable trace data")
+                    continue
+
+                traces_found += 1
+                fmt, needs_fix = check_trace_format(local_trace)
+                print(f"  Trace: {local_trace}")
+                print(f"  Size: {size:,} bytes | Format: {fmt}")
+
+                if needs_fix and do_fix:
+                    # Use a descriptive name based on the test slug
+                    fixed_name = f"{slug}.zip"
+                    fixed_path = fixed_dir / fixed_name
+                    if fix_trace(local_trace, fixed_path):
+                        print(f"  ✓ Fixed: {fixed_path}")
+                        print(f"  → npx pwtrace show {fixed_path}")
+                    else:
+                        print(f"  ✗ Failed to fix trace")
+                elif needs_fix:
+                    print(f"  ⚠ Needs --fix to work with pwtrace")
+                else:
+                    print(f"  → npx pwtrace show {local_trace}")
+
+    if traces_found == 0:
+        print("\nNo traces found for failed tests.")
+    elif do_fix:
+        print(f"\n{'='*70}")
+        print(f"Fixed {traces_found} trace(s) in: {fixed_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds the `e2e-failure-analysis` skill to `.fullsend/skills/` — the analysis methodology for nightly E2E test failures
- Includes 3 Python helper scripts: `download-artifacts.py` (GCS fetch via gcloud), `diagnostics.py` (Playwright results + config dump parsing), `find-traces.py` (trace location + pwtrace compatibility fix)
- Stacked on top of #2543 (fullsend pilot onboarding)

## What the skill does

The skill provides a step-by-step investigation procedure for the `e2e-fix` agent:

1. **Download artifacts** from prow/gcsweb URLs (PR checks and nightly runs)
2. **Diagnostic summary** — failed tests, config table dumps, deployment warnings
3. **Error-context analysis** — page snapshots, screenshots, error messages
4. **Config comparison** — expected vs deployed app-config, secrets, dynamic plugins
5. **Trace analysis** — Playwright trace inspection via pwtrace
6. **Cluster log search** — pod logs, events, build-log.txt for setup failures

## JIRA

[RHIDP-14850](https://redhat.atlassian.net/browse/RHIDP-14850) — Phase 1: Nightly E2E test failure detection, analysis, and GitHub issue creation

## Test plan

- [ ] Verify skill scripts work with a real prow URL (`python3 scripts/download-artifacts.py <url>`)
- [ ] Verify `diagnostics.py` parses results.json correctly
- [ ] Verify `find-traces.py` locates and fixes traces for pwtrace