### PR TITLE
fix(smoketest): stabilize backstage workspace smoke checks

### DIFF
--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -187,8 +187,8 @@ jobs:
           echo "===== Checking logs for plugin loaded messages"
           for plugin in $PLUGINS; do
             echo "Asserting plugin loaded: $plugin"
-            # Match either the unpack path or the canonical "loaded dynamic ... plugin '<pkg>' from" message
-            if echo "$LOGS" | grep -qiE "loaded dynamic .* plugin .*${plugin}(-dynamic)?'" ; then
+            # Match either canonical package log lines or unpack paths (including /alpha suffixes).
+            if echo "$LOGS" | grep -qiE "loaded dynamic .* plugin .*${plugin}" ; then
               echo "Plugin loaded: $plugin"
             else
               echo "Plugin NOT loaded: $plugin"

--- a/smoke-tests/app-config.yaml
+++ b/smoke-tests/app-config.yaml
@@ -21,6 +21,15 @@ auth:
   providers:
     guest: {}
 
+integrations:
+  gitlab:
+    - host: gitlab.example.com
+      token: ${GITLAB_TOKEN}
+  bitbucketServer:
+    - host: bitbucket.example.com
+      apiBaseUrl: https://bitbucket.example.com/rest/api/1.0
+      token: ${BITBUCKET_TOKEN}
+
 # Minimal catalog configuration.
 catalog:
   rules:

--- a/smoke-tests/app-config.yaml
+++ b/smoke-tests/app-config.yaml
@@ -24,6 +24,7 @@ auth:
 integrations:
   gitlab:
     - host: gitlab.example.com
+      apiBaseUrl: https://gitlab.example.com/api/v4
       token: ${GITLAB_TOKEN}
   bitbucketServer:
     - host: bitbucket.example.com

--- a/workspaces/backstage/plugins-list.yaml
+++ b/workspaces/backstage/plugins-list.yaml
@@ -29,7 +29,7 @@ plugins/auth:
 plugins/catalog-backend-module-aws:
 plugins/catalog-backend-module-azure:
 plugins/catalog-backend-module-backstage-openapi:
-plugins/catalog-backend-module-bitbucket-cloud:
+plugins/catalog-backend-module-bitbucket-cloud: --embed-package @backstage/plugin-bitbucket-cloud-common
 plugins/catalog-backend-module-bitbucket-server:
 plugins/catalog-backend-module-gcp: --embed-package @backstage/plugin-kubernetes-common
 plugins/catalog-backend-module-gerrit:
@@ -82,7 +82,7 @@ plugins/proxy-backend:
 #plugins/scaffolder: ==> Added as a static plugin in RHDH
 #plugins/scaffolder-backend: ==> Added as a static plugin in RHDH
 plugins/scaffolder-backend-module-azure:
-plugins/scaffolder-backend-module-bitbucket-cloud:
+plugins/scaffolder-backend-module-bitbucket-cloud: --embed-package @backstage/plugin-bitbucket-cloud-common
 plugins/scaffolder-backend-module-bitbucket-server:
 plugins/scaffolder-backend-module-confluence-to-markdown:
 plugins/scaffolder-backend-module-cookiecutter:


### PR DESCRIPTION
## Summary
- add minimal smoke-test SCM integrations (GitLab + Bitbucket Server) including `apiBaseUrl` so integration parsing does not fail startup
- embed `@backstage/plugin-bitbucket-cloud-common` for Bitbucket Cloud catalog/scaffolder modules to avoid runtime `MODULE_NOT_FOUND`
- relax plugin loaded-log matching to handle `/alpha` dynamic module load paths

## Test plan
- [x] validated YAML syntax for modified workflow/config files
- [x] reviewed branch diff against `upstream/main` (3 files only)
- [ ] run `/publish` on this PR
- [ ] run `/smoketest` and confirm bitbucket-cloud modules load without `MODULE_NOT_FOUND`
- [ ] verify no `(log-errors)` startup failures from missing SCM integration config

Made with [Cursor](https://cursor.com)