### PR TITLE
fix(smoketest): increase readiness wait to 5 minutes

### DIFF
--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -127,19 +127,26 @@ jobs:
 
       - name: Wait for RHDH to be ready
         run: |
-          set -e
-          for i in $(seq 1 10); do
+          set -euo pipefail
+          TOTAL_ATTEMPTS=30
+          SLEEP_SECONDS=10
+
+          TOTAL_WAIT_SECONDS=$(( TOTAL_ATTEMPTS * SLEEP_SECONDS ))
+          TOTAL_WAIT_MINUTES=$(( TOTAL_WAIT_SECONDS / 60 ))
+          echo "Readiness window: ${TOTAL_ATTEMPTS} attempts x ${SLEEP_SECONDS}s (~${TOTAL_WAIT_MINUTES}m)"
+
+          for i in $(seq 1 "$TOTAL_ATTEMPTS"); do
             if curl -fsS http://localhost:7007/health >/dev/null; then
               echo "RHDH is ready"; exit 0; fi
-            echo "Waiting for RHDH... (Attempt ${i}/10)"
+            echo "Waiting for RHDH... (Attempt ${i}/${TOTAL_ATTEMPTS})"
             # Check if container is still running
             if ! docker ps | grep -q rhdh; then
               echo "Container stopped unexpectedly."
               exit 1
             fi
-            sleep 10
+            sleep "$SLEEP_SECONDS"
           done
-          echo "RHDH did not become ready in time."
+          echo "RHDH did not become ready in time after ${TOTAL_WAIT_SECONDS}s."
           exit 1
 
       - name: List installed plugins


### PR DESCRIPTION
## Summary
- increase smoke-test readiness polling window from 100s to 300s (`30 x 10s`)
- keep the same readiness probe logic while reducing false failures caused by slow startup/plugin initialization
- improve wait-step logging with computed total wait duration and attempt counters

## Test plan
- [x] Validate workflow YAML parses
- [x] Run `/publish` on this PR
- [x] Run `/smoketest` and verify startup no longer fails due to short readiness window

Made with [Cursor](https://cursor.com)