### PR TITLE
fix(smoketest): avoid false negatives for /alpha plugin loads

### DIFF
--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -187,8 +187,8 @@ jobs:
           echo "===== Checking logs for plugin loaded messages"
           for plugin in $PLUGINS; do
             echo "Asserting plugin loaded: $plugin"
-            # Match either the unpack path or the canonical "loaded dynamic ... plugin '<pkg>' from" message
-            if echo "$LOGS" | grep -qiE "loaded dynamic .* plugin .*${plugin}(-dynamic)?'" ; then
+            # Match loaded plugins by unpack path; allow both root and /alpha module paths.
+            if echo "$LOGS" | grep -qiE "loaded dynamic .* from 'file:///opt/app-root/src/dynamic-plugins-root/${plugin}(/alpha)?'" ; then
               echo "Plugin loaded: $plugin"
             else
               echo "Plugin NOT loaded: $plugin"

--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -188,7 +188,7 @@ jobs:
           for plugin in $PLUGINS; do
             echo "Asserting plugin loaded: $plugin"
             # Match loaded plugins by unpack path; allow both root and /alpha module paths.
-            if echo "$LOGS" | grep -qiE "loaded dynamic .* from 'file:///opt/app-root/src/dynamic-plugins-root/${plugin}(/alpha)?'" ; then
+            if echo "$LOGS" | grep -qiE "loaded dynamic (frontend|backend) plugin .* from 'file:///opt/app-root/src/dynamic-plugins-root/${plugin}(/alpha)?'" ; then
               echo "Plugin loaded: $plugin"
             else
               echo "Plugin NOT loaded: $plugin"


### PR DESCRIPTION
## Summary
- update smoke-test plugin load validation to match dynamic plugin unpack paths directly
- allow both standard and `/alpha` backend module paths under `dynamic-plugins-root`
- this prevents false negatives where plugins load successfully but are reported as missing

## Test plan
- [x] Validate workflow YAML parses
- [x] Confirm diff is matcher-only in `run-workspace-smoke-tests.yaml`
- [ ] Run `/publish` on this PR
- [ ] Run `/smoketest` and verify previously false-negative plugins are marked loaded

Made with [Cursor](https://cursor.com)