### PR TITLE
[release-1.10] chore(orchestrator): update rhdh-plugins source ref

### DIFF
--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-backend"
   # Tag: 1.10.0--8.6.1, Build date: 2026-03-27T17:58:02Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend@sha256:365d67fddeeaa2cf0b0266b012eb3e74fb5d5071b848059662353e62e7f9ceab"
-  version: 8.9.4
+  version: 8.9.5
   backstage:
     role: backend-plugin
     supportedVersions: 1.49.4

--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-form-widgets.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-form-widgets.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets"
   # Tag: 1.10.0--1.6.2, Build date: 2026-03-31T17:52:14Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets@sha256:b8d9886e39fa1262bfe1046f6ec5825b8e576c4997c744e0f90f722453f35aec"
-  version: 1.10.7
+  version: 1.10.8
   backstage:
     role: frontend-plugin
     supportedVersions: 1.49.4

--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-orchestrator'
   # Tag: 1.10.0--5.4.1, Build date: 2026-03-31T17:52:03Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator@sha256:062a536d266bcd76d454fc9fdc0157b99e62074f6d3304578a68f515ced83e64"
-  version: 5.7.12
+  version: 5.7.13
   backstage:
     role: frontend-plugin
     supportedVersions: 1.49.4

--- a/workspaces/orchestrator/source.json
+++ b/workspaces/orchestrator/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"18023a18d7168342e6e7b636e005d1aa22822f48","repo-flat":false,"repo-backstage-version":"1.49.3"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"683f9d63d293ea9adfbda217a1cc0ce4e574277e","repo-flat":false,"repo-backstage-version":"1.49.3"}


### PR DESCRIPTION
Bump orchestrator workspace source.json to commit 683f9d63 for the 1.10 release branch.