### PR TITLE
chore: add additional fallback for patch rhdh versions

### DIFF
--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -47,6 +47,9 @@ DYNAMIC_PACKAGES_ANNOTATION = "io.backstage.dynamic-packages"
 # Matches a clean version suffix: "2.18.0", "1.5", but NOT ".att", ".sbom", bare SHAs, etc.
 VERSION_SUFFIX_RE = re.compile(r'^\d+\.\d+(\.\d+)?$')
 
+# Matches a three-part version prefix (x.y.z), captures x.y for normalization
+THREE_PART_PREFIX_RE = re.compile(r'^(\d+\.\d+)\.\d+$')
+
 
 def is_downstream_quay_rhdh() -> bool:
     """Check if REGISTRY_BASE is quay.io/rhdh (downstream supported, NOT quay.io/rhdh-community)."""
@@ -245,7 +248,7 @@ def list_tags_with_prefix(registry: str, repository: str, prefix: str, auth, hea
     return sorted(matched, key=version_key)
 
 
-def resolve_fallback_tag(registry_reference: str) -> str | None:
+def resolve_fallback_tag(registry_reference: str) -> dict | None:
     """Find the latest published tag sharing the same version prefix when the exact tag doesn't exist.
 
     Constructs a prefix by splitting the tag on the registry-appropriate
@@ -253,36 +256,54 @@ def resolve_fallback_tag(registry_reference: str) -> str | None:
     everything up to and including the separator. Then queries the registry
     for all tags with that prefix and returns the highest version.
 
+    For quay.io/rhdh tags using the ``"--"`` separator, if the original
+    three-part RHDH version prefix (e.g., ``1.10.2--``) has no tags, the
+    patch version is stripped and a two-part prefix (``1.10--``) is tried.
+    This is because downstream builds are not repeated for each RHDH patch
+    release if the plugin hasn't changed — a build done during ``1.10.0``
+    produces both ``1.10.0--1.5.4`` and ``1.10--1.5.4`` tags, and the
+    ``1.10--`` tag remains valid for ``1.10.1``, ``1.10.2``, etc.
+
+    If the exact plugin version suffix is found under the normalized prefix,
+    it is flagged as a prefix normalization rather than a version fallback.
+    If the normalized prefix has tags but not the exact plugin version,
+    ``None`` is returned — a new build with the original prefix is needed,
+    not a fallback to an older version under a different prefix.
+
     Args:
         registry_reference: Full image reference with the requested tag, e.g.
             ``"quay.io/rhdh/plugin:1.11--1.6.0"`` or
             ``"ghcr.io/org/repo/plugin:bs_1.45.3__2.18.0"``.
 
     Returns:
-        The full registry reference with the fallback tag substituted, e.g.
-        ``"quay.io/rhdh/plugin:1.11--1.5.4"``. Returns ``None`` if no tags
-        match the prefix, if the reference cannot be parsed, or if the best
-        matching tag equals the originally requested tag (no fallback needed).
+        A dict on success, or ``None`` if no tags match the prefix, if the
+        reference cannot be parsed, or if the best matching tag equals the
+        originally requested tag (no fallback needed).
+
+        The returned dict contains::
+
+            {
+                'reference': str,   # full registry reference with resolved tag
+                'normalized': bool, # True if only the RHDH prefix changed
+                                    # (same plugin version), False if the
+                                    # plugin version itself is different
+            }
 
     Example:
-        If ``quay.io/rhdh/plugin:1.11--1.6.0`` does not exist but
-        ``1.11--1.5.4`` and ``1.11--1.3.0`` do::
+        Prefix normalization (``1.10.2--1.5.4`` requested, ``1.10--1.5.4`` exists)::
+
+            >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.10.2--1.5.4")
+            {'reference': 'quay.io/rhdh/plugin:1.10--1.5.4', 'normalized': True}
+
+        Version fallback (``1.11--1.6.0`` requested, ``1.11--1.5.4`` is latest)::
 
             >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.11--1.6.0")
-            'quay.io/rhdh/plugin:1.11--1.5.4'
+            {'reference': 'quay.io/rhdh/plugin:1.11--1.5.4', 'normalized': False}
 
-        For ghcr.io with prefix ``bs_1.45.3__``::
-
-            >>> resolve_fallback_tag("ghcr.io/org/repo/plugin:bs_1.45.3__2.18.0")
-            'ghcr.io/org/repo/plugin:bs_1.45.3__2.14.0'
-
-        When the requested prefix has no tags at all — even if older prefixes
-        exist in the registry — the fallback returns ``None``.  For example,
-        if the registry has ``1.11--1.5.4`` and ``1.10--1.5.4`` but nothing
-        with prefix ``1.12--``::
+        No tags at all for the prefix::
 
             >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.12--1.5.4")
-            None  # no tags match prefix "1.12--", older prefixes are ignored
+            None
     """
     parsed = parse_registry_reference(registry_reference)
     if not parsed:
@@ -295,22 +316,53 @@ def resolve_fallback_tag(registry_reference: str) -> str | None:
     if separator not in tag:
         return None
     prefix = tag.rsplit(separator, 1)[0] + separator
+    requested_suffix = tag.rsplit(separator, 1)[1]
 
     auth, extra_headers = get_registry_auth(registry, repository)
     headers = {'Accept': 'application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'}
     headers.update(extra_headers)
 
     tags = list_tags_with_prefix(registry, repository, prefix, auth, headers)
-    if not tags:
+
+    normalized = False
+
+    if not tags and separator == "--":
+        prefix_version = prefix[:-len(separator)]
+        m = THREE_PART_PREFIX_RE.match(prefix_version)
+        if m:
+            normalized_prefix = m.group(1) + separator
+            tags = list_tags_with_prefix(registry, repository, normalized_prefix, auth, headers)
+            if not tags:
+                return None
+            prefix = normalized_prefix
+            normalized = True
+        else:
+            return None
+    elif not tags:
         return None
 
     best_tag = tags[-1]
     if best_tag == tag:
         return None
 
-    # Reconstruct the reference with the fallback tag (using original registry, not query registry)
     original_ref_base = registry_reference.rsplit(':', 1)[0]
-    return f"{original_ref_base}:{best_tag}"
+
+    if normalized:
+        exact_normalized_tag = prefix + requested_suffix
+        if exact_normalized_tag in tags:
+            return {
+                'reference': f"{original_ref_base}:{exact_normalized_tag}",
+                'normalized': True,
+            }
+        # Normalized prefix has tags but not the exact plugin version —
+        # this means a new build is needed with the original prefix, not
+        # a fallback to an older version under the normalized prefix.
+        return None
+
+    return {
+        'reference': f"{original_ref_base}:{best_tag}",
+        'normalized': False,
+    }
 
 
 def _fetch_image_metadata(registry_reference: str) -> dict[str, str] | None:
@@ -447,9 +499,10 @@ def _fetch_image_metadata(registry_reference: str) -> dict[str, str] | None:
 def get_image_metadata(registry_reference: str) -> dict | None:
     """Fetch container image metadata, with automatic fallback to the latest published tag.
 
-    Wraps ``_fetch_image_metadata`` with a two-step strategy: first tries the
-    exact tag, and if that fails, calls ``resolve_fallback_tag`` to find the
-    latest published tag with the same version prefix.
+    Wraps ``_fetch_image_metadata`` with a multi-step strategy: first tries the
+    exact tag, and if that fails, calls ``resolve_fallback_tag`` to find a
+    match via RHDH prefix normalization or the latest published tag with the
+    same version prefix.
 
     Args:
         registry_reference: Full image reference, e.g.
@@ -464,12 +517,20 @@ def get_image_metadata(registry_reference: str) -> dict | None:
 
             {'digest': 'sha256:...', 'build-date': '2025-05-01', ...}
 
+        On a **prefix normalization** (RHDH version prefix adjusted, same
+        plugin version), the dict includes the resolved reference but no
+        fallback flag::
+
+            {
+                'digest': 'sha256:...',
+                'registryReference': 'quay.io/rhdh/plugin:1.10--1.5.4',
+            }
+
         On a **fallback hit** (exact tag missing, older tag used), the dict
         includes three extra fields::
 
             {
                 'digest': 'sha256:...',
-                'build-date': '2025-05-01',
                 'registryReference': 'quay.io/rhdh/plugin:1.11--1.5.4',
                 'fallback': True,
                 'requestedTag': '1.11--1.6.0',
@@ -481,6 +542,11 @@ def get_image_metadata(registry_reference: str) -> dict | None:
             >>> get_image_metadata("quay.io/rhdh/plugin:1.11--1.5.4")
             {'digest': 'sha256:a1b2c3...', 'build-date': '2025-05-01'}
 
+        Prefix normalization (tag ``1.10.2--1.5.4`` missing, ``1.10--1.5.4`` used)::
+
+            >>> get_image_metadata("quay.io/rhdh/plugin:1.10.2--1.5.4")
+            {'digest': 'sha256:a1b2c3...', 'registryReference': 'quay.io/rhdh/plugin:1.10--1.5.4'}
+
         Fallback hit (tag ``1.11--1.6.0`` missing, ``1.11--1.5.4`` used)::
 
             >>> get_image_metadata("quay.io/rhdh/plugin:1.11--1.6.0")
@@ -490,28 +556,39 @@ def get_image_metadata(registry_reference: str) -> dict | None:
     metadata = _fetch_image_metadata(registry_reference)
     if metadata is not None:
         return metadata
-    
+
     original_tag = registry_reference.rsplit(':', 1)[-1] if ':' in registry_reference else ""
 
-    fallback_ref = resolve_fallback_tag(registry_reference)
-    if fallback_ref is None:
+    resolve_result = resolve_fallback_tag(registry_reference)
+    if resolve_result is None:
         log_warn(f"Requested tag {Colors.YELLOW}{original_tag}{Colors.NORM} not found, no fallback available")
         return None
 
-    fallback_tag = fallback_ref.rsplit(':', 1)[-1] if ':' in fallback_ref else ""
-    
-    log_warn(
-        f"[FALLBACK] requested tag {Colors.YELLOW}{original_tag}{Colors.NORM} but tag not found,"
-        f" using latest published tag {Colors.GREEN}{fallback_tag}{Colors.NORM} instead"
-    )
+    resolved_ref = resolve_result['reference']
+    resolved_tag = resolved_ref.rsplit(':', 1)[-1] if ':' in resolved_ref else ""
+    is_normalization = resolve_result['normalized']
 
-    metadata = _fetch_image_metadata(fallback_ref)
+    if is_normalization:
+        log_info(
+            f"[NORMALIZED] RHDH prefix: {Colors.YELLOW}{original_tag}{Colors.NORM}"
+            f" -> {Colors.GREEN}{resolved_tag}{Colors.NORM}"
+        )
+    else:
+        log_warn(
+            f"[FALLBACK] requested tag {Colors.YELLOW}{original_tag}{Colors.NORM} but tag not found,"
+            f" using latest published tag {Colors.GREEN}{resolved_tag}{Colors.NORM} instead"
+        )
+
+    metadata = _fetch_image_metadata(resolved_ref)
     if metadata is None:
         return None
 
-    metadata['registryReference'] = fallback_ref
-    metadata['fallback'] = True
-    metadata['requestedTag'] = original_tag
+    metadata['registryReference'] = resolved_ref
+
+    if not is_normalization:
+        metadata['fallback'] = True
+        metadata['requestedTag'] = original_tag
+
     return metadata
 
 
@@ -663,6 +740,13 @@ def update_plugin_build_files(plugin_builds_dir: Path, overlays_dir: Path, repor
                                 pname, "image-metadata-fetch", "pass",
                                 **stage_kwargs,
                             )
+                            # Update bootstrap oci_ref to the resolved reference
+                            # so the status page links to the actual image
+                            resolved_ref = pdata.get('registryReference', '')
+                            if resolved_ref:
+                                bootstrap_stage = report.get_stage(pname, "bootstrap")
+                                if bootstrap_stage:
+                                    bootstrap_stage["oci_ref"] = resolved_ref
 
                 # Update the equivalent metadata.yaml file in the overlays directory
                 metadata_dir = overlays_dir / "workspaces" / relative_path.parent / "metadata"

--- a/scripts/generatePluginBuildInfo.py
+++ b/scripts/generatePluginBuildInfo.py
@@ -47,7 +47,7 @@ DYNAMIC_PACKAGES_ANNOTATION = "io.backstage.dynamic-packages"
 # Matches a clean version suffix: "2.18.0", "1.5", but NOT ".att", ".sbom", bare SHAs, etc.
 VERSION_SUFFIX_RE = re.compile(r'^\d+\.\d+(\.\d+)?$')
 
-# Matches a three-part version prefix (x.y.z), captures x.y for normalization
+# Matches a three-part version prefix (x.y.z), captures x.y for alias resolution
 THREE_PART_PREFIX_RE = re.compile(r'^(\d+\.\d+)\.\d+$')
 
 
@@ -264,9 +264,9 @@ def resolve_fallback_tag(registry_reference: str) -> dict | None:
     produces both ``1.10.0--1.5.4`` and ``1.10--1.5.4`` tags, and the
     ``1.10--`` tag remains valid for ``1.10.1``, ``1.10.2``, etc.
 
-    If the exact plugin version suffix is found under the normalized prefix,
-    it is flagged as a prefix normalization rather than a version fallback.
-    If the normalized prefix has tags but not the exact plugin version,
+    If the exact plugin version suffix is found under the alias prefix,
+    it is flagged as an alias match rather than a version fallback.
+    If the alias prefix has tags but not the exact plugin version,
     ``None`` is returned — a new build with the original prefix is needed,
     not a fallback to an older version under a different prefix.
 
@@ -283,22 +283,22 @@ def resolve_fallback_tag(registry_reference: str) -> dict | None:
         The returned dict contains::
 
             {
-                'reference': str,   # full registry reference with resolved tag
-                'normalized': bool, # True if only the RHDH prefix changed
-                                    # (same plugin version), False if the
-                                    # plugin version itself is different
+                'reference': str,  # full registry reference with resolved tag
+                'alias': bool,     # True if resolved via the x.y-- alias
+                                   # (same plugin version), False if the
+                                   # plugin version itself is different
             }
 
     Example:
-        Prefix normalization (``1.10.2--1.5.4`` requested, ``1.10--1.5.4`` exists)::
+        Alias resolution (``1.10.2--1.5.4`` requested, ``1.10--1.5.4`` exists)::
 
             >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.10.2--1.5.4")
-            {'reference': 'quay.io/rhdh/plugin:1.10--1.5.4', 'normalized': True}
+            {'reference': 'quay.io/rhdh/plugin:1.10--1.5.4', 'alias': True}
 
         Version fallback (``1.11--1.6.0`` requested, ``1.11--1.5.4`` is latest)::
 
             >>> resolve_fallback_tag("quay.io/rhdh/plugin:1.11--1.6.0")
-            {'reference': 'quay.io/rhdh/plugin:1.11--1.5.4', 'normalized': False}
+            {'reference': 'quay.io/rhdh/plugin:1.11--1.5.4', 'alias': False}
 
         No tags at all for the prefix::
 
@@ -324,18 +324,18 @@ def resolve_fallback_tag(registry_reference: str) -> dict | None:
 
     tags = list_tags_with_prefix(registry, repository, prefix, auth, headers)
 
-    normalized = False
+    used_alias = False
 
     if not tags and separator == "--":
         prefix_version = prefix[:-len(separator)]
         m = THREE_PART_PREFIX_RE.match(prefix_version)
         if m:
-            normalized_prefix = m.group(1) + separator
-            tags = list_tags_with_prefix(registry, repository, normalized_prefix, auth, headers)
+            alias_prefix = m.group(1) + separator
+            tags = list_tags_with_prefix(registry, repository, alias_prefix, auth, headers)
             if not tags:
                 return None
-            prefix = normalized_prefix
-            normalized = True
+            prefix = alias_prefix
+            used_alias = True
         else:
             return None
     elif not tags:
@@ -347,21 +347,20 @@ def resolve_fallback_tag(registry_reference: str) -> dict | None:
 
     original_ref_base = registry_reference.rsplit(':', 1)[0]
 
-    if normalized:
-        exact_normalized_tag = prefix + requested_suffix
-        if exact_normalized_tag in tags:
+    if used_alias:
+        exact_alias_tag = prefix + requested_suffix
+        if exact_alias_tag in tags:
             return {
-                'reference': f"{original_ref_base}:{exact_normalized_tag}",
-                'normalized': True,
+                'reference': f"{original_ref_base}:{exact_alias_tag}",
+                'alias': True,
             }
-        # Normalized prefix has tags but not the exact plugin version —
-        # this means a new build is needed with the original prefix, not
-        # a fallback to an older version under the normalized prefix.
+        # Alias prefix has tags but not the exact plugin version —
+        # a new build is needed, not a fallback under a different prefix.
         return None
 
     return {
         'reference': f"{original_ref_base}:{best_tag}",
-        'normalized': False,
+        'alias': False,
     }
 
 
@@ -501,7 +500,7 @@ def get_image_metadata(registry_reference: str) -> dict | None:
 
     Wraps ``_fetch_image_metadata`` with a multi-step strategy: first tries the
     exact tag, and if that fails, calls ``resolve_fallback_tag`` to find a
-    match via RHDH prefix normalization or the latest published tag with the
+    match via an RHDH version alias or the latest published tag with the
     same version prefix.
 
     Args:
@@ -517,8 +516,8 @@ def get_image_metadata(registry_reference: str) -> dict | None:
 
             {'digest': 'sha256:...', 'build-date': '2025-05-01', ...}
 
-        On a **prefix normalization** (RHDH version prefix adjusted, same
-        plugin version), the dict includes the resolved reference but no
+        On an **alias hit** (RHDH version prefix adjusted, same plugin
+        version), the dict includes the resolved reference but no
         fallback flag::
 
             {
@@ -542,7 +541,7 @@ def get_image_metadata(registry_reference: str) -> dict | None:
             >>> get_image_metadata("quay.io/rhdh/plugin:1.11--1.5.4")
             {'digest': 'sha256:a1b2c3...', 'build-date': '2025-05-01'}
 
-        Prefix normalization (tag ``1.10.2--1.5.4`` missing, ``1.10--1.5.4`` used)::
+        Alias hit (tag ``1.10.2--1.5.4`` missing, ``1.10--1.5.4`` used)::
 
             >>> get_image_metadata("quay.io/rhdh/plugin:1.10.2--1.5.4")
             {'digest': 'sha256:a1b2c3...', 'registryReference': 'quay.io/rhdh/plugin:1.10--1.5.4'}
@@ -566,11 +565,11 @@ def get_image_metadata(registry_reference: str) -> dict | None:
 
     resolved_ref = resolve_result['reference']
     resolved_tag = resolved_ref.rsplit(':', 1)[-1] if ':' in resolved_ref else ""
-    is_normalization = resolve_result['normalized']
+    is_alias = resolve_result['alias']
 
-    if is_normalization:
+    if is_alias:
         log_info(
-            f"[NORMALIZED] RHDH prefix: {Colors.YELLOW}{original_tag}{Colors.NORM}"
+            f"[ALIAS] RHDH version alias: {Colors.YELLOW}{original_tag}{Colors.NORM}"
             f" -> {Colors.GREEN}{resolved_tag}{Colors.NORM}"
         )
     else:
@@ -585,7 +584,7 @@ def get_image_metadata(registry_reference: str) -> dict | None:
 
     metadata['registryReference'] = resolved_ref
 
-    if not is_normalization:
+    if not is_alias:
         metadata['fallback'] = True
         metadata['requestedTag'] = original_tag
 

--- a/scripts/plugin_utils.py
+++ b/scripts/plugin_utils.py
@@ -686,6 +686,18 @@ class BuildReport:
         stage_data.update(details)
         plugin.setdefault("stages", {})[stage] = stage_data
 
+    def get_stage(self, plugin_name: str, stage: str) -> dict | None:
+        """Return the mutable stage dict for a plugin, or None if not found."""
+        if not self.enabled:
+            return None
+        return (
+            self._data
+            .get("plugins", {})
+            .get(plugin_name, {})
+            .get("stages", {})
+            .get(stage)
+        )
+
     def set_stage_all(self, stage: str, status: str, **details) -> None:
         """Apply the same stage outcome to every plugin currently in the report."""
         if not self.enabled:

--- a/scripts/tests/test_generatePluginBuildInfo.py
+++ b/scripts/tests/test_generatePluginBuildInfo.py
@@ -405,15 +405,17 @@ class TestResolveFallbackTag:
         nonexistent_ref = "ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:bs_1.49.4__9999.99.9"
         result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
         assert result is not None
-        assert "bs_1.49.4__" in result
-        assert "9999" not in result
+        assert "bs_1.49.4__" in result['reference']
+        assert "9999" not in result['reference']
+        assert result['normalized'] is False
 
     def test_quay_nonexistent_version_resolves_to_latest(self):
         nonexistent_ref = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--9999.99.9"
         result = generatePluginBuildInfo.resolve_fallback_tag(nonexistent_ref)
         assert result is not None
-        assert "1.11--" in result
-        assert "9999" not in result
+        assert "1.11--" in result['reference']
+        assert "9999" not in result['reference']
+        assert result['normalized'] is False
 
     def test_nonexistent_prefix_returns_none(self):
         """When the prefix itself has no tags, returns None."""
@@ -434,3 +436,91 @@ class TestResolveFallbackTag:
     def test_unparseable_ref_returns_none(self):
         result = generatePluginBuildInfo.resolve_fallback_tag("invalid")
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_fallback_tag — RHDH prefix normalization (mocked)
+# ---------------------------------------------------------------------------
+
+class TestResolveFallbackTagNormalization:
+    """Tests for two-tier prefix normalization in resolve_fallback_tag."""
+
+    @patch("generatePluginBuildInfo.requests.get")
+    def test_quay_xyz_prefix_normalizes_to_xy(self, mock_get):
+        """Request 1.10.2--1.5.4, registry has 1.10--1.5.4 -> normalization, not fallback."""
+        mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+        ref = "quay.io/rhdh/plugin:1.10.2--1.5.4"
+        result = generatePluginBuildInfo.resolve_fallback_tag(ref)
+        assert result is not None
+        assert result['reference'] == "quay.io/rhdh/plugin:1.10--1.5.4"
+        assert result['normalized'] is True
+
+    @patch("generatePluginBuildInfo.requests.get")
+    def test_quay_xyz_prefix_no_exact_version_under_xy_returns_none(self, mock_get):
+        """Request 1.10.2--9999.99.9, no 1.10.2-- tags, 1.10-- has tags but not 9999.99.9 -> None (needs new build)."""
+        mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+        ref = "quay.io/rhdh/plugin:1.10.2--9999.99.9"
+        result = generatePluginBuildInfo.resolve_fallback_tag(ref)
+        assert result is None
+
+    @patch("generatePluginBuildInfo.requests.get")
+    def test_quay_xyz_prefix_no_xy_tags_returns_none(self, mock_get):
+        """Request 1.12.0--1.5.4, no 1.12.0-- or 1.12-- tags exist -> None."""
+        mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+        ref = "quay.io/rhdh/plugin:1.12.0--1.5.4"
+        result = generatePluginBuildInfo.resolve_fallback_tag(ref)
+        assert result is None
+
+    @patch("generatePluginBuildInfo.requests.get")
+    def test_ghcr_does_not_normalize_prefix(self, mock_get):
+        """ghcr.io with nonexistent bs_1.50.0__ prefix should NOT try bs_1.50__ normalization."""
+        mock_get.return_value = _mock_response(GHCR_REAL_TAGS)
+        ref = "ghcr.io/org/repo/plugin:bs_1.50.0__2.18.0"
+        result = generatePluginBuildInfo.resolve_fallback_tag(ref)
+        assert result is None
+
+    @patch("generatePluginBuildInfo.requests.get")
+    def test_quay_two_part_prefix_does_not_normalize(self, mock_get):
+        """Request 1.12--1.5.4, prefix is already two-part, no normalization attempted."""
+        mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
+        ref = "quay.io/rhdh/plugin:1.12--1.5.4"
+        result = generatePluginBuildInfo.resolve_fallback_tag(ref)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_image_metadata — normalization vs fallback distinction (mocked)
+# ---------------------------------------------------------------------------
+
+class TestGetImageMetadataNormalization:
+    """Tests for get_image_metadata normalization vs fallback distinction."""
+
+    @patch("generatePluginBuildInfo._fetch_image_metadata")
+    @patch("generatePluginBuildInfo.resolve_fallback_tag")
+    def test_normalization_no_fallback_flag(self, mock_resolve, mock_fetch):
+        """When prefix is normalized but plugin version matches, no fallback flag."""
+        mock_fetch.side_effect = [None, {"digest": "sha256:abc123"}]
+        mock_resolve.return_value = {
+            'reference': 'quay.io/rhdh/plugin:1.10--1.5.4',
+            'normalized': True,
+        }
+        metadata = generatePluginBuildInfo.get_image_metadata("quay.io/rhdh/plugin:1.10.2--1.5.4")
+        assert metadata is not None
+        assert metadata['registryReference'] == 'quay.io/rhdh/plugin:1.10--1.5.4'
+        assert 'fallback' not in metadata
+        assert 'requestedTag' not in metadata
+
+    @patch("generatePluginBuildInfo._fetch_image_metadata")
+    @patch("generatePluginBuildInfo.resolve_fallback_tag")
+    def test_regular_fallback_sets_fallback_flag(self, mock_resolve, mock_fetch):
+        """When resolve returns normalized=False (regular fallback), fallback IS set."""
+        mock_fetch.side_effect = [None, {"digest": "sha256:abc123"}]
+        mock_resolve.return_value = {
+            'reference': 'quay.io/rhdh/plugin:1.11--1.5.4',
+            'normalized': False,
+        }
+        metadata = generatePluginBuildInfo.get_image_metadata("quay.io/rhdh/plugin:1.11--1.6.0")
+        assert metadata is not None
+        assert metadata.get('fallback') is True
+        assert metadata['requestedTag'] == '1.11--1.6.0'
+        assert metadata['registryReference'] == 'quay.io/rhdh/plugin:1.11--1.5.4'

--- a/scripts/tests/test_generatePluginBuildInfo.py
+++ b/scripts/tests/test_generatePluginBuildInfo.py
@@ -407,7 +407,7 @@ class TestResolveFallbackTag:
         assert result is not None
         assert "bs_1.49.4__" in result['reference']
         assert "9999" not in result['reference']
-        assert result['normalized'] is False
+        assert result['alias'] is False
 
     def test_quay_nonexistent_version_resolves_to_latest(self):
         nonexistent_ref = "quay.io/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:1.11--9999.99.9"
@@ -415,7 +415,7 @@ class TestResolveFallbackTag:
         assert result is not None
         assert "1.11--" in result['reference']
         assert "9999" not in result['reference']
-        assert result['normalized'] is False
+        assert result['alias'] is False
 
     def test_nonexistent_prefix_returns_none(self):
         """When the prefix itself has no tags, returns None."""
@@ -439,21 +439,21 @@ class TestResolveFallbackTag:
 
 
 # ---------------------------------------------------------------------------
-# resolve_fallback_tag — RHDH prefix normalization (mocked)
+# resolve_fallback_tag — RHDH version alias resolution (mocked)
 # ---------------------------------------------------------------------------
 
-class TestResolveFallbackTagNormalization:
-    """Tests for two-tier prefix normalization in resolve_fallback_tag."""
+class TestResolveFallbackTagAlias:
+    """Tests for RHDH version alias resolution in resolve_fallback_tag."""
 
     @patch("generatePluginBuildInfo.requests.get")
-    def test_quay_xyz_prefix_normalizes_to_xy(self, mock_get):
-        """Request 1.10.2--1.5.4, registry has 1.10--1.5.4 -> normalization, not fallback."""
+    def test_quay_xyz_prefix_resolves_via_alias(self, mock_get):
+        """Request 1.10.2--1.5.4, registry has 1.10--1.5.4 -> alias, not fallback."""
         mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
         ref = "quay.io/rhdh/plugin:1.10.2--1.5.4"
         result = generatePluginBuildInfo.resolve_fallback_tag(ref)
         assert result is not None
         assert result['reference'] == "quay.io/rhdh/plugin:1.10--1.5.4"
-        assert result['normalized'] is True
+        assert result['alias'] is True
 
     @patch("generatePluginBuildInfo.requests.get")
     def test_quay_xyz_prefix_no_exact_version_under_xy_returns_none(self, mock_get):
@@ -472,16 +472,16 @@ class TestResolveFallbackTagNormalization:
         assert result is None
 
     @patch("generatePluginBuildInfo.requests.get")
-    def test_ghcr_does_not_normalize_prefix(self, mock_get):
-        """ghcr.io with nonexistent bs_1.50.0__ prefix should NOT try bs_1.50__ normalization."""
+    def test_ghcr_does_not_use_alias(self, mock_get):
+        """ghcr.io with nonexistent bs_1.50.0__ prefix should NOT try bs_1.50__ alias."""
         mock_get.return_value = _mock_response(GHCR_REAL_TAGS)
         ref = "ghcr.io/org/repo/plugin:bs_1.50.0__2.18.0"
         result = generatePluginBuildInfo.resolve_fallback_tag(ref)
         assert result is None
 
     @patch("generatePluginBuildInfo.requests.get")
-    def test_quay_two_part_prefix_does_not_normalize(self, mock_get):
-        """Request 1.12--1.5.4, prefix is already two-part, no normalization attempted."""
+    def test_quay_two_part_prefix_does_not_use_alias(self, mock_get):
+        """Request 1.12--1.5.4, prefix is already two-part, no alias resolution attempted."""
         mock_get.return_value = _mock_response(QUAY_REAL_TAGS)
         ref = "quay.io/rhdh/plugin:1.12--1.5.4"
         result = generatePluginBuildInfo.resolve_fallback_tag(ref)
@@ -489,20 +489,20 @@ class TestResolveFallbackTagNormalization:
 
 
 # ---------------------------------------------------------------------------
-# get_image_metadata — normalization vs fallback distinction (mocked)
+# get_image_metadata — alias vs fallback distinction (mocked)
 # ---------------------------------------------------------------------------
 
-class TestGetImageMetadataNormalization:
-    """Tests for get_image_metadata normalization vs fallback distinction."""
+class TestGetImageMetadataAlias:
+    """Tests for get_image_metadata alias vs fallback distinction."""
 
     @patch("generatePluginBuildInfo._fetch_image_metadata")
     @patch("generatePluginBuildInfo.resolve_fallback_tag")
-    def test_normalization_no_fallback_flag(self, mock_resolve, mock_fetch):
-        """When prefix is normalized but plugin version matches, no fallback flag."""
+    def test_alias_no_fallback_flag(self, mock_resolve, mock_fetch):
+        """When resolved via alias but plugin version matches, no fallback flag."""
         mock_fetch.side_effect = [None, {"digest": "sha256:abc123"}]
         mock_resolve.return_value = {
             'reference': 'quay.io/rhdh/plugin:1.10--1.5.4',
-            'normalized': True,
+            'alias': True,
         }
         metadata = generatePluginBuildInfo.get_image_metadata("quay.io/rhdh/plugin:1.10.2--1.5.4")
         assert metadata is not None
@@ -513,11 +513,11 @@ class TestGetImageMetadataNormalization:
     @patch("generatePluginBuildInfo._fetch_image_metadata")
     @patch("generatePluginBuildInfo.resolve_fallback_tag")
     def test_regular_fallback_sets_fallback_flag(self, mock_resolve, mock_fetch):
-        """When resolve returns normalized=False (regular fallback), fallback IS set."""
+        """When resolve returns alias=False (regular fallback), fallback IS set."""
         mock_fetch.side_effect = [None, {"digest": "sha256:abc123"}]
         mock_resolve.return_value = {
             'reference': 'quay.io/rhdh/plugin:1.11--1.5.4',
-            'normalized': False,
+            'alias': False,
         }
         metadata = generatePluginBuildInfo.get_image_metadata("quay.io/rhdh/plugin:1.11--1.6.0")
         assert metadata is not None

--- a/user-guide/07-plugin-catalog-index.md
+++ b/user-guide/07-plugin-catalog-index.md
@@ -114,11 +114,11 @@ For each plugin, the image metadata fetch follows a three-tier resolution:
 
 1. **Exact tag match**: The constructed tag (e.g., `1.10.0--1.5.4`) is queried directly. If the image exists, its metadata is used as-is.
 
-2. **RHDH prefix normalization** (quay.io/rhdh only): If the exact tag is not found and the RHDH version prefix has three parts (x.y.z), the patch version is stripped to try the minor prefix (e.g., `1.10.2--` → `1.10--`). This is because downstream builds are not repeated for each RHDH patch release if the plugin hasn't changed — a build done during `1.10.0` produces both `1.10.0--1.5.4` and `1.10--1.5.4` tags, and the `1.10--` tag remains valid for `1.10.1`, `1.10.2`, etc. If the exact plugin version is found under the normalized prefix, the resolved reference is used without marking it as a fallback. If the normalized prefix has tags but not the exact plugin version, the plugin is reported as not found — a new downstream build is needed.
+2. **RHDH version alias** (quay.io/rhdh only): If the exact tag is not found and the RHDH version prefix has three parts (x.y.z), the patch version is stripped to try the minor-version alias (e.g., `1.10.2--` → `1.10--`). This is because downstream builds are not repeated for each RHDH patch release if the plugin hasn't changed — a build done during `1.10.0` produces both `1.10.0--1.5.4` and `1.10--1.5.4` tags, and the `1.10--` alias remains valid for `1.10.1`, `1.10.2`, etc. If the exact plugin version is found under the alias, the resolved reference is used without marking it as a fallback. If the alias has tags but not the exact plugin version, the plugin is reported as not found — a new downstream build is needed.
 
-3. **Fallback to latest version**: If the exact plugin version is not found under the original prefix, the latest published plugin version within that prefix is used. This is flagged as a fallback in the output, and the metadata YAML's `version:` field is updated to match. Fallback only applies within the original prefix — the normalized (minor-version) prefix is only used for exact matches.
+3. **Fallback to latest version**: If the exact plugin version is not found under the original prefix, the latest published plugin version within that prefix is used. This is flagged as a fallback in the output, and the metadata YAML's `version:` field is updated to match. Fallback only applies within the original prefix — the alias (minor-version) prefix is only used for exact matches.
 
-This normalization does not apply to ghcr.io (community) builds, which use Backstage version prefixes (`bs_x.y.z__`).
+Alias resolution does not apply to ghcr.io (community) builds, which use Backstage version prefixes (`bs_x.y.z__`).
 
 ### Step 3: DPDY Generation (`generateDynamicPluginsDefaultYaml.sh`)
 

--- a/user-guide/07-plugin-catalog-index.md
+++ b/user-guide/07-plugin-catalog-index.md
@@ -108,6 +108,18 @@ Queries the container registry for each plugin's OCI image to retrieve:
 Then updates `plugin_builds` with the relevant metadata.
 Images that don't exist in the registry are logged as warnings.
 
+#### Tag Resolution Strategy
+
+For each plugin, the image metadata fetch follows a three-tier resolution:
+
+1. **Exact tag match**: The constructed tag (e.g., `1.10.0--1.5.4`) is queried directly. If the image exists, its metadata is used as-is.
+
+2. **RHDH prefix normalization** (quay.io/rhdh only): If the exact tag is not found and the RHDH version prefix has three parts (x.y.z), the patch version is stripped to try the minor prefix (e.g., `1.10.2--` → `1.10--`). This is because downstream builds are not repeated for each RHDH patch release if the plugin hasn't changed — a build done during `1.10.0` produces both `1.10.0--1.5.4` and `1.10--1.5.4` tags, and the `1.10--` tag remains valid for `1.10.1`, `1.10.2`, etc. If the exact plugin version is found under the normalized prefix, the resolved reference is used without marking it as a fallback. If the normalized prefix has tags but not the exact plugin version, the plugin is reported as not found — a new downstream build is needed.
+
+3. **Fallback to latest version**: If the exact plugin version is not found under the original prefix, the latest published plugin version within that prefix is used. This is flagged as a fallback in the output, and the metadata YAML's `version:` field is updated to match. Fallback only applies within the original prefix — the normalized (minor-version) prefix is only used for exact matches.
+
+This normalization does not apply to ghcr.io (community) builds, which use Backstage version prefixes (`bs_x.y.z__`).
+
 ### Step 3: DPDY Generation (`generateDynamicPluginsDefaultYaml.sh`)
 
 Generates `dynamic-plugins.default.yaml` — the default plugin configuration shipped with RHDH. This step only runs for the **supported** tier (requires a YAML-format packages file with enabled/disabled structure).


### PR DESCRIPTION
### Description
Update fallback to use the RHDH minor versions when patch version does not exist. 
Ex: (1.10.2--1.5.4 does not exist, so try 1.10--1.5.4 instead)

Fixes [RHIDP-14887](https://redhat.atlassian.net/browse/RHIDP-14887)