### PR TITLE
chore(orchestrator): add admin menu item to default app config example

### DIFF
--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
@@ -48,6 +48,10 @@ spec:
                     text: Orchestrator
                     textKey: menuItem.orchestrator
                   path: /orchestrator
+              menuItems:
+                orchestrator:
+                  parent: default.admin
+                  icon: orchestratorIcon
               entityTabs:
                 - path: /workflows
                   title: Workflows


### PR DESCRIPTION
## Fixes:

https://redhat.atlassian.net/browse/RHIDP-13675 (Point 1)

## Summary
Updates the Orchestrator package metadata (`rhdh-bsp-orchestrator.yaml`) to include a `menuItems` entry in the default `appConfigExamples` configuration.
This places the Orchestrator sidebar item under the **Admin** section (`default.admin`) instead of the top-level navigation, matching the intended default navigation layout for RHDH.

## Changes
- Add `menuItems.orchestrator` with:
  - `parent: default.admin`
  - `icon: orchestratorIcon`