### PR TITLE
fix(adoption-insights): load translations from Alpha module

### DIFF
--- a/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights.yaml
+++ b/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights.yaml
@@ -34,6 +34,7 @@ spec:
             red-hat-developer-hub.backstage-plugin-adoption-insights:
               translationResources:
                 - importName: adoptionInsightsTranslations
+                  module: Alpha
                   ref: adoptionInsightsTranslationRef
               appIcons:
                 - name: adoptionInsightsIcon


### PR DESCRIPTION
## Summary
- Update adoption-insights frontend metadata to load `adoptionInsightsTranslations` from the `Alpha` Scalprum module, matching [rhdh-plugins#3449](https://github.com/redhat-developer/rhdh-plugins/pull/3449).
- Bump `@red-hat-developer-hub/backstage-plugin-adoption-insights` version to `0.8.3`.