### PR TITLE
test(e2e): skip Rerun Failswitch from failure point in nightly

### DIFF
--- a/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
@@ -111,7 +111,7 @@ export function registerOrchestratorCoreWorkflowTests(
 
     // eslint-disable-next-line playwright/expect-expect
     test("Rerun Failswitch from failure point", async ({}, testInfo) => {
-      test.skip(isNightlyMode, "SonataFlow rerun from failure point uses stale env vars (RHDHBUGS-XXXX)");
+      test.skip(isNightlyMode, "SonataFlow rerun from failure point uses stale env vars (#2627)");
       // HTTPBIN patch + 60s Wait timer + failure/recovery rerun
       test.setTimeout(360_000);
       const ns = testInfo.project.name;

--- a/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
@@ -6,6 +6,10 @@ import {
   cleanupAfterTest,
 } from "../support/utils/test-helpers.js";
 
+const isNightlyMode =
+  !!process.env.E2E_NIGHTLY_MODE ||
+  (process.env.JOB_NAME?.includes("periodic-") ?? false);
+
 type EnsureDataIndexOrSkip = (
   ns: string,
   testObj: { skip: (condition: boolean, reason: string) => void },
@@ -107,6 +111,7 @@ export function registerOrchestratorCoreWorkflowTests(
 
     // eslint-disable-next-line playwright/expect-expect
     test("Rerun Failswitch from failure point", async ({}, testInfo) => {
+      test.skip(isNightlyMode, "SonataFlow rerun from failure point uses stale env vars (RHDHBUGS-XXXX)");
       // HTTPBIN patch + 60s Wait timer + failure/recovery rerun
       test.setTimeout(360_000);
       const ns = testInfo.project.name;


### PR DESCRIPTION
## Summary

- Skip "Rerun Failswitch from failure point" test in nightly mode due to a SonataFlow product bug
- SonataFlow's "rerun from failure point" does not pick up updated environment variables — the patched httpbin URL reverts to `foobar.org` on rerun, causing an SSL error
- This is a product bug in the SonataFlow engine, not fixable in this repo

Fixes #2627

## Test plan

- [ ] Verify the test is skipped in nightly runs (`E2E_NIGHTLY_MODE=true` or `JOB_NAME` containing `periodic-`)
- [ ] Verify the test still runs in PR check mode (non-nightly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)