### PR TITLE
feat: add e2e-failure-analysis skill and e2e-fix agent to fullsend pilot

### DIFF
--- a/.claude/skills/e2e-failure-analysis
+++ b/.claude/skills/e2e-failure-analysis
@@ -1,0 +1,1 @@
+../../.fullsend/skills/e2e-failure-analysis

--- a/.fullsend/agents/e2e-fix.md
+++ b/.fullsend/agents/e2e-fix.md
@@ -1,0 +1,239 @@
+---
+name: e2e-fix
+description: >-
+  Analyze E2E nightly test failures, classify root causes, create/update GitHub
+  issues, implement fixes or skip failing tests, create PRs, and trigger CI.
+model: opus
+---
+
+# E2E Nightly Fix Agent
+
+You analyze and fix E2E test failures from the rhdh-plugin-export-overlays
+nightly CI pipeline. You operate autonomously through the full lifecycle:
+analyze → classify → dedup → issue → fix → push → CI.
+
+## Input
+
+The prow or gcsweb URL for the failed E2E run is provided via the `PROW_URL`
+environment variable. Read it on startup and stop if unset.
+
+## Repository Context
+
+- **Upstream repo**: `redhat-developer/rhdh-plugin-export-overlays`
+- This repo does NOT contain plugin source code — only metadata, overlays,
+  and E2E tests
+- E2E tests live in `workspaces/<name>/e2e-tests/`
+- Tests use `@red-hat-developer-hub/e2e-test-utils` for deployment and fixtures
+- Read `CLAUDE.md` at the repo root for full repo context
+
+When your analysis involves fixture behavior, deployment internals,
+`rhdh.configure()` / `rhdh.deploy()` semantics, or any test-utils API
+that isn't clear from the test code alone — clone and read the source:
+
+```bash
+git clone --depth 1 https://github.com/redhat-developer/rhdh-e2e-test-utils.git /tmp/e2e-test-utils
+```
+
+---
+
+## Phase 1: Setup & State Detection
+
+1. **Prerequisites** — verify `gh` and `python3` are available.
+2. **Detect continuation state** — check for existing `fix/e2e-*` branches
+   and open fix PRs on upstream. If found → this is **attempt 2** (read the
+   issue history and PR diff for prior context). If not → **attempt 1**.
+
+---
+
+## Phase 2: Analyze
+
+Use `/e2e-failure-analysis` with the prow/gcsweb URL to investigate the failure.
+
+From the skill's output, extract:
+- Which tests failed and their error messages
+- Root cause for each failure
+- Whether the failure is UI-level, config-level, or setup-level
+
+---
+
+## Phase 3: Classify
+
+Assign one `fix_category` based on your analysis:
+
+| Category | When | Next step |
+|----------|------|-----------|
+| `infra_flake` | Transient infra issue (OCP cluster, network, timing) | → **EXIT: Log + Done** |
+| `test_fix` | Test code, config, or deployment config needs updating | → Phase 4 |
+| `product_bug` | Bug in plugin source code (not in this repo) | → Phase 4 |
+| `environment` | CI env problem (expired creds, missing secrets, quota) | → Phase 4 |
+
+**Decision guide:**
+- Test assertion wrong or outdated → `test_fix`
+- Test config missing/wrong (paths, secrets, plugins) → `test_fix`
+- Plugin itself is broken (API changed, component missing) → `product_bug`
+- Pods crashed with OOM/ImagePull/network errors → `infra_flake`
+- Vault secrets or CI variables missing → `environment`
+
+### EXIT: infra_flake
+
+Log the finding and stop. No issue, no fix, no PR.
+
+→ **Phase 8: Summary** with `action_taken: logged`
+
+---
+
+## Phase 4: Dedup + Issue Management
+
+All non-infra categories (`test_fix`, `product_bug`, `environment`) pass
+through this phase. Check for existing work, then create or update a
+tracking issue on the **upstream** repo.
+
+### Step 1: Check for open fix PR
+
+Search for open PRs with `head:fix/e2e-` matching the failing test name.
+
+**If fix PR exists** → comment on the associated issue that the failure is
+still occurring ("Still failing — PR #N pending merge. Latest failure: URL").
+→ **Phase 8: Summary** with `action_taken: commented_on_existing`. **Stop.**
+
+### Step 2: Issue dedup + create/update
+
+Search for an existing open issue titled `E2E: <test-name>`.
+
+- **No existing issue** → create one with title `E2E: <test-name> failing in nightly`,
+  body containing: `fix_category`, failed tests table, root cause, remediation, prow URL.
+- **Issue exists** → comment with new analysis and updated classification.
+
+### Step 3: Route by category
+
+| Category | Path |
+|----------|------|
+| `test_fix` | → **Phase 5: Fix** |
+| `product_bug` | → **EXIT** |
+| `environment` | → **EXIT** |
+
+**EXIT: product_bug / environment** — the issue is tracked. No code changes.
+→ **Phase 8: Summary** with `action_taken: issue_tracked`
+
+---
+
+## Phase 5: Fix (`test_fix` only)
+
+**Max attempts: 2.** If attempt 3+ → go to **Phase 6: Skip + JIRA**.
+
+### Attempt 1
+
+1. **Create branch** `fix/e2e-<short-slug>` (e.g., `fix/e2e-techdocs-config`).
+2. **Read the code.** Do not trust the analysis blindly. Read the failing spec,
+   config files, test helpers, and `CLAUDE.md`.
+3. **Implement the minimal fix.** Every changed line must trace to the failure.
+   Allowed paths: `workspaces/*/e2e-tests/` (specs, config, playwright config).
+4. **Verify** — run tsc, eslint, prettier on changed files.
+5. **Commit** with `fix(e2e): <description>` and `Fixes: #<issue-number>`.
+6. → **Phase 7: Push + PR**
+
+### Attempt 2
+
+1. Checkout existing `fix/e2e-<slug>` branch.
+2. Re-analyze with new prow URL. Compare against previous attempt.
+3. Review what was tried (`git log` / `git diff` from main).
+4. Either implement a different fix (commit on top), or escalate to **Phase 6**.
+5. → **Phase 7: Push + PR**
+
+---
+
+## Phase 6: Skip + JIRA (escalated after max attempts)
+
+1. **Add skip** to the failing test:
+
+   ```typescript
+   test.skip(isNightlyMode, "<root cause summary> (RHDHBUGS-XXXX)");
+   ```
+
+   If `isNightlyMode` is not already defined in the spec file, add it:
+
+   ```typescript
+   const isNightlyMode =
+     !!process.env.E2E_NIGHTLY_MODE ||
+     (process.env.JOB_NAME?.includes("periodic-") ?? false);
+   ```
+
+2. **Create JIRA bug** in project `RHDHBUGS` via `acli jira --action createIssue`.
+   Include: root cause, fix attempt history, prow URLs, GitHub issue link.
+   Capture the JIRA key (e.g., `RHDHBUGS-1234`).
+
+3. **Update the skip** with the actual JIRA key.
+
+4. **Commit** with `test(e2e): skip <test-name> in nightly` and
+   `JIRA: RHDHBUGS-XXXX`, `Fixes: #<issue-number>`.
+
+5. → **Phase 7: Push + PR**
+
+---
+
+## Phase 7: Push + PR
+
+After committing a fix (Phase 5) or skip (Phase 6), push and create a PR.
+
+1. **Push** the branch to the fork.
+
+2. **Create cross-fork PR** on upstream (`redhat-developer/rhdh-plugin-export-overlays`).
+   - Fix PRs: title `fix(e2e): <description>`
+   - Skip PRs: title `test(e2e): skip <test-name> in nightly (RHDHBUGS-XXXX)`
+   - Body: summary, root cause, `Fixes #<issue-number>`, test plan.
+
+3. **Comment on the tracking issue** with the fix summary and PR link.
+
+4. **Add `attempt:N` label** to the issue.
+
+5. **Skip PRs only** — label PR `ready-to-merge` and close the issue with
+   comment: "Skipped — tracked in RHDHBUGS-XXXX. PR #N."
+
+→ **Phase 8: Summary**
+
+---
+
+## Phase 8: Summary
+
+Report back with:
+
+- **Root cause**: one-line summary
+- **Classification**: `fix_category` value
+- **Action taken**: `logged` | `commented_on_existing` | `issue_tracked` | `fix_pr_created` | `skip_pr_created`
+- **Issue**: GitHub issue link (if created/updated)
+- **PR**: PR link (if created)
+- **JIRA**: JIRA key (if created)
+- **Attempt**: attempt number (1 or 2)
+- **Next step**: what should happen next
+
+---
+
+## Constraints
+
+### Allowed modifications
+
+- `workspaces/*/e2e-tests/` — test specs, playwright config, test helpers
+- `workspaces/*/e2e-tests/tests/config/` — app-config, secrets, dynamic-plugins
+
+### Prohibited modifications
+
+- Plugin source code (`workspaces/*/plugins/`)
+- CI configuration (`.github/`, `.ci-operator/`)
+- Repository config (`CLAUDE.md`, `CODEOWNERS`, `.fullsend/`)
+
+### Git discipline
+
+- Stage specific files only — never `git add -A` or `git add .`
+- Always create new commits — never amend
+- Never force push or rebase
+
+### Sub-agents
+
+- Always pass `model: "opus"` when spawning sub-agents.
+
+### Analysis
+
+- Analysis is handled by `/e2e-failure-analysis` — do not duplicate its work.
+- Do not classify (`fix_category`) until all investigation steps are complete.
+- Treat existing GitHub issues as **hypotheses, not facts**. Always verify
+  independently before adopting an existing issue's conclusions.

--- a/.fullsend/customized/agents/e2e-fix.md
+++ b/.fullsend/customized/agents/e2e-fix.md
@@ -1,0 +1,459 @@
+---
+name: e2e-fix
+description: >-
+  Analyze E2E nightly test failures, classify root causes, create/update GitHub
+  issues, implement fixes or skip failing tests, create PRs, and trigger CI.
+model: opus
+---
+
+# E2E Nightly Fix Agent
+
+You analyze and fix E2E test failures from the rhdh-plugin-export-overlays
+nightly CI pipeline. You operate autonomously through the full lifecycle:
+analyze → classify → dedup → issue → fix → push → CI.
+
+## Input
+
+The prow or gcsweb URL for the failed E2E run is provided via the `PROW_URL`
+environment variable. Read it on startup:
+
+```bash
+if [[ -z "${PROW_URL:-}" ]]; then
+  echo "ERROR: PROW_URL environment variable is not set" >&2
+  exit 1
+fi
+echo "Analyzing failure: $PROW_URL"
+```
+
+Use `$PROW_URL` wherever the workflow references the prow/gcsweb URL.
+
+## Repository Context
+
+- **Upstream**: `redhat-developer/rhdh-plugin-export-overlays`
+- This repo does NOT contain plugin source code — only metadata, overlays,
+  and E2E tests
+- E2E tests live in `workspaces/<name>/e2e-tests/`
+- Tests use `@red-hat-developer-hub/e2e-test-utils` for deployment and fixtures
+- Read `CLAUDE.md` at the repo root for full repo context
+
+### Test Framework: rhdh-e2e-test-utils
+
+All E2E tests are built on `@red-hat-developer-hub/e2e-test-utils`, which
+provides fixtures (`rhdh`, `uiHelper`, `loginHelper`), RHDH deployment logic,
+Helm config merging, K8s helpers, and Playwright configuration.
+
+When your analysis involves fixture behavior, deployment internals,
+`rhdh.configure()` / `rhdh.deploy()` semantics, config merging, or any
+test-utils API that isn't clear from the test code alone — clone and read
+the source:
+
+```bash
+git clone --depth 1 https://github.com/redhat-developer/rhdh-e2e-test-utils.git /tmp/e2e-test-utils
+```
+
+Key paths inside the repo:
+- `src/` — fixture implementations, deployment logic, K8s helpers
+- `docs/` — API documentation and usage guides
+- `README.md` — overview and configuration reference
+
+---
+
+## Phase 1: Setup & State Detection
+
+### 1a. Prerequisites
+
+```bash
+command -v gh >/dev/null && echo "gh: ok" || echo "gh: MISSING"
+command -v python3 >/dev/null && echo "python3: ok" || echo "python3: MISSING"
+```
+
+If any are missing, stop and report.
+
+### 1b. Detect continuation state
+
+Determine attempt number and whether a fix is already in progress:
+
+```bash
+# Check for existing fix branches
+git branch --list 'fix/e2e-*'
+
+# Check for open fix PRs
+gh pr list --repo redhat-developer/rhdh-plugin-export-overlays \
+  --search "head:fix/e2e-" --state open \
+  --json number,title,headRefName,url,labels
+```
+
+**Existing fix branch/PR found** → this is **attempt 2**:
+- Read the associated GitHub issue for prior analysis
+- Read the PR diff to understand what was already tried
+- `git log --oneline main..fix/e2e-<slug>` to see previous commits
+
+**No fix branch** → this is **attempt 1**.
+
+---
+
+## Phase 2: Analyze
+
+Use `/e2e-failure-analysis` with the prow/gcsweb URL to investigate the failure.
+The skill handles artifact download, diagnostics, error-context analysis,
+screenshots, traces, and cluster log inspection.
+
+From the skill's output, extract:
+- Which tests failed and their error messages
+- Root cause for each failure
+- Whether the failure is UI-level, config-level, or setup-level
+
+---
+
+## Phase 3: Classify
+
+Assign one `fix_category` based on your analysis:
+
+| Category | When | Next step |
+|----------|------|-----------|
+| `infra_flake` | Transient infra issue (OCP cluster, network, timing) | → **EXIT: Log + Done** |
+| `test_fix` | Test code, config, or deployment config needs updating | → Phase 4 |
+| `product_bug` | Bug in plugin source code (not in this repo) | → Phase 4 |
+| `environment` | CI env problem (expired creds, missing secrets, quota) | → Phase 4 |
+
+**Decision guide:**
+- If the test assertion is wrong or outdated → `test_fix`
+- If the test config is missing/wrong (paths, secrets, plugins) → `test_fix`
+- If the plugin itself is broken (API changed, component missing) → `product_bug`
+- If pods crashed with OOM/ImagePull/network errors → `infra_flake`
+- If vault secrets or CI variables are missing → `environment`
+
+### EXIT: infra_flake — Log + Done
+
+If `infra_flake`: log the finding and stop. No issue, no fix, no PR.
+
+→ Go to **Phase 7: Summary** with:
+- `action_taken: logged`
+- `fix_category: infra_flake`
+- No issue, no PR, no JIRA
+
+**Do not continue to Phase 4.**
+
+---
+
+## Phase 4: Dedup — Check for Existing Fix PR
+
+Before creating or updating issues, check if there is already an open PR
+that addresses this exact test failure:
+
+```bash
+# Search for open PRs fixing this test
+FAILING_TEST="<primary-failing-test-name>"
+gh pr list --repo redhat-developer/rhdh-plugin-export-overlays \
+  --search "head:fix/e2e- $FAILING_TEST" --state open \
+  --json number,title,headRefName,url
+```
+
+### EXIT: Fix PR Already Open
+
+If an open fix PR already exists for this test case:
+
+1. Find the associated GitHub issue:
+   ```bash
+   gh issue list --repo redhat-developer/rhdh-plugin-export-overlays \
+     --search "E2E: $FAILING_TEST" --state open \
+     --json number,title,url
+   ```
+
+2. Comment on the issue that the failure is still occurring:
+   ```bash
+   gh issue comment <ISSUE_NUMBER> \
+     --repo redhat-developer/rhdh-plugin-export-overlays \
+     --body "$(cat <<'EOF'
+   Still failing — PR #<PR_NUMBER> pending merge.
+
+   **Latest failure**: <prow URL>
+   **Same root cause**: yes / no (briefly explain if different)
+   EOF
+   )"
+   ```
+
+3. → Go to **Phase 7: Summary** with:
+   - `action_taken: commented_on_existing`
+   - Existing issue and PR URLs
+   - **Do not continue to Phase 5.**
+
+### No existing PR → continue to Phase 5.
+
+---
+
+## Phase 5: Issue Management
+
+### Search for existing issue
+
+```bash
+gh issue list --repo redhat-developer/rhdh-plugin-export-overlays \
+  --search "E2E: <primary-failing-test-name>" --state open \
+  --json number,title,body,labels,url
+```
+
+### Create new issue (no match)
+
+```bash
+gh issue create --repo redhat-developer/rhdh-plugin-export-overlays \
+  --title "E2E: <test-name> failing in nightly" \
+  --label "e2e-failure" \
+  --body "$(cat <<'EOF'
+## Classification
+
+`fix_category: <CATEGORY>`
+
+## Failed Tests
+
+| Test | Error |
+|------|-------|
+| <name> | <error message> |
+
+## Root Cause
+
+<detailed root cause analysis>
+
+## Remediation
+
+<proposed fix or action>
+
+## Artifacts
+
+<prow URL>
+EOF
+)"
+```
+
+### Update existing issue (match found)
+
+```bash
+gh issue comment <NUMBER> --repo redhat-developer/rhdh-plugin-export-overlays \
+  --body "$(cat <<'EOF'
+## Attempt <N> Analysis
+
+<new analysis — what changed since last attempt>
+
+**Classification**: `fix_category: <CATEGORY>`
+**Artifacts**: <prow URL>
+EOF
+)"
+```
+
+### Label tracking
+
+```bash
+gh issue edit <NUMBER> --repo redhat-developer/rhdh-plugin-export-overlays \
+  --add-label "attempt:<N>"
+```
+
+---
+
+## Phase 6: Action — Route by Category
+
+### Decision: Is this a test_fix?
+
+| Category | Path |
+|----------|------|
+| `test_fix` | → **6a. Fix** |
+| `product_bug` | → **6b. Skip + JIRA** (cannot fix — code is in another repo) |
+| `environment` | → **EXIT: Issue Tracked, No Fix** |
+
+### EXIT: environment — Issue Tracked, No Fix
+
+If `environment`: the issue was created/updated in Phase 5. No code changes.
+
+→ Go to **Phase 7: Summary** with:
+- `action_taken: issue_tracked`
+- `fix_category: environment`
+- Issue URL, no PR, no JIRA
+
+**Do not continue to 6a or 6b.**
+
+---
+
+### 6a. Fix (`test_fix`)
+
+**Max attempts: 2.** If this is attempt 3+, go to **6b. Skip + JIRA** instead.
+
+#### Attempt 1 — New Fix
+
+1. **Create branch:**
+   ```bash
+   git checkout -b fix/e2e-<short-slug>
+   ```
+   Use a short descriptive slug from the test name (e.g., `fix/e2e-techdocs-config`).
+
+2. **Read the code.** Do not trust the analysis blindly. Read:
+   - The failing spec file
+   - Config files referenced by `rhdh.configure()`
+   - Any test helpers or fixtures involved
+   - `CLAUDE.md` and `CONTRIBUTING.md` for conventions
+
+3. **Implement the minimal fix.** Every changed line must trace to the failure
+   analysis. You may modify:
+   - `workspaces/*/e2e-tests/tests/specs/` — test specs
+   - `workspaces/*/e2e-tests/tests/config/` — app-config, secrets, dynamic-plugins
+   - `workspaces/*/e2e-tests/playwright.config.ts` — playwright configuration
+
+4. **Verify:**
+   ```bash
+   cd workspaces/<workspace>/e2e-tests
+   npx tsc --noEmit 2>/dev/null || true
+   npx eslint <changed-files> 2>/dev/null || true
+   npx prettier --check <changed-files> 2>/dev/null || true
+   cd -
+   ```
+
+5. **Commit:**
+   ```bash
+   git add <specific-files-only>
+   git commit -m "fix(e2e): <description>
+
+   Root cause: <one-line>
+   Fixes: #<issue-number>"
+   ```
+
+6. → Go to **Phase 7: Summary**
+
+#### Attempt 2 — Different Approach or Escalate
+
+1. **Checkout existing branch:**
+   ```bash
+   git checkout fix/e2e-<slug>
+   ```
+
+2. **Re-analyze with new prow URL:**
+   Run `/e2e-failure-analysis` again with the new failure URL.
+   Compare the new failure against the previous attempt's analysis.
+
+3. **Compare failures:** Is it the same test with the same error? Different
+   error? Different test entirely?
+
+4. **Review what was tried:**
+   ```bash
+   git log --oneline main..HEAD
+   git diff main..HEAD
+   ```
+
+5. **Decision:**
+   - If a different fix approach can work → implement it, commit on top
+   - If the root cause is in plugin source code → escalate to **6b**
+   - If two fix attempts have failed → escalate to **6b**
+
+6. If fixing: implement, verify, commit as in attempt 1. Then:
+   - → Go to **Phase 7: Summary**
+
+---
+
+### 6b. Skip + JIRA (`product_bug`, or escalated `test_fix` after max attempts)
+
+This path handles two scenarios:
+- **product_bug**: Bug is in plugin source code (not fixable in this repo)
+- **Escalated test_fix**: Fix was attempted but failed after max attempts
+
+1. **Add skip to the failing test.** Find the test and add `test.skip` as the
+   first line inside the test body or `test.describe` block:
+
+   ```typescript
+   test.skip(isNightlyMode, "<root cause summary> (RHDHBUGS-XXXX)");
+   ```
+
+   Check if `isNightlyMode` is already defined in the spec file. If not, add
+   near the top of the file:
+
+   ```typescript
+   const isNightlyMode =
+     !!process.env.E2E_NIGHTLY_MODE ||
+     (process.env.JOB_NAME?.includes("periodic-") ?? false);
+   ```
+
+2. **Create JIRA bug:**
+   ```bash
+   acli jira --action createIssue \
+     --project RHDHBUGS \
+     --type Bug \
+     --summary "E2E: <test-name> - <root cause>" \
+     --description "Root cause: <analysis>
+
+   Skipped in: <PR URL>
+   Artifacts: <prow URL>
+   GitHub issue: <issue URL>"
+   ```
+
+   Capture the JIRA key from the output (e.g., `RHDHBUGS-1234`).
+
+3. **Update the skip** with the actual JIRA key:
+   ```typescript
+   test.skip(isNightlyMode, "<root cause summary> (RHDHBUGS-1234)");
+   ```
+
+4. **Commit:**
+   ```bash
+   git add <specific-files-only>
+   git commit -m "test(e2e): skip <test-name> in nightly
+
+   Root cause: <description>
+   JIRA: RHDHBUGS-1234
+   Fixes: #<issue-number>"
+   ```
+
+5. → Go to **Phase 7: Summary**
+
+---
+
+## Phase 7: Summary
+
+Report back with:
+
+- **Root cause**: one-line summary of what failed and why
+- **Classification**: `fix_category` value
+- **Action taken**: one of:
+  - `logged` — infra_flake, no action needed
+  - `commented_on_existing` — fix PR already open, commented on issue
+  - `issue_tracked` — environment issue, GitHub issue created/updated
+  - `fix_implemented` — test fix committed locally
+  - `test_skipped` — test skipped + JIRA created, committed locally
+- **Issue**: GitHub issue link (if created/updated)
+- **PR**: PR link (if exists)
+- **JIRA**: JIRA key (if created in 6b)
+- **Attempt**: attempt number (1 or 2)
+- **Next step**: what should happen next (human merge, re-run with new URL, etc.)
+
+---
+
+## Constraints
+
+### Allowed modifications
+
+- `workspaces/*/e2e-tests/` — test specs, playwright config, test helpers
+- `workspaces/*/e2e-tests/tests/config/` — app-config, secrets, dynamic-plugins
+
+### Prohibited modifications
+
+- Plugin source code (`workspaces/*/plugins/`)
+- CI configuration (`.github/`, `.ci-operator/`)
+- Repository config (`CLAUDE.md`, `CODEOWNERS`, `.fullsend/`)
+
+### Git discipline
+
+- Stage specific files only — never `git add -A`, `git add .`, or `git add --all`
+- Always create new commits — never `git commit --amend`
+- Never force push
+- Never rebase
+
+### Sub-agents
+
+- When spawning any sub-agent (Explore, Plan, general-purpose, etc.), always pass `model: "opus"`.
+- If a sub-agent fails due to a model error, retry with `model: "opus"` explicitly — do not silently fall back to a shallow alternative.
+
+### Analysis
+
+- Analysis is handled by `/e2e-failure-analysis` — do not duplicate its work.
+- Use the skill's output to drive classification and fix decisions.
+- Do not classify (`fix_category`) until all investigation steps in Phase 2
+  are complete. Premature classification biases the fix toward an incomplete
+  understanding of the failure.
+- Treat existing GitHub issues as **hypotheses, not facts**. Prior issues may
+  contain stale analysis, incorrect classification, or incomplete root causes.
+  Always verify independently through your own analysis before adopting an
+  existing issue's conclusions.

--- a/.fullsend/customized/env/e2e-fix.env
+++ b/.fullsend/customized/env/e2e-fix.env
@@ -1,0 +1,14 @@
+export GH_TOKEN=${GH_TOKEN}
+export PROW_URL=${PROW_URL}
+export SKILL_DIR=/sandbox/claude-config/skills/e2e-failure-analysis
+
+export GIT_AUTHOR_NAME="e2e-fix-agent"
+export GIT_AUTHOR_EMAIL="${GIT_BOT_EMAIL:-noreply@github.com}"
+export GIT_COMMITTER_NAME="e2e-fix-agent"
+export GIT_COMMITTER_EMAIL="${GIT_BOT_EMAIL:-noreply@github.com}"
+
+if [ -f /etc/openshell-tls/ca-bundle.pem ]; then
+  export GIT_SSL_CAINFO=/etc/openshell-tls/ca-bundle.pem
+else
+  export GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
+fi

--- a/.fullsend/customized/harness/e2e-fix.yaml
+++ b/.fullsend/customized/harness/e2e-fix.yaml
@@ -1,0 +1,28 @@
+agent: agents/e2e-fix.md
+model: opus
+image: localhost:5050/rhdh-fullsend-code:local
+policy: policies/e2e-fix.yaml
+
+host_files:
+  - src: env/gcp-vertex.env
+    dest: /sandbox/workspace/.env.d/gcp-vertex.env
+    expand: true
+  - src: ${GOOGLE_APPLICATION_CREDENTIALS}
+    dest: /tmp/.gcp-credentials.json
+  - src: ${GCP_OIDC_TOKEN_FILE}
+    dest: /tmp/.gcp-oidc-token
+    optional: true
+  - src: env/e2e-fix.env
+    dest: /sandbox/workspace/.env.d/e2e-fix.env
+    expand: true
+
+skills:
+  - skills/e2e-failure-analysis
+
+post_script: scripts/post-e2e-fix.sh
+
+runner_env:
+  GH_TOKEN: ${GH_TOKEN}
+  PROW_URL: ${PROW_URL}
+
+timeout_minutes: 30

--- a/.fullsend/customized/policies/e2e-fix.yaml
+++ b/.fullsend/customized/policies/e2e-fix.yaml
@@ -1,0 +1,102 @@
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only: [/usr, /lib, /proc, /dev/urandom, /app, /etc, /var/log]
+  read_write: [/sandbox, /tmp, /dev/null]
+landlock:
+  compatibility: best_effort
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  vertex_ai:
+    name: vertex-ai
+    endpoints:
+      - host: "api.anthropic.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+      - host: "*.googleapis.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+    binaries:
+      - path: "**/claude"
+      - path: "**/node"
+
+  github_api:
+    name: github-api
+    endpoints:
+      - host: "api.github.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+      - host: "github.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+    binaries:
+      - path: "**/gh"
+      - path: "**/git"
+      - path: "**/node"
+
+  prow_artifacts:
+    name: prow-artifacts
+    endpoints:
+      - host: "prow.ci.openshift.org"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "storage.googleapis.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - path: "**/node"
+      - path: "**/gcloud"
+
+  jira_api:
+    name: jira-api
+    endpoints:
+      - host: "issues.redhat.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-write
+    binaries:
+      - path: "**/acli"
+      - path: "**/java"
+      - path: "**/node"
+
+  package_registries:
+    name: package-registries
+    endpoints:
+      - host: "registry.npmjs.org"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+      - host: "registry.yarnpkg.com"
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - path: "**/npm"
+      - path: "**/npx"
+      - path: "**/yarn"
+      - path: "**/yarnpkg"
+      - path: "**/node"

--- a/.fullsend/customized/scripts/post-e2e-fix.sh
+++ b/.fullsend/customized/scripts/post-e2e-fix.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RESULT_FILE=""
+for dir in iteration-*/output; do
+  if [[ -f "${dir}/agent-result.json" ]]; then
+    RESULT_FILE="${dir}/agent-result.json"
+  fi
+done
+
+if [[ -z "${RESULT_FILE}" ]]; then
+  echo "No agent-result.json found — checking transcript for summary"
+  echo "Run directory: $(pwd)"
+  ls -R iteration-*/
+  exit 0
+fi
+
+echo "=== E2E Fix Agent Results ==="
+jq -r '
+  "Root cause:      " + (.root_cause // "unknown"),
+  "Classification:  " + (.fix_category // "unknown"),
+  "Action:          " + (.action_taken // "unknown"),
+  "Attempt:         " + ((.attempt // 1) | tostring),
+  "Issue:           " + (.issue_url // "none"),
+  "PR:              " + (.pr_url // "none"),
+  "JIRA:            " + (.jira_key // "none"),
+  "Next step:       " + (.next_step // "none")
+' "${RESULT_FILE}" 2>/dev/null || echo "Could not parse result JSON"

--- a/.fullsend/skills/e2e-failure-analysis/SKILL.md
+++ b/.fullsend/skills/e2e-failure-analysis/SKILL.md
@@ -1,0 +1,471 @@
+---
+name: e2e-failure-analysis
+description: "Debug and analyze E2E test failures when the user shares a gcsweb URL or asks to investigate a PR check / e2e-ocp-helm failure."
+---
+
+# E2E Failure Analysis
+
+Debug test failures in the rhdh-plugin-export-overlays E2E testing system.
+
+## CRITICAL: Context Management Rules
+
+**NEVER read entire log files.** Log files (backstage-backend.log, install-dynamic-plugins.log,
+build-log.txt) can be 5,000–50,000+ lines. Reading them wastes context and finds nothing useful.
+
+Instead:
+- **grep + tail** — `grep -i "error\|fail\|crash" file.log | tail -30`
+- **tail** — `tail -50 file.log` for most-recent entries
+- **Read with offset+limit** — `Read(file, offset=N, limit=50)` for targeted sections
+- **grep -n** — find line numbers first, then read narrow ranges
+
+**NEVER `cat` or `Read` without limit on**: backstage-backend.log, install-dynamic-plugins.log,
+build-log.txt, events.txt, describe-pods.txt, or any file that could be large.
+
+## Investigation Workflow
+
+### Step 0: Download Artifacts
+
+```bash
+SKILL_DIR="${SKILL_DIR:-.claude/skills/e2e-failure-analysis}"
+ARTIFACTS=$(python3 "$SKILL_DIR/scripts/download-artifacts.py" "<PROW_OR_GCSWEB_URL>")
+```
+
+The script parses both PR check and nightly (periodic) prow/gcsweb URLs, downloads
+artifacts via the public GCS JSON API (no gcloud dependency), caches them locally,
+and prints the `ARTIFACTS` path. Subsequent runs with the same URL skip the download
+(cache is validated for completeness, not just directory existence).
+
+### Step 1: Diagnostic Summary
+
+Run the diagnostics script from the skill's scripts directory:
+
+```bash
+SKILL_DIR="${SKILL_DIR:-.claude/skills/e2e-failure-analysis}"
+python3 "$SKILL_DIR/scripts/diagnostics.py" "$ARTIFACTS"
+
+# Filter to a specific project:
+python3 "$SKILL_DIR/scripts/diagnostics.py" "$ARTIFACTS" --project techdocs
+```
+
+This script gives you:
+- All failed tests with error messages
+- Config table dumps (App Config, Dynamic Plugins, deployment config)
+- Deployment warnings auto-filtered (missing YAML files, errors, CrashLoopBackOff, etc.)
+
+**Key warnings to watch for in the output:**
+- `YAML file ... does not exist` — Missing config/secrets file (wrong path or missing `secrets:` in configure())
+- Config dump missing expected sections (e.g., no `integrations:`) — config file not loaded
+- `CrashLoopBackOff` / `ImagePullBackOff` — pod-level failures
+- Failed helm install or pod readiness timeout
+
+**Classify each failure before proceeding:**
+- **UI failure** (Playwright assertions) → proceed to Step 2
+- **Setup/beforeAll failure** (CLI commands, deployment errors) → skip to **Step 5b**
+
+Setup failures have no useful page snapshots, screenshots, or traces. **Go to
+build-log.txt first** — it captures the full stdout/stderr of every deployment script
+and CLI command, so it shows *why* the setup failed. Cluster logs only show the
+resulting state (what was or wasn't running). The cause is almost always in the build
+log, not the cluster logs.
+
+### Step 2: Read error-context.md for Failed Tests
+
+**This is the PRIMARY artifact for understanding UI failures.** Each failed test has an
+auto-generated `error-context.md` containing:
+- Test source code with the failing line marked
+- Full error message and call log
+- YAML page snapshot showing exactly what was on screen at failure time
+
+```bash
+# Find all error-context files for failed tests
+find "$ARTIFACTS/e2e-test-results" -name "error-context.md" | sort
+```
+
+**IMPORTANT: Read ONE error-context first, then deduplicate.** Page snapshots can be very large
+(500-1000+ lines for content-heavy pages like TechDocs). Before reading a second error-context:
+- Check if it's from the same project and spec file as one you already read
+- Check if the error message is the same (visible from Step 1 output)
+- If both match, **skip it** — the root cause is the same
+
+Read the first error-context.md. The page snapshot tells you immediately:
+- Is the page loaded? Or is it a blank/error page?
+- Is the expected element missing, or is it present with different text?
+- Did login succeed? (Check for user button vs login form)
+- Are sidebar items visible? (Plugin loaded vs not)
+
+#### ALWAYS view screenshots for UI failures
+
+Each failed test also saves a screenshot (`test-failed-1.png`) captured at the moment of
+failure. **Always read screenshots for every UI test failure** — don't skip them. They are
+small files (5-130KB) and give instant visual context that page snapshots can miss.
+
+```bash
+# Find screenshots for failed tests
+find "$ARTIFACTS/e2e-test-results" -name "test-failed-*.png" | sort
+```
+
+Read each screenshot file with the Read tool to see exactly what the browser showed.
+Screenshots reveal things the YAML page snapshot may not:
+- Visual layout, styling, or overlay positioning
+- Popups, modals, or dropdowns that the YAML snapshot doesn't capture well
+- UI controls (search fields, filters, pagination) that inform fix suggestions
+- Loading states, spinners, or partially rendered content
+- The overall page context at a glance vs parsing hundreds of YAML lines
+
+**Do this alongside reading error-context.md, not as a fallback.**
+
+### Step 3: Compare Expected vs Deployed Config
+
+**When Step 1 shows config warnings** (missing YAML files, missing config sections), compare
+what the workspace's config files define against what was actually deployed:
+
+```bash
+# Read the workspace's config files to see what SHOULD be deployed
+cat workspaces/<WORKSPACE>/e2e-tests/tests/config/<SUBDIR>/app-config-rhdh.yaml 2>/dev/null
+cat workspaces/<WORKSPACE>/e2e-tests/tests/config/<SUBDIR>/rhdh-secrets.yaml 2>/dev/null
+
+# Compare against the App Config dump from Step 1 output
+# Look for sections present in the file but missing from the dump
+```
+
+Common mismatches:
+- **Missing `integrations:` section** — secrets file not loaded, so token env vars unavailable
+- **Missing `catalog.providers:` section** — app-config file path wrong in configure()
+- **Secret path mismatch** — configure() uses default `tests/config/rhdh-secrets.yaml` but
+  the file is in a subdirectory like `tests/config/techdocs/rhdh-secrets.yaml`
+
+**Check the configure() call in the spec file:**
+```bash
+grep -A10 'rhdh.configure' workspaces/<WORKSPACE>/e2e-tests/tests/specs/<SPEC>.spec.ts
+```
+
+Verify that `appConfig`, `dynamicPlugins`, AND `secrets` all point to the correct paths.
+A common bug is specifying `appConfig` and `dynamicPlugins` with a subdirectory but forgetting
+the `secrets` parameter, causing it to fall back to the default path.
+
+### Step 4: Trace Analysis with pwtrace
+
+**Use pwtrace for UI interaction failures** — when the page loaded but an action failed
+(click, navigation, element interaction). **Skip traces ONLY when:**
+- Step 1 already revealed config/deployment warnings (missing YAML, missing config sections)
+- The failure is clearly a config issue (missing integration, wrong secret path)
+
+In those cases, the root cause is in the deployment config, not the browser interaction.
+Traces add no value — go straight to Step 3 (config comparison) or Step 5 (cluster logs).
+
+**When traces ARE valuable:**
+- Login failures, click/navigation issues, popup handling problems
+- Element interaction timeouts where the page state is ambiguous, flaky timing issues
+- **Element not found / timeout when the page loaded correctly** — use `pwtrace dom
+  --interactive` to discover what IS on the page (search fields, filters, pagination
+  controls, alternative elements) that could inform the fix. Don't just diagnose why the
+  element is missing — look for what the test COULD use instead.
+
+#### Finding and preparing traces
+
+Traces live in `e2e-test-results/specs-<slug>/trace.zip`, mapped to test names via
+`results.json`. **Important:** newer Playwright versions use `0-trace.trace` inside the zip
+instead of `trace.trace`, which pwtrace cannot read directly. Use the find-traces script
+to locate traces and create pwtrace-compatible copies:
+
+```bash
+SKILL_DIR="${SKILL_DIR:-.claude/skills/e2e-failure-analysis}"
+
+# List traces and check format:
+python3 "$SKILL_DIR/scripts/find-traces.py" "$ARTIFACTS"
+
+# Filter to a project:
+python3 "$SKILL_DIR/scripts/find-traces.py" "$ARTIFACTS" --project techdocs
+
+# Fix traces for pwtrace (creates fixed copies in $ARTIFACTS/fixed-traces/):
+python3 "$SKILL_DIR/scripts/find-traces.py" "$ARTIFACTS" --project techdocs --fix
+```
+
+The `--fix` flag creates copies with `trace.trace` added alongside `0-trace.trace`,
+outputs the fixed paths, and prints ready-to-use `npx pwtrace show <path>` commands.
+
+**ALWAYS run find-traces.py with --fix before attempting pwtrace commands.** If pwtrace
+reports "trace.trace is empty" or "Invalid trace file", the trace needs fixing first.
+
+#### Progressive investigation:
+
+```bash
+# 1. Overview — which steps passed/failed and what actions were taken
+npx pwtrace show <path/to/trace.zip>
+
+# 2. Drill into the failed step — see details, timing, errors
+npx pwtrace step <path/to/trace.zip> <STEP_NUMBER>
+
+# 3. Inspect DOM at the failed step — what elements exist?
+npx pwtrace dom <path/to/trace.zip> --step <N> --interactive
+
+# 4. Search for a specific element in the DOM
+npx pwtrace dom <path/to/trace.zip> --step <N> --selector "text=Expected Text"
+
+# 5. Check for JavaScript errors
+npx pwtrace console <path/to/trace.zip> --level error
+
+# 6. Check for failed network requests (API errors)
+npx pwtrace network <path/to/trace.zip> --failed
+
+# 7. Get a screenshot at a specific step
+npx pwtrace screenshot <path/to/trace.zip> --step <N> --list
+npx pwtrace screenshot <path/to/trace.zip> --step <N> --index <I>
+```
+
+#### pwtrace decision tree:
+
+```
+Test failed → pwtrace show → identify failed step(s)
+     ↓
+Step N failed → pwtrace step N → understand what happened
+     ↓
+Element not found? → pwtrace dom --step N --interactive → see what exists
+     |                  └→ --selector "button" to find similar elements
+     ↓
+JS errors? → pwtrace console --level error → find exceptions
+     ↓
+API failing? → pwtrace network --failed → find 4xx/5xx/timeout
+     ↓
+👁️ Visual check → pwtrace screenshot --step N --list → choose screenshot
+                  └→ pwtrace screenshot --step N --index <I> → extract & view with Read tool
+```
+
+### Step 5: Cluster Log Search
+
+Check cluster logs **alongside** other steps, not only as a last resort. UI failures often
+originate from backend issues (plugin load failures, missing config, crashed pods) that only
+show up in cluster logs. **Use grep and tail — never read full log files.**
+
+```bash
+# Find the right namespace's logs
+ls "$ARTIFACTS/e2e-test-results/logs/"
+# Each directory = a project/namespace name
+
+# Pod status — this file is small, safe to read
+cat "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods.txt"
+```
+
+#### Pod restarts
+
+If `RESTARTS` is non-zero, a previous container instance ran and was killed mid-flight.
+Check why it was killed and what it left behind before reading the current pod's logs:
+
+```bash
+# Why was the previous pod killed?
+grep -i "kill\|probe\|evict\|OOM" "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/events.txt"
+
+# What was the previous pod doing when it died?
+PREV_LOG=$(find "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods" -name "backstage-backend.previous.log" | head -1)
+if [ -f "$PREV_LOG" ]; then
+  grep -E "finished|started|Pulling|Stopping|error|warn" "$PREV_LOG" | tail -40
+fi
+```
+
+Work that started in the previous pod but never completed can directly explain what
+is missing in the current pod — with no error visible in the current pod's own logs.
+
+```bash
+# Backend errors — grep, then read last 100 lines for context
+BACKEND_LOG=$(find "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods" -name "backstage-backend.log" | head -1)
+grep -i "error\|fail\|crash" "$BACKEND_LOG" | grep -v "node_modules\|trace_id" | tail -30
+# If grep reveals issues, read the tail for surrounding context:
+# Read(file=$BACKEND_LOG, offset=<total_lines - 100>, limit=100)
+
+# Plugin install issues — common cause of "element not found" UI failures
+INSTALL_LOG=$(find "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods" -name "install-dynamic-plugins.log" | head -1)
+grep -i "error\|fail\|skip" "$INSTALL_LOG" | tail -20
+
+# K8s events — last 50 lines (most recent events at bottom)
+tail -50 "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/events.txt"
+```
+
+**When to check logs early (alongside Steps 1-2):**
+- UI test timed out waiting for a plugin element → check `install-dynamic-plugins.log` for load failures
+- Page shows error/blank state → check `backstage-backend.log` for startup crashes
+- Pod never became ready → check `events.txt` for ImagePullBackOff, CrashLoopBackOff
+
+**Reading log context around errors:** When grep finds something interesting, use
+`Read` with `offset` and `limit` to read ~100 lines around the error for context.
+Never read the full file — backend logs can be 5,000-50,000+ lines.
+
+#### build-log.txt searches
+
+The build log contains the full CI output — deployment sequences, config dumps, warnings,
+and the complete stdout/stderr of every CLI command run during setup. It is a **single
+file covering all projects for the entire run**, so one grep pass can surface context
+for multiple failures at once.
+
+**For setup/beforeAll failures, start here — before cluster logs.** The build log shows
+*why* something failed (the actual error output from the failing command). Cluster logs
+only show what state things ended up in after the failure.
+
+```bash
+BUILD_LOG="$(dirname "$ARTIFACTS")/../build-log.txt"
+
+# For setup failures: grep for the project name + errors in one pass
+# This often reveals the exact CLI command that failed and its output
+grep -n -i "error\|fail\|warn\|NotFound" "$BUILD_LOG" | grep -i "${PROJECT}" | head -20
+
+# If multiple projects have setup failures, scan all at once
+grep -n -i "error\|fail\|warn\|NotFound" "$BUILD_LOG" | grep -i "proj1\|proj2\|proj3" | head -30
+
+# Find the deployment sequence / config table for a project
+grep -n "${PROJECT}" "$BUILD_LOG" | head -20
+# Then Read with offset+limit around those line numbers to see surrounding context
+
+# Find env vars / mode
+grep -E "GIT_PR_NUMBER|E2E_NIGHTLY|VAULT_" "$BUILD_LOG" | head -10
+
+# Find config dump — look for "App Config" section near project mention
+grep -n "App Config\|${PROJECT}" "$BUILD_LOG" | head -20
+```
+
+After the build log explains the cause, confirm the resulting cluster state:
+```bash
+cat "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/pods.txt"
+cat "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/deployments.txt"
+tail -50 "$ARTIFACTS/e2e-test-results/logs/${PROJECT}/events.txt"
+```
+
+## Architecture Reference
+
+### e2e-test-utils
+
+All E2E tests use `@red-hat-developer-hub/e2e-test-utils` — a shared package that provides
+fixtures (`rhdh`, `uiHelper`, `loginHelper`), RHDH deployment logic, K8s helpers, and
+Playwright configuration. When debugging unexpected deployment behavior, config merging,
+or fixture internals, consult the source and docs:
+- **Repo**: https://github.com/redhat-developer/rhdh-e2e-test-utils
+- **Docs**: https://github.com/redhat-developer/rhdh-e2e-test-utils/tree/main/docs
+
+To check which version a failing run used:
+```bash
+grep -i "e2e-test-utils" "$BUILD_LOG" | head -5
+```
+
+### Project = Namespace = RHDH Deployment
+
+Each Playwright project creates a separate K8s namespace. Project name = namespace name.
+The project name tells you which log directory to check.
+
+### Deployment Modes
+
+| Mode | Detection | Plugins | Config Injection |
+|------|-----------|---------|-----------------|
+| PR check | `GIT_PR_NUMBER` set | OCI `pr_{N}__{version}` | Yes — metadata appConfigExamples |
+| Nightly | `E2E_NIGHTLY_MODE=true` | Released OCI refs | No |
+| Local | Neither | Local paths | Yes |
+
+### Deployment Flow (rhdh.deploy())
+
+```
+1. Config Merge: Package defaults → Auth config → Workspace overrides (deep merge)
+2. Secrets: envsubst on rhdh-secrets.yaml only ($VAR → value)
+3. Dynamic Plugins: auto-generate from metadata or use explicit file; resolve OCI URLs
+4. Helm Install: helm upgrade -i
+5. Readiness: Pod Ready + HTTP health check → sets RHDH_BASE_URL
+```
+
+### Secret Flow
+
+```
+CI env ($VAULT_TOKEN=abc) → rhdh-secrets.yaml (TOKEN: $VAULT_TOKEN) → app-config (token: ${TOKEN})
+                                ↓ envsubst                                ↓ K8s Secret reference
+                            TOKEN: abc                                token: abc (runtime)
+```
+
+## Common Failure Patterns
+
+### Plugin Not Loading
+**Grep for**: `grep -i "error\|fail" install-dynamic-plugins.log | tail -20`
+**Causes**: OCI not published (`/publish` not run), version mismatch, wrapper not disabled
+
+### Deployment Failure (CrashLoopBackOff)
+**Grep for**: `tail -50 events.txt` + `grep -i "error\|crash" backstage-backend.log | tail -20`
+**Causes**: Bad plugin config, missing env var, image pull failure
+
+### Login Failure
+**Check**: error-context.md page snapshot — is it login page or error?
+**Causes**: Keycloak not deployed, wrong secret, RHDH not ready
+
+### Timeout Waiting for Element
+**Check**: error-context.md → screenshot → pwtrace dom --interactive → adjacent tests in spec file
+**Causes**: Data not loaded, backend failing, wrong selector, element not on visible page
+**Before suggesting a fix**: `grep -A5 '<element text>' <spec-file>` — check if sibling
+tests already handle this element.
+
+### Config/Secret Mismatch
+**Detected in Step 1**: `YAML file ... does not exist` warning or missing config sections in dump
+**Causes**: Inconsistent paths in `rhdh.configure()` — one param points to a subdirectory
+while another falls back to the default path, or secrets file not loaded at all
+**Fix pattern**: Verify `appConfig`, `dynamicPlugins`, and `secrets` all use consistent paths
+
+### Worker Restart Lost State
+**Symptom**: Retry fails differently than first attempt
+**Check**: Was env var set inside runOnce? It's lost on worker restart.
+
+## Artifact Directory Structure
+
+```
+artifacts/
+├── playwright-report/
+│   ├── results.json             # Test results with stdout/stderr + trace attachment mappings
+│   └── data/                    # Hash-named trace/screenshot data (same content as e2e-test-results)
+│       └── <sha1-hash>.zip      # Trace files (may use 0-trace.trace format)
+├── e2e-test-results/
+│   ├── logs/<project>/          # Per-namespace cluster diagnostics
+│   │   ├── events.txt
+│   │   ├── pods.txt
+│   │   └── pods/<pod>/
+│   │       ├── backstage-backend.log
+│   │       └── install-dynamic-plugins.log
+│   └── specs-<slug>-<project>/  # Per-test failure artifacts
+│       ├── error-context.md     # Page snapshot (START HERE)
+│       ├── trace.zip            # Playwright trace (may need --fix for pwtrace)
+│       ├── test-failed-1.png    # Screenshot
+│       └── video.webm           # Recording
+└── fixed-traces/                # Created by find-traces.py --fix
+    └── specs-<slug>.zip         # pwtrace-compatible copies
+```
+
+**Trace locations:** Both `e2e-test-results/specs-*/trace.zip` and `playwright-report/data/*.zip`
+contain traces. The `e2e-test-results` traces are named by test slug (easier to identify).
+The `playwright-report/data` traces are hash-named (mapped via results.json attachments).
+Use `find-traces.py` to find and fix them — don't manually search for traces.
+
+**Trace format:** Newer Playwright uses `0-trace.trace` (not `trace.trace`) inside the zip.
+pwtrace expects `trace.trace`. Run `find-traces.py --fix` to create compatible copies.
+
+## Discovery Commands
+
+```bash
+# Workspaces with e2e tests
+ls -d workspaces/*/e2e-tests 2>/dev/null | cut -d'/' -f2
+
+# What config a project uses
+grep -A10 'rhdh.configure' workspaces/<name>/e2e-tests/tests/specs/*.spec.ts
+
+# What secrets a workspace needs
+cat workspaces/<name>/e2e-tests/.env.sample 2>/dev/null
+```
+
+## When the structured steps don't resolve the RCA
+
+If after following the steps above you still don't have a clear root cause — or your
+conclusion feels uncertain — set aside the hypothesis you've formed and reason freely.
+
+Keep the context of what you've already looked at: it tells you what's been ruled out
+and where the answer isn't. What you discard is the conclusion drawn from those steps,
+not the investigation history.
+
+1. **Re-read only the original error message** from Step 1.
+2. **Reason from the error outward**: what has to be true for this error to occur? Work
+   forward from the error itself, not backward from what the steps led you to look at.
+3. **Use what you've already seen to eliminate paths** — if you've checked cluster logs
+   and they were clean, the cause is upstream of runtime. If error-context showed the
+   page loaded fine, the issue isn't deployment. Let ruled-out evidence narrow the space.
+4. **Identify what you haven't checked yet** that could still explain the error, and go
+   there directly.
+5. **Confirm with one cross-check** before concluding — a single additional artifact that
+   either supports or contradicts the new hypothesis.

--- a/.fullsend/skills/e2e-failure-analysis/scripts/diagnostics.py
+++ b/.fullsend/skills/e2e-failure-analysis/scripts/diagnostics.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Extract test results, deployment warnings, and config dumps from results.json.
+
+Usage:
+    python3 diagnostics.py <ARTIFACTS_DIR> [--project <name>]
+
+Arguments:
+    ARTIFACTS_DIR   Path to the artifacts directory containing playwright-report/results.json
+    --project       Filter output to a specific Playwright project name (case-insensitive substring match)
+
+Output sections:
+    1. TEST RESULTS — pass/fail/skip counts and failed test details
+    2. DIAGNOSTICS PER FAILED PROJECT — config table dumps and filtered warnings/errors
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def walk_suites(suite, specs=None):
+    if specs is None:
+        specs = []
+    for spec in suite.get("specs", []):
+        specs.append(spec)
+    for child in suite.get("suites", []):
+        walk_suites(child, specs)
+    return specs
+
+
+WARNING_PATTERNS = re.compile(
+    r"YAML file.*does not exist|"
+    r"error|Error|ERROR|"
+    r"WARN|warn|Warning|"
+    r"does not exist|not found|"
+    r"missing|Missing|"
+    r"failed|Failed|FAILED|"
+    r"CrashLoopBackOff|ImagePullBackOff|"
+    r"secret.*not|Secret.*not",
+    re.IGNORECASE,
+)
+NOISE = re.compile(r"node_modules|trace_id|Download|Extracting|integrity checksum")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <ARTIFACTS_DIR> [--project <name>]", file=sys.stderr)
+        sys.exit(1)
+
+    artifacts = Path(sys.argv[1])
+    project_filter = None
+    if "--project" in sys.argv:
+        idx = sys.argv.index("--project")
+        if idx + 1 < len(sys.argv):
+            project_filter = sys.argv[idx + 1].lower()
+
+    results_file = artifacts / "playwright-report" / "results.json"
+    if not results_file.exists():
+        print(f"ERROR: {results_file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    r = json.loads(results_file.read_text())
+    stats = r.get("stats", {})
+    all_specs = []
+    for s in r.get("suites", []):
+        walk_suites(s, all_specs)
+
+    # Section 1: Test Results
+    print("=" * 70)
+    print("TEST RESULTS")
+    print("=" * 70)
+    print(
+        f"Passed: {stats.get('expected', 0)}  "
+        f"Failed: {stats.get('unexpected', 0)}  "
+        f"Skipped: {stats.get('skipped', 0)}  "
+        f"Flaky: {stats.get('flaky', 0)}"
+    )
+    print()
+
+    failed_projects = set()
+    for spec in all_specs:
+        for test in spec.get("tests", []):
+            proj = test.get("projectName", "?")
+            if project_filter and project_filter not in proj.lower():
+                continue
+            for result in test.get("results", []):
+                status = result["status"]
+                if status not in ("passed", "skipped"):
+                    failed_projects.add(proj)
+                    err = result.get("error", {}).get("message", "no error")
+                    print(f"FAILED [{proj}] {spec['title']}")
+                    print(f"  {err[:400]}")
+                    print()
+                elif project_filter:
+                    print(f"{status.upper()} [{proj}] {spec['title']}")
+
+    # Section 2: Diagnostics per failed project
+    for proj in sorted(failed_projects):
+        print("=" * 70)
+        print(f"DIAGNOSTICS FOR PROJECT: {proj}")
+        print("=" * 70)
+        for spec in all_specs:
+            for test in spec.get("tests", []):
+                if test.get("projectName") != proj:
+                    continue
+                for result in test.get("results", []):
+                    stdout = "".join(
+                        s.get("text", "") for s in result.get("stdout", [])
+                    )
+                    if not stdout:
+                        continue
+
+                    title = spec["title"][:50]
+
+                    # Config tables
+                    for match in re.finditer(
+                        r"(┌─[^\n]*(?:Config|Plugins|Deployment)[^\n]*\n)(.*?)(└─+)",
+                        stdout,
+                        re.DOTALL,
+                    ):
+                        header = match.group(1).strip()
+                        body = match.group(2)
+                        if len(body) < 5000:
+                            print(f"--- {header} [{title}] ---")
+                            print(body.rstrip())
+                            print()
+
+                    # Warnings and errors
+                    warnings = []
+                    for line in stdout.split("\n"):
+                        if WARNING_PATTERNS.search(line) and not NOISE.search(line):
+                            warnings.append(line.rstrip())
+                    if warnings:
+                        print(f"--- Warnings/Errors [{title}] ---")
+                        for w in warnings[-40:]:
+                            print(w)
+                        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.fullsend/skills/e2e-failure-analysis/scripts/download-artifacts.py
+++ b/.fullsend/skills/e2e-failure-analysis/scripts/download-artifacts.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Download E2E test artifacts from a prow/gcsweb URL via the public GCS JSON API."""
+
+import gzip
+import json
+import os
+import re
+import shutil
+import ssl
+import sys
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib.parse import urlparse
+
+BUCKET = "test-platform-results"
+API_URL = f"https://storage.googleapis.com/storage/v1/b/{BUCKET}/o"
+DL_URL = f"https://storage.googleapis.com/{BUCKET}"
+MAX_WORKERS = 8
+
+EXCLUDE_RE = re.compile(r"\.webm$|/playwright-report/data/|/playwright-report/trace/")
+INCLUDE_RE = re.compile(r"/e2e-test-results/.*/trace\.zip$")
+
+
+def _ssl_ctx():
+    for ca in (os.environ.get("SSL_CERT_FILE"), os.environ.get("REQUESTS_CA_BUNDLE"),
+               "/etc/openshell-tls/ca-bundle.pem", "/etc/ssl/certs/ca-certificates.crt"):
+        if ca and Path(ca).is_file():
+            return ssl.create_default_context(cafile=ca)
+    return ssl.create_default_context()
+
+
+CTX = _ssl_ctx()
+
+
+def parse_url(url):
+    path = urlparse(url.rstrip("/")).path
+    for pfx in ("/view/gs/", "/gcs/"):
+        if path.startswith(pfx):
+            path = path[len(pfx):]
+            break
+    parts = path.split("/")
+
+    if "pr-logs" in parts:
+        i = parts.index("pull") + 1
+        pr, job, jid = parts[i + 1], parts[i + 2], parts[i + 3]
+        sub = job.split("-main-")[-1] if "-main-" in job else "e2e-ocp-helm"
+        return {"type": "pr", "pr": pr, "job_id": jid, "subdir": sub,
+                "gcs": f"pr-logs/pull/redhat-developer_rhdh-plugin-export-overlays/{pr}/{job}/{jid}"}
+
+    if "/logs/" in "/" + "/".join(parts):
+        i = parts.index("logs")
+        job, jid = parts[i + 1], parts[i + 2]
+        sub = job.split("-main-")[-1] if "-main-" in job else "e2e-ocp-helm-nightly"
+        return {"type": "nightly", "job_id": jid, "subdir": sub,
+                "gcs": f"logs/{job}/{jid}"}
+
+    return None
+
+
+def gcs_list(prefix):
+    items, token = [], None
+    while True:
+        p = {"prefix": prefix, "maxResults": "1000"}
+        if token:
+            p["pageToken"] = token
+        with urllib.request.urlopen(f"{API_URL}?{urllib.parse.urlencode(p)}", context=CTX) as r:
+            data = json.loads(r.read())
+        items.extend(data.get("items", []))
+        token = data.get("nextPageToken")
+        if not token:
+            return items
+
+
+def download(gcs_prefix, dest):
+    dest.mkdir(parents=True, exist_ok=True)
+
+    print("Listing objects...", file=sys.stderr)
+    all_items = gcs_list(gcs_prefix + "/")
+    keep = [i for i in all_items if INCLUDE_RE.search(i["name"]) or not EXCLUDE_RE.search(i["name"])]
+    total_mb = sum(int(i.get("size", 0)) for i in keep) / 1024 / 1024
+    print(f"Downloading {len(keep)}/{len(all_items)} files ({total_mb:.1f} MB)...", file=sys.stderr)
+
+    plen = len(gcs_prefix) + 1
+
+    def _dl(item):
+        rel = item["name"][plen:]
+        local = dest / rel
+        local.parent.mkdir(parents=True, exist_ok=True)
+        urllib.request.urlretrieve(f"{DL_URL}/{urllib.parse.quote(item['name'], safe='/')}", str(local))
+
+    failed = 0
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futs = {pool.submit(_dl, i): i for i in keep}
+        for f in as_completed(futs):
+            try:
+                f.result()
+            except Exception as e:
+                failed += 1
+                print(f"  FAILED: {futs[f]['name'].split('/')[-1]}: {e}", file=sys.stderr)
+
+    print(f"Done: {len(keep) - failed}/{len(keep)} files.", file=sys.stderr)
+
+    # Decompress gzipped text files (GCS serves them with raw gzip encoding)
+    for path in dest.rglob("*"):
+        if not path.is_file() or path.suffix in (".zip", ".gz", ".png", ".webm"):
+            continue
+        with open(path, "rb") as f:
+            if f.read(2) != b"\x1f\x8b":
+                continue
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with gzip.open(path, "rb") as fi, open(tmp, "wb") as fo:
+            shutil.copyfileobj(fi, fo)
+        tmp.replace(path)
+
+
+def is_cache_valid(artifacts_dir):
+    if not artifacts_dir.exists():
+        return False
+    has = lambda g: any(artifacts_dir.rglob(g))
+    return sum([has("logs/*/pods.txt"), has("results.json"), has("error-context.md")]) >= 2
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 download-artifacts.py <PROW_URL>", file=sys.stderr)
+        sys.exit(1)
+
+    info = parse_url(sys.argv[1])
+    if not info:
+        print(f"ERROR: Could not parse URL: {sys.argv[1]}", file=sys.stderr)
+        sys.exit(1)
+
+    base = Path("node_modules/.cache/e2e-artifacts")
+    cache_dir = base / info.get("pr", "nightly") / info["job_id"]
+    container = "redhat-developer-rhdh-plugin-export-overlays-ocp-helm"
+    artifacts_dir = cache_dir / container / "artifacts"
+
+    if is_cache_valid(artifacts_dir):
+        print("Artifacts already downloaded, using cache.", file=sys.stderr)
+        print(artifacts_dir)
+        return
+
+    if cache_dir.exists():
+        print("Cache incomplete, re-downloading...", file=sys.stderr)
+        shutil.rmtree(cache_dir)
+
+    gcs_src = f"{info['gcs']}/artifacts/{info['subdir']}/{container}"
+    download(gcs_src, cache_dir / container)
+
+    if not artifacts_dir.exists():
+        print(f"ERROR: Artifacts dir not found: {artifacts_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Download complete.", file=sys.stderr)
+    print(artifacts_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/.fullsend/skills/e2e-failure-analysis/scripts/find-traces.py
+++ b/.fullsend/skills/e2e-failure-analysis/scripts/find-traces.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Find, map, and fix Playwright trace files for pwtrace analysis.
+
+Traces live in two locations (same content, different naming):
+  1. e2e-test-results/specs-<slug>/trace.zip — named by test, easy to identify
+  2. playwright-report/data/<hash>.zip — hash-named, referenced by results.json
+
+Newer Playwright versions use `0-trace.trace` instead of `trace.trace` inside the zip,
+which pwtrace can't read. This script identifies traces, maps them to test names,
+and creates fixed copies that pwtrace can consume.
+
+Usage:
+    python3 find-traces.py <ARTIFACTS_DIR> [--project <name>] [--fix]
+
+Arguments:
+    ARTIFACTS_DIR   Path to the artifacts directory containing playwright-report/ and e2e-test-results/
+    --project       Filter to a specific project name (case-insensitive substring)
+    --fix           Create pwtrace-compatible copies in <ARTIFACTS_DIR>/fixed-traces/
+
+Without --fix, shows trace locations and whether they need fixing.
+With --fix, creates fixed copies and prints ready-to-use pwtrace commands.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def check_trace_format(zip_path: Path) -> tuple[str, bool]:
+    """Check trace format. Returns (format_description, needs_fix)."""
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            names = zf.namelist()
+            if "trace.trace" in names:
+                return "standard", False
+            if "0-trace.trace" in names:
+                return "0-trace.trace (needs fix for pwtrace)", True
+            trace_files = [n for n in names if "trace" in n.lower()]
+            if trace_files:
+                return f"non-standard: {trace_files}", True
+            return "no trace data found", True
+    except zipfile.BadZipFile:
+        return "INVALID ZIP", True
+
+
+def fix_trace(zip_path: Path, output_path: Path) -> bool:
+    """Create a pwtrace-compatible copy by adding trace.trace alongside 0-trace.trace."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        try:
+            with zipfile.ZipFile(zip_path) as zf:
+                zf.extractall(tmp)
+        except zipfile.BadZipFile:
+            return False
+
+        src = tmp / "0-trace.trace"
+        dst = tmp / "trace.trace"
+        if src.exists() and not dst.exists():
+            shutil.copy2(src, dst)
+        elif not src.exists():
+            return False
+
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _dirs, files in os.walk(tmp):
+                for f in files:
+                    file_path = Path(root) / f
+                    arcname = file_path.relative_to(tmp)
+                    zf.write(file_path, arcname)
+
+    return True
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <ARTIFACTS_DIR> [--project <name>] [--fix]", file=sys.stderr)
+        sys.exit(1)
+
+    artifacts = Path(sys.argv[1])
+    project_filter = None
+    do_fix = "--fix" in sys.argv
+    if "--project" in sys.argv:
+        idx = sys.argv.index("--project")
+        if idx + 1 < len(sys.argv):
+            project_filter = sys.argv[idx + 1].lower()
+
+    results_file = artifacts / "playwright-report" / "results.json"
+    if not results_file.exists():
+        print(f"ERROR: {results_file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    r = json.loads(results_file.read_text())
+
+    # Collect all specs from results.json
+    all_specs = []
+    def walk(suite):
+        for spec in suite.get("specs", []):
+            all_specs.append(spec)
+        for child in suite.get("suites", []):
+            walk(child)
+    for s in r.get("suites", []):
+        walk(s)
+
+    fixed_dir = artifacts / "fixed-traces"
+    if do_fix:
+        fixed_dir.mkdir(exist_ok=True)
+
+    # Map each failed test to its trace file
+    print("=" * 70)
+    print("TRACE FILES FOR FAILED TESTS")
+    print("=" * 70)
+
+    traces_found = 0
+    for spec in all_specs:
+        for test in spec.get("tests", []):
+            proj = test.get("projectName", "?")
+            if project_filter and project_filter not in proj.lower():
+                continue
+
+            for result in test.get("results", []):
+                status = result.get("status", "?")
+                if status in ("passed", "skipped"):
+                    continue
+
+                title = spec["title"]
+                print(f"\nFAILED [{proj}] {title}")
+
+                # Find trace from attachment
+                attachments = result.get("attachments", [])
+                trace_att = [a for a in attachments if a.get("name") == "trace"]
+                if not trace_att:
+                    print("  No trace attachment recorded")
+                    continue
+
+                ci_path = trace_att[0].get("path", "")
+                if not ci_path:
+                    print("  Trace attachment has no path")
+                    continue
+
+                # Find local trace via the CI slug
+                slug = Path(ci_path).parent.name
+                local_trace = artifacts / "e2e-test-results" / slug / "trace.zip"
+
+                if not local_trace.exists():
+                    print(f"  Trace not found at: {local_trace}")
+                    continue
+
+                size = local_trace.stat().st_size
+                if size < 1000:
+                    print(f"  Trace stub ({size} bytes) — no usable trace data")
+                    continue
+
+                traces_found += 1
+                fmt, needs_fix = check_trace_format(local_trace)
+                print(f"  Trace: {local_trace}")
+                print(f"  Size: {size:,} bytes | Format: {fmt}")
+
+                if needs_fix and do_fix:
+                    # Use a descriptive name based on the test slug
+                    fixed_name = f"{slug}.zip"
+                    fixed_path = fixed_dir / fixed_name
+                    if fix_trace(local_trace, fixed_path):
+                        print(f"  ✓ Fixed: {fixed_path}")
+                        print(f"  → npx pwtrace show {fixed_path}")
+                    else:
+                        print(f"  ✗ Failed to fix trace")
+                elif needs_fix:
+                    print(f"  ⚠ Needs --fix to work with pwtrace")
+                else:
+                    print(f"  → npx pwtrace show {local_trace}")
+
+    if traces_found == 0:
+        print("\nNo traces found for failed tests.")
+    elif do_fix:
+        print(f"\n{'='*70}")
+        print(f"Fixed {traces_found} trace(s) in: {fixed_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
@@ -6,6 +6,7 @@ const FAILSWITCH_APP_LABEL = "app.kubernetes.io/name=failswitch";
 const POD_HTTPBIN_POLL_MS = 2_000;
 const POD_HTTPBIN_TIMEOUT_MS = 120_000;
 const FAILSWITCH_ROLLOUT_TIMEOUT_S = 120;
+const MANAGEMENT_READY_TIMEOUT_MS = 60_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -92,6 +93,64 @@ export function restartAndWait(ns: string): void {
   );
 }
 
+/**
+ * Poll the SonataFlow management API health endpoint until it responds
+ * successfully. After a rollout restart the pod may report Ready to K8s
+ * before the management API is fully initialised, causing retrigger calls
+ * to receive 503 Service Temporarily Unavailable.
+ */
+async function waitForManagementApiReady(
+  ns: string,
+  timeoutMs = MANAGEMENT_READY_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pod = runOcOptional([
+      "-n",
+      ns,
+      "get",
+      "pods",
+      "-l",
+      FAILSWITCH_APP_LABEL,
+      "--field-selector=status.phase=Running",
+      "-o",
+      "jsonpath={.items[0].metadata.name}",
+    ]).stdout.trim();
+
+    if (pod) {
+      // Quarkus/SonataFlow exposes /q/health/ready; fall back to the
+      // management processes endpoint if the health path isn't available.
+      const health = runOcOptional(
+        [
+          "-n",
+          ns,
+          "exec",
+          pod,
+          "--",
+          "curl",
+          "-sf",
+          "-o",
+          "/dev/null",
+          "-w",
+          "%{http_code}",
+          "http://localhost:8080/q/health/ready",
+        ],
+        15_000,
+      );
+      if (health.exitCode === 0 && health.stdout.trim() === "200") {
+        return;
+      }
+    }
+
+    await sleep(POD_HTTPBIN_POLL_MS);
+  }
+  // Don't fail the test — proceed and let the retrigger attempt surface
+  // any remaining issues with a clearer error message.
+  console.warn(
+    `[patchHttpbin] SonataFlow management API readiness not confirmed within ${timeoutMs}ms, proceeding anyway`,
+  );
+}
+
 export async function patchHttpbin(ns: string, value: string): Promise<void> {
   let existing: EnvEntry[] = [];
   try {
@@ -141,6 +200,7 @@ export async function patchHttpbin(ns: string, value: string): Promise<void> {
 
   restartAndWait(ns);
   await waitForRunningPodHttpbin(ns, value);
+  await waitForManagementApiReady(ns);
 }
 
 export async function cleanupAfterTest(

--- a/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
@@ -6,7 +6,6 @@ const FAILSWITCH_APP_LABEL = "app.kubernetes.io/name=failswitch";
 const POD_HTTPBIN_POLL_MS = 2_000;
 const POD_HTTPBIN_TIMEOUT_MS = 120_000;
 const FAILSWITCH_ROLLOUT_TIMEOUT_S = 120;
-const MANAGEMENT_READY_TIMEOUT_MS = 60_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -93,64 +92,6 @@ export function restartAndWait(ns: string): void {
   );
 }
 
-/**
- * Poll the SonataFlow management API health endpoint until it responds
- * successfully. After a rollout restart the pod may report Ready to K8s
- * before the management API is fully initialised, causing retrigger calls
- * to receive 503 Service Temporarily Unavailable.
- */
-async function waitForManagementApiReady(
-  ns: string,
-  timeoutMs = MANAGEMENT_READY_TIMEOUT_MS,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const pod = runOcOptional([
-      "-n",
-      ns,
-      "get",
-      "pods",
-      "-l",
-      FAILSWITCH_APP_LABEL,
-      "--field-selector=status.phase=Running",
-      "-o",
-      "jsonpath={.items[0].metadata.name}",
-    ]).stdout.trim();
-
-    if (pod) {
-      // Quarkus/SonataFlow exposes /q/health/ready; fall back to the
-      // management processes endpoint if the health path isn't available.
-      const health = runOcOptional(
-        [
-          "-n",
-          ns,
-          "exec",
-          pod,
-          "--",
-          "curl",
-          "-sf",
-          "-o",
-          "/dev/null",
-          "-w",
-          "%{http_code}",
-          "http://localhost:8080/q/health/ready",
-        ],
-        15_000,
-      );
-      if (health.exitCode === 0 && health.stdout.trim() === "200") {
-        return;
-      }
-    }
-
-    await sleep(POD_HTTPBIN_POLL_MS);
-  }
-  // Don't fail the test — proceed and let the retrigger attempt surface
-  // any remaining issues with a clearer error message.
-  console.warn(
-    `[patchHttpbin] SonataFlow management API readiness not confirmed within ${timeoutMs}ms, proceeding anyway`,
-  );
-}
-
 export async function patchHttpbin(ns: string, value: string): Promise<void> {
   let existing: EnvEntry[] = [];
   try {
@@ -200,7 +141,6 @@ export async function patchHttpbin(ns: string, value: string): Promise<void> {
 
   restartAndWait(ns);
   await waitForRunningPodHttpbin(ns, value);
-  await waitForManagementApiReady(ns);
 }
 
 export async function cleanupAfterTest(


### PR DESCRIPTION
## Summary

- Adds the `e2e-failure-analysis` skill with Python diagnostic scripts for downloading artifacts, finding traces, and running diagnostics on E2E nightly test failures
- Adds the `e2e-fix` agent that automates the full fix lifecycle: analyze → classify → dedup → issue → fix → push → CI
- Wires the skill symlink under `.claude/skills/` so it is available as a slash command in Claude Code sessions

## Test plan

- [ ] Run `/e2e-failure-analysis` on a known failing gcsweb URL to verify the skill triggers correctly
- [ ] Verify diagnostic scripts execute without errors against a real nightly run artifact directory
- [ ] Confirm `e2e-fix` agent picks up `PROW_URL` from env and progresses through Phase 1 setup

Assisted-by: Claude Code