### PR TITLE
fix(e2e): wait for SonataFlow health readiness after httpbin patch

### DIFF
--- a/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
@@ -6,6 +6,8 @@ const FAILSWITCH_APP_LABEL = "app.kubernetes.io/name=failswitch";
 const POD_HTTPBIN_POLL_MS = 2_000;
 const POD_HTTPBIN_TIMEOUT_MS = 120_000;
 const FAILSWITCH_ROLLOUT_TIMEOUT_S = 120;
+const HEALTH_READY_TIMEOUT_MS = 60_000;
+const HEALTH_READY_POLL_MS = 2_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -92,6 +94,61 @@ export function restartAndWait(ns: string): void {
   );
 }
 
+/**
+ * Poll the Quarkus health endpoint inside the failswitch pod until it
+ * responds 200. After a rollout restart the pod may report Ready to K8s
+ * before the SonataFlow management API is fully initialised, causing
+ * retrigger calls to receive 503 Service Temporarily Unavailable.
+ */
+async function waitForHealthReady(
+  ns: string,
+  timeoutMs = HEALTH_READY_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pod = runOcOptional([
+      "-n",
+      ns,
+      "get",
+      "pods",
+      "-l",
+      FAILSWITCH_APP_LABEL,
+      "--field-selector=status.phase=Running",
+      "-o",
+      "jsonpath={.items[0].metadata.name}",
+    ]).stdout.trim();
+
+    if (pod) {
+      const health = runOcOptional(
+        [
+          "-n",
+          ns,
+          "exec",
+          pod,
+          "--",
+          "curl",
+          "-sf",
+          "-o",
+          "/dev/null",
+          "-w",
+          "%{http_code}",
+          "http://localhost:8080/q/health/ready",
+        ],
+        15_000,
+      );
+      if (health.exitCode === 0 && health.stdout.trim() === "200") {
+        return;
+      }
+    }
+
+    await sleep(HEALTH_READY_POLL_MS);
+  }
+
+  console.warn(
+    `[patchHttpbin] Health readiness not confirmed within ${timeoutMs}ms, proceeding`,
+  );
+}
+
 export async function patchHttpbin(ns: string, value: string): Promise<void> {
   let existing: EnvEntry[] = [];
   try {
@@ -141,6 +198,7 @@ export async function patchHttpbin(ns: string, value: string): Promise<void> {
 
   restartAndWait(ns);
   await waitForRunningPodHttpbin(ns, value);
+  await waitForHealthReady(ns);
 }
 
 export async function cleanupAfterTest(


### PR DESCRIPTION
## Summary

- Add `waitForHealthReady()` to poll the Quarkus `/q/health/ready` endpoint inside the failswitch pod after rollout restart
- Called at the end of `patchHttpbin()` to ensure the SonataFlow management API is fully initialized before returning
- Prevents the "Rerun Failswitch from failure point" test from hitting a 503 when the retrigger happens too soon after pod restart

## Root Cause

After `patchHttpbin` restarts the failswitch deployment, the pod reaches K8s `Running` state and the HTTPBIN env var is confirmed correct, but the Quarkus application inside hasn't fully initialized its HTTP endpoints. The test's retrigger call (via the "Run again → From failure point" UI action) hits this window and receives `503 Service Temporarily Unavailable` from the not-yet-ready management API.

The previous issue analysis (#2632) incorrectly classified this as a `product_bug` (SonataFlow caching old env vars). The workflow log disproves this — the retrigger error was `503`, not the `foobar.org` SSL error. The env var was correctly updated; the pod just wasn't ready to serve requests.

Fixes #2632

## Test plan

- [ ] CI passes on `/test e2e-ocp-helm-nightly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)