### PR TITLE
chore(orchestrator): backport 1.9.6 CVE fixes

### DIFF
--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend-module-loki.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend-module-loki.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki"
   # Tag: 1.9.4--1.0.6, Build date: 2026-04-30T18:56:52Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend-module-loki@sha256:96746078a2c13ebf673d7f84d327f0e60d70e3c36794ec9b953016834e263f78"
-  version: 1.0.6
+  version: 1.0.7
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.45.3
@@ -35,3 +35,4 @@ spec:
           workflowLogProvider:
             loki:
               baseUrl: ${LOKI_BASE_URL}
+              token: ${AUTH_TOKEN}

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-backend.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-backend"
   # Tag: 1.9.4--8.6.7, Build date: 2026-04-30T18:57:25Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend@sha256:0909c5ed32a913ffa51bd248f08b9afdb938e6461dedc3a08c6ac6e963a85dd7"
-  version: 8.6.7
+  version: 8.6.8
   backstage:
     role: backend-plugin
     supportedVersions: 1.45.3

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-form-widgets.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator-form-widgets.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets"
   # Tag: 1.9.4--1.6.9, Build date: 2026-04-30T18:56:56Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets@sha256:70fe997519010e9cb570249f609ae22771b85a9813767fe7ad7818a2aac82a3e"
-  version: 1.6.9
+  version: 1.6.10
   backstage:
     role: frontend-plugin
     supportedVersions: 1.45.3

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-orchestrator.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-orchestrator'
   # Tag: 1.9.4--5.4.7, Build date: 2026-04-30T18:56:52Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator@sha256:1f33cd54d84e597fbb72acae06ba719d42f0a5d45ec1e3ae96845c6cfad72177"
-  version: 5.4.7
+  version: 5.4.8
   backstage:
     role: frontend-plugin
     supportedVersions: 1.45.3

--- a/workspaces/orchestrator/metadata/redhat-backstage-plugin-scaffolder-backend-module-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/redhat-backstage-plugin-scaffolder-backend-module-orchestrator.yaml
@@ -20,7 +20,7 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator"
   # Tag: 1.9.4--1.3.6, Build date: 2026-04-30T18:56:21Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator@sha256:f02280932ca261a359f3c640dc11e400b299eadfd25e6cac0d9a93c0ad65f90f"
-  version: 1.3.6
+  version: 1.3.7
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.45.3

--- a/workspaces/orchestrator/source.json
+++ b/workspaces/orchestrator/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"86db18c0d24cc0ecd7a76753ce77247dc17fefa9","repo-flat":false,"repo-backstage-version":"1.45.2"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"3ab71d446a1af2c6192eddac2d443d40c0a5eaf5","repo-flat":false,"repo-backstage-version":"1.45.2"}


### PR DESCRIPTION
Includes RHDH v1.9.6 CVE fixes, points to this PR: https://github.com/redhat-developer/rhdh-plugins/pull/3524