### PR TITLE
Moving status from comment to attr in default.packages.yaml

### DIFF
--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -2,68 +2,112 @@
 #
 # Do not add packages to this list without prior agreement from PM
 #
-# New packages should only be "tech-preview" or "generally-available"
+# New packages *status* should only be "tech-preview" or "generally-available"
 #    16 are tech-preview, and should be promoted via a PM-sponsored Feature to generally-available at some point
 #    06 are community, and should be removed over time
 packages:
-  enabled: # should onyly include GA (or TP with a path to GA) content here
-  - package: '@backstage-community/plugin-analytics-provider-segment' # generally-available
-  - package: '@backstage-community/plugin-scaffolder-backend-module-regex' # generally-available
-  - package: '@backstage/plugin-techdocs' # generally-available
-  - package: '@backstage/plugin-techdocs-backend' # generally-available
-  - package: '@backstage/plugin-techdocs-module-addons-contrib' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-adoption-insights' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-adoption-insights-backend' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions' # tech-preview
-  - package: '@red-hat-developer-hub/backstage-plugin-dynamic-home-page' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-global-header' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-extensions' # tech-preview
-  - package: '@red-hat-developer-hub/backstage-plugin-extensions-backend' # tech-preview
-  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed" # generally-available
-  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed-backend" # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-quickstart' # generally-available
+  enabled: # should only include GA (or TP with a path to GA) content here
+  - package: '@backstage-community/plugin-analytics-provider-segment'
+    status: "generally-available"
+  - package: '@backstage-community/plugin-scaffolder-backend-module-regex'
+    status: "generally-available"
+  - package: '@backstage/plugin-techdocs'
+    status: "generally-available"
+  - package: '@backstage/plugin-techdocs-backend'
+    status: "generally-available"
+  - package: '@backstage/plugin-techdocs-module-addons-contrib'
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-adoption-insights'
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions'
+    status: "tech-preview"
+  - package: '@red-hat-developer-hub/backstage-plugin-dynamic-home-page'
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-global-header'
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-extensions'
+    status: "tech-preview"
+  - package: '@red-hat-developer-hub/backstage-plugin-extensions-backend'
+    status: "tech-preview"
+  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed"
+    status: "generally-available"
+  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed-backend"
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-quickstart'
+    status: "generally-available"
 
   disabled: # should ideally contain no community content; TODO: remove some community or TP stuff in 2.1?
-  - package: '@backstage-community/plugin-acr' # tech-preview
-  - package: '@backstage-community/plugin-catalog-backend-module-keycloak' # generally-available
-  - package: '@backstage-community/plugin-catalog-backend-module-pingidentity' # tech-preview
-  - package: '@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor' # tech-preview
-  - package: '@backstage-community/plugin-rbac' # generally-available
-  - package: '@backstage-community/plugin-scaffolder-backend-module-kubernetes' # generally-available
-  - package: '@backstage-community/plugin-tech-radar' # generally-available
-  - package: '@backstage-community/plugin-tech-radar-backend' # generally-available
-  - package: '@backstage-community/plugin-topology' # generally-available
-  - package: '@backstage/plugin-catalog-backend-module-github' # generally-available
-  - package: '@backstage/plugin-catalog-backend-module-github-org' # generally-available
+  - package: '@backstage-community/plugin-acr'
+    status: "tech-preview"
+  - package: '@backstage-community/plugin-catalog-backend-module-keycloak'
+    status: "generally-available"
+  - package: '@backstage-community/plugin-catalog-backend-module-pingidentity'
+    status: "tech-preview"
+  - package: '@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor'
+    status: "tech-preview"
+  - package: '@backstage-community/plugin-rbac'
+    status: "generally-available"
+  - package: '@backstage-community/plugin-scaffolder-backend-module-kubernetes'
+    status: "generally-available"
+  - package: '@backstage-community/plugin-tech-radar'
+    status: "generally-available"
+  - package: '@backstage-community/plugin-tech-radar-backend'
+    status: "generally-available"
+  - package: '@backstage-community/plugin-topology'
+    status: "generally-available"
+  - package: '@backstage/plugin-catalog-backend-module-github'
+    status: generally-available
+  - package: '@backstage/plugin-catalog-backend-module-github-org'
+    status: "generally-available"
   - package: '@backstage/plugin-catalog-backend-module-gitlab' # production
   - package: '@backstage/plugin-catalog-backend-module-gitlab-org' # production
-  - package: '@backstage/plugin-catalog-backend-module-ldap' # generally-available
-  - package: '@backstage/plugin-catalog-backend-module-msgraph' # generally-available
-  - package: '@backstage/plugin-events-backend-module-github' # tech-preview
-  - package: '@backstage/plugin-kubernetes' # tech-preview
-  - package: '@backstage/plugin-kubernetes-backend' # generally-available
-  - package: '@backstage/plugin-notifications' # tech-preview
-  - package: '@backstage/plugin-notifications-backend' # tech-preview
-  - package: '@backstage/plugin-notifications-backend-module-email' # tech-preview
-  - package: '@backstage/plugin-scaffolder-backend-module-github' # generally-available
-  - package: '@backstage/plugin-scaffolder-backend-module-gitlab' # tech-preview
-  - package: '@backstage/plugin-signals' # tech-preview
-  - package: '@backstage/plugin-signals-backend' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-bulk-import' # tech-preview
-  - package: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend' # tech-preview
-  - package: '@red-hat-developer-hub/backstage-plugin-homepage-backend' # tech-preview
-  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki' # tech-preview
-  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets' # generally-available
-  - package: '@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator' # generally-available
-  - package: '@roadiehq/scaffolder-backend-module-http-request' # generally-available
+  - package: '@backstage/plugin-catalog-backend-module-ldap'
+    status: "generally-available"
+  - package: '@backstage/plugin-catalog-backend-module-msgraph'
+    status: "generally-available"
+  - package: '@backstage/plugin-events-backend-module-github'
+    status: "tech-preview"
+  - package: '@backstage/plugin-kubernetes'
+    status: "tech-preview"
+  - package: '@backstage/plugin-kubernetes-backend'
+    status: "generally-available"
+  - package: '@backstage/plugin-notifications'
+    status: "tech-preview"
+  - package: '@backstage/plugin-notifications-backend'
+    status: "tech-preview"
+  - package: '@backstage/plugin-notifications-backend-module-email'
+    status: "tech-preview"
+  - package: '@backstage/plugin-scaffolder-backend-module-github'
+    status: generally-available
+  - package: '@backstage/plugin-scaffolder-backend-module-gitlab'
+    status: "tech-preview"
+  - package: '@backstage/plugin-signals'
+    status: "tech-preview"
+  - package: '@backstage/plugin-signals-backend'
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-bulk-import'
+    status: "tech-preview"
+  - package: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend'
+    status: "tech-preview"
+  - package: '@red-hat-developer-hub/backstage-plugin-homepage-backend'
+    status: "tech-preview"
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator'
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend'
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki'
+    status: "tech-preview"
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets'
+    status: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator'
+    status: "generally-available"
+  - package: '@roadiehq/scaffolder-backend-module-http-request'
+    status: "generally-available"
 
   # these community supported plugins do not have a downstream analogue in overlays repo's rhdh-supported-packages.txt
   - package: '@backstage-community/plugin-quay' # community
   - package: '@backstage-community/plugin-quay-backend' # community
   - package: '@backstage-community/plugin-scaffolder-backend-module-quay' # community
   - package: '@backstage-community/plugin-tekton' # community
-  - package: '@roadiehq/backstage-plugin-argo-cd-backend' # community - TODO: replace with RH Argo CD plugin when it's ready
-  - package: '@roadiehq/scaffolder-backend-argocd' # community - TODO: replace with RH Argo CD plugin when it's ready
+  - package: '@roadiehq/backstage-plugin-argo-cd-backend' # community TODO: replace with RH Argo CD plugin when it's ready
+  - package: '@roadiehq/scaffolder-backend-argocd' # community TODO: replace with RH Argo CD plugin when it's ready

--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -59,8 +59,10 @@ packages:
     status: generally-available
   - package: '@backstage/plugin-catalog-backend-module-github-org'
     status: "generally-available"
-  - package: '@backstage/plugin-catalog-backend-module-gitlab' # production
-  - package: '@backstage/plugin-catalog-backend-module-gitlab-org' # production
+  - package: '@backstage/plugin-catalog-backend-module-gitlab'
+    status: "generally-available"
+  - package: '@backstage/plugin-catalog-backend-module-gitlab-org'
+    status: "generally-available"
   - package: '@backstage/plugin-catalog-backend-module-ldap'
     status: "generally-available"
   - package: '@backstage/plugin-catalog-backend-module-msgraph'
@@ -105,9 +107,15 @@ packages:
     status: "generally-available"
 
   # these community supported plugins do not have a downstream analogue in overlays repo's rhdh-supported-packages.txt
-  - package: '@backstage-community/plugin-quay' # community
-  - package: '@backstage-community/plugin-quay-backend' # community
-  - package: '@backstage-community/plugin-scaffolder-backend-module-quay' # community
-  - package: '@backstage-community/plugin-tekton' # community
-  - package: '@roadiehq/backstage-plugin-argo-cd-backend' # community TODO: replace with RH Argo CD plugin when it's ready
-  - package: '@roadiehq/scaffolder-backend-argocd' # community TODO: replace with RH Argo CD plugin when it's ready
+  - package: '@backstage-community/plugin-quay'
+    status: "community"
+  - package: '@backstage-community/plugin-quay-backend'
+    status: "community"
+  - package: '@backstage-community/plugin-scaffolder-backend-module-quay'
+    status: "community"
+  - package: '@backstage-community/plugin-tekton'
+    status: "community"
+  - package: '@roadiehq/backstage-plugin-argo-cd-backend' # TODO: replace with RH Argo CD plugin when it's ready
+    status: "community"
+  - package: '@roadiehq/scaffolder-backend-argocd' # TODO: replace with RH Argo CD plugin when it's ready
+    status: "community"


### PR DESCRIPTION
It moves the **plugin status** (`generally-available` and `tech-preview`) to the _default.packages.yaml_ from inline comment to attribute.