### PR TITLE
feat: build __coverage plugin images in the release publish

### DIFF
--- a/.github/workflows/publish-release-branch-workspace-plugins.yaml
+++ b/.github/workflows/publish-release-branch-workspace-plugins.yaml
@@ -103,11 +103,15 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The job only reads files and pushes images via podman + GITHUB_TOKEN;
+          # it never uses the git credential, so don't persist it.
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         env:
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$REGISTRY_PASSWORD" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "$REGISTRY_PASSWORD" | podman login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -125,15 +129,29 @@ jobs:
           # nightly to collect coverage from it. This reuses the exact script
           # the PR /publish flow runs; each workspace run instruments only the
           # images that match its own metadata (others are skipped fast, with
-          # no image pull), and a failure here never blocks the release.
+          # no image pull).
+          #
+          # Images are built for every rolled-out workspace, including those the
+          # nightly currently resolves via {{inherit}} — their ghcr images
+          # aren't consumed until the Phase 2 coverage periodic forces ghcr, but
+          # building them now keeps the producer ready ahead of that consumer.
+          #
+          # A failure never blocks the release (exit 0), but it is surfaced as a
+          # workflow warning so a silently-broken pipeline — which would starve
+          # the nightly of coverage — is noticeable in the run summary.
           shopt -s nullglob
-          found=0
+          rolled_out=0
+          failed=0
           for anchor_dir in workspaces/*/coverage-anchors; do
             ws="$(dirname "$anchor_dir")"
             [[ -d "$ws/e2e-tests" ]] || continue
-            found=1
+            rolled_out=$((rolled_out + 1))
             echo "=== Instrumenting $ws ==="
             echo "$PUBLISHED_EXPORTS" | ./scripts/instrument-plugin.sh "$ws" \
-              || echo "[WARN] instrumentation failed for $ws (non-fatal)"
+              || { echo "::warning title=coverage-instrumentation::failed for $ws"; failed=$((failed + 1)); }
           done
-          [[ "$found" == 1 ]] || echo "[INFO] No rolled-out workspaces (coverage-anchors/) to instrument."
+          if [[ "$rolled_out" -eq 0 ]]; then
+            echo "[INFO] No rolled-out workspaces (coverage-anchors/) to instrument."
+          elif [[ "$failed" -gt 0 ]]; then
+            echo "::warning title=coverage-instrumentation::$failed of $rolled_out workspace(s) failed to instrument; nightly coverage may be stale"
+          fi

--- a/.github/workflows/publish-release-branch-workspace-plugins.yaml
+++ b/.github/workflows/publish-release-branch-workspace-plugins.yaml
@@ -86,3 +86,54 @@ jobs:
       attestations: write
       packages: write
       id-token: write
+
+  instrument:
+    name: Instrument plugin images for E2E coverage
+    needs:
+      - export
+    # Build coverage images only when something was actually published.
+    if: |
+      always() &&
+      needs.export.result == 'success' &&
+      needs.export.outputs.published-exports != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GitHub Container Registry
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$REGISTRY_PASSWORD" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+
+      - name: Instrument and publish coverage images for rolled-out workspaces
+        env:
+          PUBLISHED_EXPORTS: ${{ needs.export.outputs.published-exports }}
+        run: |
+          # Build the __coverage variant of each just-published image for every
+          # workspace already set up for overlay E2E coverage (i.e. has a
+          # coverage-anchors/ directory). The nightly deploys RELEASED images,
+          # so the instrumented variant must exist at publish time for the
+          # nightly to collect coverage from it. This reuses the exact script
+          # the PR /publish flow runs; each workspace run instruments only the
+          # images that match its own metadata (others are skipped fast, with
+          # no image pull), and a failure here never blocks the release.
+          shopt -s nullglob
+          found=0
+          for anchor_dir in workspaces/*/coverage-anchors; do
+            ws="$(dirname "$anchor_dir")"
+            [[ -d "$ws/e2e-tests" ]] || continue
+            found=1
+            echo "=== Instrumenting $ws ==="
+            echo "$PUBLISHED_EXPORTS" | ./scripts/instrument-plugin.sh "$ws" \
+              || echo "[WARN] instrumentation failed for $ws (non-fatal)"
+          done
+          [[ "$found" == 1 ]] || echo "[INFO] No rolled-out workspaces (coverage-anchors/) to instrument."

--- a/README.md
+++ b/README.md
@@ -188,3 +188,12 @@ These anchors never change with plugin versions. Regenerate them only when a new
 ```
 
 See `scripts/generate-coverage-anchors.sh` and `codecov.yml` for the full mechanism.
+
+### Coverage images for the nightly
+
+Browser coverage can only be collected from an **instrumented** plugin image. The PR `/publish` flow builds an instrumented `__coverage` variant of each plugin image and the e2e-test-utils fixture swaps to it in PR mode, which is why PR e2e runs report coverage. The release publish (`publish-release-branch-workspace-plugins.yaml`) builds the same `__coverage` variant for every rolled-out workspace (any with a `coverage-anchors/` directory), so the instrumented image already exists for the nightly to deploy.
+
+For the nightly to actually feed the default-branch dashboard, two companion pieces are still required:
+
+- The e2e-test-utils image swap must also run in nightly mode (today it only swaps when a PR URL is present), and for plugins resolved via `{{inherit}}` it must use the instrumented ghcr image instead of the RHDH catalog image — those catalog images aren't ours to instrument.
+- The periodic Prow job must have the Codecov token available (the same `VAULT_CODECOV_TOKEN` the PR `ocp-helm` step uses).


### PR DESCRIPTION
## Why

Browser E2E coverage can only be collected from an **instrumented** plugin image. Today only the PR `/publish` flow builds the `__coverage` variant (`auto-publish-pr.yaml`). The nightly deploys **released** images, which have no instrumented variant — so it collects nothing, and the Codecov default-branch view only fills via manual snapshot seeding (#2638).

This is the first piece of the "live nightly coverage" path: make the instrumented images **exist** for the nightly to deploy.

## What

Adds an `instrument` job to the release publish (`publish-release-branch-workspace-plugins.yaml`, runs on push to `main` / release branches) that, after the export job publishes the final images:

- Loops over every workspace already set up for overlay coverage (has a `coverage-anchors/` directory) **and** with `e2e-tests/`
- Runs the **exact** `scripts/instrument-plugin.sh` the PR `/publish` flow uses, piping the just-published image refs
- Each workspace run instruments only the images matching its own metadata (others skip fast, no image pull); a workspace not re-published in this run finds no matching images and exits cleanly
- The job is **non-fatal** (`|| echo WARN` per workspace) — a coverage-image build failure never blocks a release

No new script: it reuses `instrument-plugin.sh` (`--squash-all`, both bundles, packageName metadata match from #2604) exactly as the PR flow does.

## Validation

- YAML parses; the `run` block passes `bash -n`
- The workspace-discovery loop locally resolves the 4 rolled-out workspaces (`theme`, `global-header`, `bulk-import`, `quickstart`)
- Mirrors the existing PR-flow instrument job (checkout → ghcr login → node → instrument) so the runner/permission shape is already proven

## Still needed for live nightly coverage (companion work, documented in README)

1. **e2e-test-utils** — the `__coverage` image swap must also run in nightly mode (today it's `if (prUrl)` only), and for `{{inherit}}` plugins it must use the instrumented ghcr image instead of the RHDH catalog image (which we can't instrument). Separate repo.
2. **Prow periodic job** — must have the Codecov token available (same `VAULT_CODECOV_TOKEN` as the PR `ocp-helm` step). `openshift/release`.

Phase 1 (this PR + #1) gives live nightly coverage for non-`{{inherit}}` plugins (e.g. theme). Phase 2 (a dedicated coverage periodic that forces ghcr instead of inherit) covers GA/TP plugins.

Follow-up to the coverage rollout (#2579, #2587, #2604, #2638).

🤖 Generated with [Claude Code](https://claude.com/claude-code)