### PR TITLE
fix: never fail the publish workflow on coverage instrumentation

### DIFF
--- a/.github/workflows/publish-release-branch-workspace-plugins.yaml
+++ b/.github/workflows/publish-release-branch-workspace-plugins.yaml
@@ -97,6 +97,14 @@ jobs:
       needs.export.result == 'success' &&
       needs.export.outputs.published-exports != ''
     runs-on: ubuntu-latest
+    # Coverage instrumentation must never affect the release. The run step is
+    # already non-fatal per workspace, but an infra failure in an earlier step
+    # (checkout, registry login, node setup) would otherwise fail the job and
+    # turn the publish workflow — and its README status badge — red even though
+    # the artifacts published fine. continue-on-error keeps the run green; the
+    # job still shows its own status, and instrumentation problems surface as
+    # ::warning:: annotations.
+    continue-on-error: true
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
## Follow-up to #2645

Deep review of the merged coverage instrument job surfaced one gap: the job's **steps** are non-fatal (each workspace is wrapped in `|| ::warning::`), but the **job** is not.

If an earlier step fails for infrastructure reasons — `actions/checkout`, `podman login`, or `actions/setup-node` — the job fails, which marks the entire **publish workflow run** as `failure`. That workflow drives the README status badge (`publish-workspace-plugins.yaml?branch=main&event=push`), so it would go red even though the release artifacts published fine in the already-completed `export` job.

This contradicts the job's own stated intent ("A failure never blocks the release").

## Fix

Add `continue-on-error: true` to the instrument job. Its outcome no longer changes the workflow conclusion, so the publish stays green and the badge stays accurate. The job still shows its own status in the run details (so a failure is visible to anyone who looks), and per-workspace instrumentation problems still surface as `::warning::` annotations in the run summary.

## Context

The instrument job builds `__coverage` images that nothing consumes yet (the consumer — the e2e-test-utils nightly swap — is gated behind an explicit opt-in), so this is purely about keeping the publish workflow's signal honest. No behavior change to the release or the nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)