### PR TITLE
Update `scorecard` workspace to commit `91d7834` for backstage `1.49.3.`

### DIFF
--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-dependabot.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-dependabot.yaml
@@ -17,8 +17,8 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-dependabot"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot:bs_1.49.4__0.2.11!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot
-  version: 0.2.11
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot:bs_1.49.4__0.2.12!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot
+  version: 0.2.12
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.49.4

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-filecheck.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-filecheck.yaml
@@ -17,8 +17,8 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-filecheck"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-filecheck:bs_1.49.4__0.1.8!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-filecheck
-  version: 0.1.8
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-filecheck:bs_1.49.4__0.1.10!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-filecheck
+  version: 0.1.10
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.49.4

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-github.yaml
@@ -17,8 +17,8 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-github"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.49.4__2.7.7!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github
-  version: 2.7.7
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.49.4__2.7.8!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github
+  version: 2.7.8
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.49.4

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-jira.yaml
@@ -17,8 +17,8 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-jira"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.49.4__2.7.7!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira
-  version: 2.7.7
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.49.4__2.7.8!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira
+  version: 2.7.8
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.49.4

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-openssf.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-openssf.yaml
@@ -17,8 +17,8 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-openssf"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf:bs_1.49.4__0.2.11!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf
-  version: 0.2.11
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf:bs_1.49.4__0.2.12!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf
+  version: 0.2.12
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.49.4

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-sonarqube.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend-module-sonarqube.yaml
@@ -17,8 +17,8 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-sonarqube"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-sonarqube:bs_1.49.4__0.1.6!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-sonarqube
-  version: 0.1.6
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-sonarqube:bs_1.49.4__0.1.7!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-sonarqube
+  version: 0.1.7
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.49.4

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard-backend.yaml
@@ -17,8 +17,8 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard-backend"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.49.4__2.7.7!red-hat-developer-hub-backstage-plugin-scorecard-backend
-  version: 2.7.7
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.49.4__2.7.8!red-hat-developer-hub-backstage-plugin-scorecard-backend
+  version: 2.7.8
   backstage:
     role: backend-plugin
     supportedVersions: 1.49.4

--- a/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
+++ b/workspaces/scorecard/metadata/rhdh-backstage-plugin-scorecard.yaml
@@ -17,8 +17,8 @@ metadata:
     - analytics
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-scorecard"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.49.4__2.7.7!red-hat-developer-hub-backstage-plugin-scorecard
-  version: 2.7.7
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.49.4__2.7.8!red-hat-developer-hub-backstage-plugin-scorecard
+  version: 2.7.8
   backstage:
     role: frontend-plugin
     supportedVersions: 1.49.4

--- a/workspaces/scorecard/source.json
+++ b/workspaces/scorecard/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"283fcbb80a0af0d0b3086330afb87edbf537df03","repo-flat":false,"repo-backstage-version":"1.49.3"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"91d7834cda0dbcf9fc55beb5a2cdce5a9eab0db6","repo-flat":false,"repo-backstage-version":"1.49.3"}


### PR DESCRIPTION
Cherry-picking this [PR](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2572) (automatic cherry pick failed because of conflicts) in order to bring the filecheck module fix to 1.10.2.

Related to https://redhat.atlassian.net/browse/RHDHBUGS-3197

---------