### PR TITLE
[release-1.10] chore(orchestrator): bump default serverless workflows ref.

### DIFF
--- a/workspaces/orchestrator/e2e-tests/tests/support/utils/workflow-deployment-helpers.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/support/utils/workflow-deployment-helpers.ts
@@ -21,7 +21,7 @@ const DEMO_WORKFLOW_REPO =
   "https://github.com/rhdhorchestrator/orchestrator-demo.git";
 const WORKFLOW_REPO_REF =
   process.env.SERVERLESS_WORKFLOWS_REF ||
-  "daeeee8dec16beab6d96a81774ef500081a2c2b0";
+  "2c8de41b292794832f40b8e376da434495683efc";
 
 const MANIFEST_DIRS = [
   "workflows/greeting/manifests",


### PR DESCRIPTION


Update SERVERLESS_WORKFLOWS_REF default to 2c8de41b292794832f40b8e376da434495683efc for orchestrator e2e workflow deployment, the new default are the images updated for osl 1.38. 