### PR TITLE
[Backport 1.9.x]  Update `bulk-import` workspace to commit `87766e4` for backstage `1.45.2` on branch `release-1.9`

### DIFF
--- a/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml
+++ b/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-bulk-import-backend"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
-  version: 7.0.1
+  version: 7.0.2
   backstage:
     role: backend-plugin
     supportedVersions: 1.45.3

--- a/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import.yaml
+++ b/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-bulk-import'
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
-  version: 7.0.1
+  version: 7.0.2
   backstage:
     role: frontend-plugin
     supportedVersions: 1.45.3

--- a/workspaces/bulk-import/source.json
+++ b/workspaces/bulk-import/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"8ab71de525c3c4816d6766d959448b00dfb7e141","repo-flat":false,"repo-backstage-version":"1.45.2"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"87766e42023ea7c594eb1367ac0e6972f859c0b3","repo-flat":false,"repo-backstage-version":"1.45.2"}


### PR DESCRIPTION
Updates the `bulk-import` workspace `source.json` to point to the new Version Packages
commit `87766e42023ea7c594eb1367ac0e6972f859c0b3` which includes:

- `@red-hat-developer-hub/backstage-plugin-bulk-import@7.0.2`
- `@red-hat-developer-hub/backstage-plugin-bulk-import-backend@7.0.2`
- `@red-hat-developer-hub/backstage-plugin-bulk-import-common@7.0.2`

This picks up the JSS class name scoping fix ([RHDHBUGS-3369](https://redhat.atlassian.net/browse/RHDHBUGS-3369)) to prevent style
collisions in the Bulk Import plugin table rows.

Related:
- Jira: https://redhat.atlassian.net/browse/RHDHBUGS-3369
- Backport PR: https://github.com/redhat-developer/rhdh-plugins/pull/3511
- Version Packages PR: https://github.com/redhat-developer/rhdh-plugins/pull/3568