### PR TITLE
chore: replace disabled with enabled in DP configs

### DIFF
--- a/.github/workflows/workspace-tests.yaml
+++ b/.github/workflows/workspace-tests.yaml
@@ -264,7 +264,7 @@ jobs:
 
               STRIPPED=$(echo "$PACKAGE_NAME" | sed 's|^@||; s|/|-|')
               echo "- package: \"oci://ghcr.io/${IMAGE_PATH_AND_PLUGIN}:${NEW_TAG}!${STRIPPED}\"" >> "$OUT_FILE"
-              echo "  disabled: false" >> "$OUT_FILE"
+              echo "  enabled: true" >> "$OUT_FILE"
               if [ -n "$CONFIG_CONTENT" ]; then
                 echo "  pluginConfig:" >> "$OUT_FILE"
                 echo "$CONFIG_CONTENT" | sed 's/^/    /' >> "$OUT_FILE"

--- a/catalog-entities/extensions/plugins/ai-model-catalog.yaml
+++ b/catalog-entities/extensions/plugins/ai-model-catalog.yaml
@@ -89,7 +89,7 @@ spec:
      plugins:
        # AI Model Catalog plugins
        - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog:bs_1.42.5__0.7.0!red-hat-developer-hub-backstage-plugin-catalog-backend-module-model-catalog
-         disabled: false
+         enabled: true
        - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-techdoc-url-reader-backend:bs_1.42.5__0.3.0!red-hat-developer-hub-backstage-plugin-catalog-techdoc-url-reader-backend
 
      ```

--- a/catalog-entities/extensions/plugins/home-page.yaml
+++ b/catalog-entities/extensions/plugins/home-page.yaml
@@ -79,7 +79,7 @@ spec:
       plugins:
         # Frontend plugin
         - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
-          disabled: false
+          enabled: true
           pluginConfig:
             dynamicPlugins:
               frontend:
@@ -238,7 +238,7 @@ spec:
                       ref: homepageTranslationRef
         # Backend plugin
         - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.49.4__0.1.0!red-hat-developer-hub-backstage-plugin-homepage-backend
-          disabled: false
+          enabled: true
           pluginConfig:
             homepage:
               defaultWidgets:

--- a/catalog-entities/extensions/plugins/lightspeed.yaml
+++ b/catalog-entities/extensions/plugins/lightspeed.yaml
@@ -108,7 +108,7 @@ spec:
       plugins:
         # Frontend plugin
         - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.39.1__0.5.7!red-hat-developer-hub-backstage-plugin-lightspeed
-          disabled: false
+          enabled: true
           pluginConfig:
             lightspeed:
               # OPTIONAL: Custom users prompts displayed to users
@@ -133,7 +133,7 @@ spec:
         
         # Backend plugin
         - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.39.1__0.5.7!red-hat-developer-hub-backstage-plugin-lightspeed-backend
-          disabled: false
+          enabled: true
           pluginConfig:
             lightspeed:
               # REQUIRED: Configure LLM servers with OpenAI API compatibility

--- a/catalog-entities/extensions/plugins/mcp-actions-backend.yaml
+++ b/catalog-entities/extensions/plugins/mcp-actions-backend.yaml
@@ -87,7 +87,7 @@ spec:
      plugins:
        # MCP server backend plugin
        - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-mcp-actions-backend:bs_1.48.3__0.1.5!backstage-plugin-mcp-actions-backend
-         disabled: false
+         enabled: true
      ```
 
      If you also wish to install the Red Hat MCP Extras plugins, consult the installation instructions for the `Software Catalog MCP Extras`, `Techdocs MCP Extras`, or `Scaffolder MCP Extras` plugins.

--- a/catalog-entities/extensions/plugins/scaffolder-mcp-extras.yaml
+++ b/catalog-entities/extensions/plugins/scaffolder-mcp-extras.yaml
@@ -77,7 +77,7 @@ spec:
      plugins:
        # MCP extras backend plugin
        - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-mcp-extras:bs_1.48.3__0.4.0!red-hat-developer-hub-backstage-plugin-scaffolder-mcp-extras
-         disabled: false
+         enabled: true
      ```
 
      ## RHDH Configuration

--- a/catalog-entities/extensions/plugins/software-catalog-mcp-extras.yaml
+++ b/catalog-entities/extensions/plugins/software-catalog-mcp-extras.yaml
@@ -83,7 +83,7 @@ spec:
      plugins:
        # MCP extras backend plugin
        - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-software-catalog-mcp-extras:bs_1.48.3__0.2.1!red-hat-developer-hub-backstage-plugin-software-catalog-mcp-extras
-         disabled: false
+         enabled: true
      ```
 
      ## RHDH Configuration

--- a/catalog-entities/extensions/plugins/techdocs-mcp-extras.yaml
+++ b/catalog-entities/extensions/plugins/techdocs-mcp-extras.yaml
@@ -80,7 +80,7 @@ spec:
      plugins:
        # MCP extras backend plugin
        - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-techdocs-mcp-extras:bs_1.48.3__0.2.1!red-hat-developer-hub-backstage-plugin-techdocs-mcp-extras
-         disabled: false
+         enabled: true
      ```
 
      ## RHDH Configuration

--- a/user-guide/01-getting-started.md
+++ b/user-guide/01-getting-started.md
@@ -307,7 +307,7 @@ Use the OCI references from the bot's comment to test in your own Backstage inst
 # dynamic-plugins.yaml
 plugins:
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-your-plugin:pr_123__1.0.0
-    disabled: false
+    enabled: true
 ```
 
 ---

--- a/user-guide/07-plugin-catalog-index.md
+++ b/user-guide/07-plugin-catalog-index.md
@@ -138,7 +138,7 @@ Output structure (truncated):
 plugins:
   # Tag: 1.10--0.8.2, Build date: 2026-05-20T13:45:25Z
   - package: oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-adoption-insights:1.10--0.8.2
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -146,7 +146,7 @@ plugins:
             # ... frontend wiring config
   # Tag: 1.10--1.2.0, Build date: 2026-05-19T09:12:00Z
   - package: oci://quay.io/rhdh/backstage-community-plugin-acr:1.10--1.2.0
-    disabled: true
+    enabled: false
 ```
 
 ### Step 4: Catalog Index Generation (`generateCatalogIndex.py`)

--- a/workspaces/analytics/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/analytics/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,3 +1,3 @@
 plugins:
   - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
-    disabled: false
+    enabled: true

--- a/workspaces/argocd/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/argocd/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,10 +1,10 @@
 plugins:
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
-    disabled: false
+    enabled: true
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.45.3__2.4.3!backstage-community-plugin-argocd
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -29,4 +29,4 @@ plugins:
                     allOf:
                       - isArgocdConfigured
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd-backend:bs_1.45.3__1.0.2!backstage-community-plugin-argocd-backend
-    disabled: false
+    enabled: true

--- a/workspaces/bulk-import/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/bulk-import/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,9 +1,9 @@
 plugins:
   # bulk-import plugins
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -19,4 +19,4 @@ plugins:
                   text: Bulk import
 
   - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
-    disabled: true
+    enabled: false

--- a/workspaces/global-header/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/global-header/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,12 +1,12 @@
 plugins:
   - package: ./dynamic-plugins/dist/backstage-plugin-notifications
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-signals
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
     pluginConfig:
       app:

--- a/workspaces/homepage/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/homepage/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,6 +1,6 @@
 plugins:
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -43,7 +43,7 @@ plugins:
               - importName: homepageTranslations
                 ref: homepageTranslationRef
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage-backend:bs_1.49.4__0.1.1!red-hat-developer-hub-backstage-plugin-homepage-backend
-    disabled: false
+    enabled: true
     pluginConfig:
       homepage:
         defaultWidgets:

--- a/workspaces/rbac/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/rbac/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,6 +1,6 @@
 plugins:
   - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:

--- a/workspaces/scorecard/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/scorecard/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -2,7 +2,7 @@
 # Filecheck backend module is intentionally excluded — it lives in filecheck/dynamic-plugins.yaml.
 plugins:
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.49.4__2.7.4!red-hat-developer-hub-backstage-plugin-scorecard
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -38,9 +38,9 @@ plugins:
                   props:
                     metricId: "github.open_prs"
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.49.4__2.7.4!red-hat-developer-hub-backstage-plugin-scorecard-backend
-    disabled: false
+    enabled: true
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.49.4__2.7.4!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github
-    disabled: false
+    enabled: true
     pluginConfig:
       scorecard:
         plugins:
@@ -69,7 +69,7 @@ plugins:
                     icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" style="color:#FAA0A0"><rect x="4" y="4" width="16" height="16" rx="2" stroke="#FAA0A0" stroke-width="2"/><path d="M9 9l6 6M15 9l-6 6" stroke="#FAA0A0" stroke-width="2" stroke-linecap="round"/></svg>
                     color: "#faa0a0"
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.49.4__2.7.4!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira
-    disabled: false
+    enabled: true
     pluginConfig:
       jira:
         baseUrl: ${JIRA_URL}
@@ -87,7 +87,7 @@ plugins:
                 initialDelay:
                   seconds: 15
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot:bs_1.49.4__0.2.11!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot
-    disabled: false
+    enabled: true
     pluginConfig:
       scorecard:
         plugins:
@@ -125,7 +125,7 @@ plugins:
                 initialDelay:
                   seconds: 20
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-dynamic-home-page:bs_1.49.4__1.13.1!red-hat-developer-hub-backstage-plugin-dynamic-home-page
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -145,9 +145,9 @@ plugins:
                   id: "entity-section"
                   title: "Entity section"
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
-    disabled: true
+    enabled: false
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf:bs_1.49.4__2.5.1!red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf
-    disabled: false
+    enabled: true
     pluginConfig:
       scorecard:
         plugins:

--- a/workspaces/tekton/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/tekton/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,10 +1,10 @@
 plugins:
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:

--- a/workspaces/theme/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/theme/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,6 +1,6 @@
 plugins:
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-qe-theme
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -17,7 +17,7 @@ plugins:
                 variant: dark
                 importName: darkThemeProvider
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-theme
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:

--- a/workspaces/topology/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/topology/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,7 +1,7 @@
 plugins:
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
-    disabled: false
+    enabled: true
   - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
-    disabled: false
+    enabled: true


### PR DESCRIPTION
Per [RHIDP-14726](https://redhat.atlassian.net/browse/RHIDP-14726), this PR replaces the `disabled` field with `enabled` in the following files:

 - .github/workflows/workspace-tests.yaml — disabled: false → enabled: true
 - workspaces/*/e2e-tests/tests/config/dynamic-plugins.yaml — all 10 workspace configs
 - catalog-entities/extensions/plugins/*.yaml — all 7 files
 - user-guide/ — both markdown files

Follow-up to #2577 and https://github.com/redhat-developer/rhdh/pull/4937