### PR TITLE
chore(backstage): fix bitbucket cloud export

### DIFF
--- a/workspaces/backstage/plugins-list.yaml
+++ b/workspaces/backstage/plugins-list.yaml
@@ -29,7 +29,7 @@ plugins/auth:
 plugins/catalog-backend-module-aws:
 plugins/catalog-backend-module-azure:
 plugins/catalog-backend-module-backstage-openapi:
-plugins/catalog-backend-module-bitbucket-cloud:
+plugins/catalog-backend-module-bitbucket-cloud: --embed-package @backstage/plugin-bitbucket-cloud-common
 plugins/catalog-backend-module-bitbucket-server:
 plugins/catalog-backend-module-gcp: --embed-package @backstage/plugin-kubernetes-common
 plugins/catalog-backend-module-gerrit:
@@ -82,7 +82,7 @@ plugins/proxy-backend:
 #plugins/scaffolder: ==> Added as a static plugin in RHDH
 #plugins/scaffolder-backend: ==> Added as a static plugin in RHDH
 plugins/scaffolder-backend-module-azure:
-plugins/scaffolder-backend-module-bitbucket-cloud:
+plugins/scaffolder-backend-module-bitbucket-cloud: --embed-package @backstage/plugin-bitbucket-cloud-common
 plugins/scaffolder-backend-module-bitbucket-server:
 plugins/scaffolder-backend-module-confluence-to-markdown:
 plugins/scaffolder-backend-module-cookiecutter:


### PR DESCRIPTION
This change ensures the bitbucket-cloud-common package is embedded in the catalog/scaffolder bitbucket cloud modules which should sort errors seen in the smoke test output.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED