### PR TITLE
chore: plugin(orchestrator): release 1.10.2 - loki module backport

### DIFF
--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend-mod-loki.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend-mod-loki.yaml
@@ -19,7 +19,7 @@ spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki"
   # Tag: 1.10.0--1.0.1, Build date: 2026-04-20T22:08:14Z
   dynamicArtifact: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend-module-loki@sha256:d5970c0e63d43162fa77f342a76b3bffbe54fe6cbabc56335ea11ecaa74591c4"
-  version: 1.2.6
+  version: 1.2.7
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.49.4

--- a/workspaces/orchestrator/source.json
+++ b/workspaces/orchestrator/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"683f9d63d293ea9adfbda217a1cc0ce4e574277e","repo-flat":false,"repo-backstage-version":"1.49.3"}
+{"repo":"https://github.com/redhat-developer/rhdh-plugins","repo-ref":"eb6cce6110fc8bd532e717e9d995764481b36f1b","repo-flat":false,"repo-backstage-version":"1.49.3"}


### PR DESCRIPTION
includes fix for https://redhat.atlassian.net/browse/RHDHBUGS-3398