### PR TITLE
fix(coverage): guard the refresh workflow against a Prow re-run loop

### DIFF
--- a/.github/workflows/refresh-coverage-snapshot.yaml
+++ b/.github/workflows/refresh-coverage-snapshot.yaml
@@ -179,6 +179,11 @@ jobs:
             exit 0
           fi
 
+          # Subject of our own refresh commits — pinned once so the guard below
+          # and the commit at the end can't drift apart (a mismatch would silently
+          # disable the guard and re-open the loop it exists to prevent).
+          refresh_subject="refresh ${WS} snapshot from passing e2e run"
+
           # Loop guard. On a PR where Prow auto-runs the e2e on every push (e.g.
           # an /ok-to-test'd bot bump PR), our snapshot commit re-triggers the e2e
           # via the synchronize webhook — Prow ignores [skip ci] and isn't gated by
@@ -186,13 +191,26 @@ jobs:
           # workflow again. The "unchanged" guard below would normally stop the
           # second pass, but if a workspace's coverage is flaky run-to-run the lcov
           # differs every time and it never catches — an unbounded refresh/e2e loop.
-          # So: if HEAD is already this workspace's refresh commit, this run came
-          # from the e2e Prow ran on top of it — keep the first snapshot, stop here.
-          if [[ "$(git log -1 --format='%an')" == "github-actions[bot]" ]] \
-            && git log -1 --format='%s' | grep -qF "refresh ${WS} snapshot from passing e2e run"; then
-            echo "HEAD is already this workspace's refresh commit — skipping to avoid a re-refresh loop."
-            exit 0
-          fi
+          #
+          # Walk the contiguous run of our own refresh commits at the tip: if THIS
+          # workspace already has one there, this run came from the e2e Prow ran on
+          # top of it — keep the first snapshot and stop. Looking back past HEAD
+          # (not just at it) also bounds the multi-workspace case the concurrency
+          # comment allows: two workspaces' refresh commits would otherwise
+          # alternate at HEAD forever, each missing the other's. A real (non-refresh)
+          # commit breaks the run, so a genuine new change still refreshes.
+          # [[ ]] matching (not `git log | grep -q`) keeps this off a pipe, so a
+          # SIGPIPE under `set -o pipefail` can't misread a match as a miss.
+          n=0
+          while subject=$(git log -1 --format='%s' "HEAD~${n}" 2>/dev/null) \
+            && [[ "$(git log -1 --format='%an' "HEAD~${n}" 2>/dev/null)" == "github-actions[bot]" ]] \
+            && [[ "$subject" == *"snapshot from passing e2e run"* ]]; do
+            if [[ "$subject" == *"$refresh_subject"* ]]; then
+              echo "Workspace '${WS}' already has a refresh commit in the bot run at the tip — skipping to avoid a re-refresh loop."
+              exit 0
+            fi
+            n=$((n + 1))
+          done
 
           # A passed run can still carry zero browser coverage (backend-only, or
           # uninstrumented images). refresh-coverage-snapshot.sh is non-fatal in
@@ -210,7 +228,7 @@ jobs:
           # GITHUB_TOKEN pushes don't trigger GitHub Actions (no Actions loop);
           # Prow re-running the e2e is handled by the loop guard above. [skip ci]
           # still skips any push-triggered Actions check on this data-only commit.
-          git commit -m "chore(coverage): refresh ${WS} snapshot from passing e2e run [skip ci]"
+          git commit -m "chore(coverage): ${refresh_subject} [skip ci]"
 
           # The push is unforced so it never clobbers concurrent work. The per-PR
           # concurrency group serializes bot refreshes, but a human push landing

--- a/.github/workflows/refresh-coverage-snapshot.yaml
+++ b/.github/workflows/refresh-coverage-snapshot.yaml
@@ -36,6 +36,14 @@ name: Refresh E2E coverage snapshot
 #   <ws>.lcov) touches, so they aren't expected on it. The one residual edge to
 #   re-check is a PR that itself changed e2e-tests where e2e-code-quality is a
 #   *required* status check on a protected branch.
+#
+# - Prow (unlike GitHub Actions) DOES re-run the e2e on the refresh commit via the
+#   synchronize webhook on PRs where it auto-runs on push (e.g. /ok-to-test'd bot
+#   bump PRs) — it ignores [skip ci] and isn't gated by GITHUB_TOKEN. That fresh
+#   "Passed" comment re-fires this workflow, and with flaky coverage the
+#   "unchanged" guard never catches it → a refresh/e2e loop. The "Regenerate"
+#   step's loop guard (skip if HEAD is already this workspace's refresh commit)
+#   bounds it to the first refresh after a real change.
 
 on:
   issue_comment:
@@ -171,6 +179,21 @@ jobs:
             exit 0
           fi
 
+          # Loop guard. On a PR where Prow auto-runs the e2e on every push (e.g.
+          # an /ok-to-test'd bot bump PR), our snapshot commit re-triggers the e2e
+          # via the synchronize webhook — Prow ignores [skip ci] and isn't gated by
+          # GITHUB_TOKEN. That posts a fresh "Passed" comment which fires this
+          # workflow again. The "unchanged" guard below would normally stop the
+          # second pass, but if a workspace's coverage is flaky run-to-run the lcov
+          # differs every time and it never catches — an unbounded refresh/e2e loop.
+          # So: if HEAD is already this workspace's refresh commit, this run came
+          # from the e2e Prow ran on top of it — keep the first snapshot, stop here.
+          if [[ "$(git log -1 --format='%an')" == "github-actions[bot]" ]] \
+            && git log -1 --format='%s' | grep -qF "refresh ${WS} snapshot from passing e2e run"; then
+            echo "HEAD is already this workspace's refresh commit — skipping to avoid a re-refresh loop."
+            exit 0
+          fi
+
           # A passed run can still carry zero browser coverage (backend-only, or
           # uninstrumented images). refresh-coverage-snapshot.sh is non-fatal in
           # that case; guard the commit on an actual change below.
@@ -184,9 +207,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "coverage-snapshots/${WS}.lcov"
-          # No loop: GITHUB_TOKEN pushes don't trigger workflow runs. The
-          # [skip ci] tag is belt-and-suspenders for any push-triggered check,
-          # not the primary guard.
+          # GITHUB_TOKEN pushes don't trigger GitHub Actions (no Actions loop);
+          # Prow re-running the e2e is handled by the loop guard above. [skip ci]
+          # still skips any push-triggered Actions check on this data-only commit.
           git commit -m "chore(coverage): refresh ${WS} snapshot from passing e2e run [skip ci]"
 
           # The push is unforced so it never clobbers concurrent work. The per-PR


### PR DESCRIPTION
## Problem (found rolling out topology)

The auto-refresh workflow (#2717) can loop on a PR where **Prow auto-runs the e2e on every push** (an `/ok-to-test`'d bot bump PR):

```
e2e passes → bot posts 'Passed' → workflow commits coverage-snapshots/<ws>.lcov
          → Prow re-runs e2e on that commit (synchronize webhook; ignores
            [skip ci], not gated by GITHUB_TOKEN) → 'Passed' again → workflow again
```

The existing "snapshot unchanged → nothing to commit" guard is supposed to stop the second pass, but **topology's coverage is flaky run-to-run** (the lcov differs every run), so it never catches → unbounded loop.

This doesn't happen on `/test`-triggered PRs (Prow doesn't auto-run on push there), which is why tech-radar was fine.

## Fix

Skip the refresh when **HEAD is already this workspace's refresh commit** (`github-actions[bot]` author + the refresh message). That state means the run was triggered by the e2e Prow ran *on top of our own commit* — re-refreshing would loop. We keep the **first** snapshot after a real change and drop the self-induced re-runs.

Bounded to one refresh per real change; flaky variation between runs is ignored (the first is representative).

The workflow was temporarily disabled to stop the live loop; this re-enables safe operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)