### PR TITLE
[debug] Investigate SHARED_DIR data loss in nightly

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # =============================================================================
 # E2E Test Runner for rhdh-plugin-export-overlays
+# debug: investigating SHARED_DIR data loss (RHIDP investigation)
 #
 # Runs workspace E2E tests in parallel using Playwright workers.
 # Uses yarn workspaces for dependency management (single root node_modules).


### PR DESCRIPTION
No-op PR to trigger the nightly presubmit and inspect the test pod for OOM/eviction events that may be causing SHARED_DIR to be empty in the send-data-router post step.

Will be closed after investigation.