### PR TITLE
feat: workspace mode for the native smoke harness

### DIFF
--- a/.github/workflows/native-smoke.yaml
+++ b/.github/workflows/native-smoke.yaml
@@ -28,6 +28,13 @@ on:
           Catalog-extending modules are not supported yet.
         type: string
         required: false
+      workspace:
+        description: >-
+          Workspace mode — validate ALL published plugins of workspaces/<name>
+          (resolved from its metadata/*.yaml oci:// refs). Takes precedence over
+          plugin_ref when both are set.
+        type: string
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -41,9 +48,10 @@ env:
   # Single source of truth for the plugin validated on pull_request and when the
   # dispatch input is left empty.
   DEFAULT_PLUGIN_REF: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-module-http-request:bs_1.49.4__5.6.0!roadiehq-scaffolder-backend-module-http-request"
-  # Known-good FRONTEND plugin (dual-system bundle) for the second run, which covers
-  # the frontend bundle validation and the --app-config/--test-env paths.
-  FRONTEND_PLUGIN_REF: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-acs:bs_1.49.4__0.2.0!backstage-community-plugin-acs"
+  # Known-good FRONTEND workspace for the second run: acs has a dual-system frontend
+  # bundle AND a smoke-tests/test.env, so one --workspace run covers workspace
+  # resolution, test-config auto-discovery, and frontend bundle validation.
+  FRONTEND_WORKSPACE: "acs"
 
 jobs:
   smoke:
@@ -85,9 +93,16 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Unit tests
+        # node:test over the pure helpers (workspace resolution, name validation,
+        # env/app-config substitution, frontend bundle matrix) — ~1s.
+        run: yarn test
+
       - name: Resolve plugin ref
-        # Dispatch input wins; otherwise the default. Encapsulated in env vars so the
-        # value never lands in a shell script via ${{ }} interpolation.
+        # Single-ref mode only (skipped in workspace mode). Dispatch input wins;
+        # otherwise the default. Encapsulated in env vars so the value never lands
+        # in a shell script via ${{ }} interpolation.
+        if: inputs.workspace == ''
         env:
           INPUT_REF: ${{ inputs.plugin_ref }}
         run: |
@@ -99,26 +114,28 @@ jobs:
       - name: Run native smoke harness
         # yarn smoke builds with esbuild then runs `node dist/native-smoke.mjs`.
         # Exits non-zero on any failure, so the job fails on a bad plugin.
-        run: yarn smoke --dynamic-plugins dp.yaml --out results.json
-
-      - name: Run native smoke harness (frontend bundle + test-config flags)
-        # Second run covering the paths the backend default can't reach: frontend
-        # bundle validation (both frontend systems) and the --app-config/--test-env
-        # parsing/merge/substitution. The borrowed workspace files exercise the
-        # harness plumbing, not those plugins' semantics. Skipped when a custom
-        # ref was dispatched — that run is about the caller's plugin.
-        if: inputs.plugin_ref == ''
+        env:
+          INPUT_WORKSPACE: ${{ inputs.workspace }}
         run: |
-          printf 'plugins:\n  - package: %s\n' "$FRONTEND_PLUGIN_REF" > dp-fe.yaml
-          yarn smoke --dynamic-plugins dp-fe.yaml \
-            --app-config ../workspaces/mcp-chat/smoke-tests/app-config.test.yaml \
-            --test-env ../workspaces/acs/smoke-tests/test.env \
-            --out results-frontend.json
+          if [ -n "$INPUT_WORKSPACE" ]; then
+            yarn smoke --workspace "$INPUT_WORKSPACE" --out results.json
+          else
+            yarn smoke --dynamic-plugins dp.yaml --out results.json
+          fi
+
+      - name: Run native smoke harness (workspace mode, frontend + test-config)
+        # Second run covering the paths the backend default can't reach — and it IS
+        # the feature this workflow ships: workspace resolution, smoke-tests/
+        # auto-discovery (acs has a test.env), and frontend bundle validation (acs
+        # ships a dual-system bundle). Skipped when a custom ref or workspace was
+        # dispatched — those runs are about the caller's plugin.
+        if: inputs.plugin_ref == '' && inputs.workspace == ''
+        run: yarn smoke --workspace "$FRONTEND_WORKSPACE" --out results-workspace.json
 
       - name: Show results
         if: always()
         run: |
-          for f in results.json results-frontend.json; do
+          for f in results.json results-workspace.json; do
             [ -f "$f" ] && { echo "== $f"; cat "$f"; } || echo "no $f produced"
           done
 

--- a/smoke-tests-native/.gitignore
+++ b/smoke-tests-native/.gitignore
@@ -5,3 +5,4 @@ results*.json
 dp*.yaml
 *.log
 dist/
+dist-tests/

--- a/smoke-tests-native/README.md
+++ b/smoke-tests-native/README.md
@@ -65,6 +65,28 @@ YAML
 yarn smoke --dynamic-plugins dp.yaml
 ```
 
+### Workspace mode
+
+Validate ALL published plugins of a workspace together — the same unit the Docker
+smoke covers:
+
+```bash
+yarn smoke --workspace mcp-integrations
+```
+
+It resolves every `oci://` `spec.dynamicArtifact` from
+`workspaces/<name>/metadata/*.yaml` and installs/boots them in one run. Metadata
+whose artifact is a local `./dynamic-plugins/dist/…` path (plugin bundled inside the
+RHDH image, no published OCI artifact — e.g. `scaffolder-backend-module-kubernetes`)
+is skipped with a warning and recorded in `results.json`
+(`workspace.skippedMetadata`); a workspace with no `oci://` refs at all reports
+`status: error` (nothing to validate). `--workspace` and `--dynamic-plugins` are
+mutually exclusive.
+
+Workspace mode also auto-discovers the workspace's Docker-smoke test config —
+`workspaces/<name>/smoke-tests/app-config.test.yaml` and `smoke-tests/test.env` —
+when present. Explicit `--app-config`/`--test-env` flags win over discovered files.
+
 ### Test config (parity with the Docker smoke)
 
 Workspaces that ship `smoke-tests/app-config.test.yaml` and/or `smoke-tests/test.env`
@@ -86,7 +108,9 @@ yarn smoke --dynamic-plugins dp.yaml \
   referencing an unset variable with no default is dropped (with a warning), not
   replaced by an empty string.
 
-`yarn check` runs `tsc --noEmit`. This is a standalone tool dir, not a
+`yarn test` runs the unit tests (`node:test` over `src/*.test.ts` — workspace
+resolution, name validation, env/app-config substitution, frontend bundle matrix);
+`yarn check` runs `tsc --noEmit` + the tests. This is a standalone tool dir, not a
 `workspaces/*/e2e-tests` one, so it is outside `e2e-code-quality.yaml` (which only scans
 `workspaces/*/e2e-tests/**`).
 
@@ -97,7 +121,8 @@ yarn smoke --dynamic-plugins dp.yaml \
 - **`pull_request`** (paths `smoke-tests-native/**`): validates the harness itself on every
   change here, against a known-good pure-backend plugin.
 - **`workflow_dispatch`**: Actions → "Native Smoke Harness" → Run workflow, with an optional
-  `plugin_ref` to validate any plugin on demand.
+  `plugin_ref` (single ref) or `workspace` (all of a workspace's published plugins)
+  to validate on demand.
 
 It installs skopeo, builds, runs `yarn smoke`, uploads `results.json`, and fails the job on
 a non-passing plugin.

--- a/smoke-tests-native/package.json
+++ b/smoke-tests-native/package.json
@@ -12,8 +12,9 @@
   "scripts": {
     "build": "esbuild src/native-smoke.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/native-smoke.mjs",
     "smoke": "yarn build && node dist/native-smoke.mjs",
+    "test": "esbuild src/*.test.ts --bundle --platform=node --format=esm --packages=external --outdir=dist-tests --out-extension:.js=.mjs && node --test \"dist-tests/*.test.mjs\"",
     "tsc:check": "tsc --noEmit",
-    "check": "yarn tsc:check"
+    "check": "yarn tsc:check && yarn test"
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "1.9.2",

--- a/smoke-tests-native/src/loader.test.ts
+++ b/smoke-tests-native/src/loader.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { validateFrontendBundle, type PluginEntry } from "./loader";
+
+// Build a fake extracted-plugin dir with the given bundle artifacts.
+function makePlugin(files: string[]): PluginEntry {
+  const dir = mkdtempSync(join(tmpdir(), "bundle-"));
+  for (const rel of files) {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, "{}");
+  }
+  return { name: "test", version: "1.0.0", dirName: "test", path: dir, role: "frontend" };
+}
+
+const LEGACY = ["package.json", "dist-scalprum/plugin-manifest.json"];
+const NEW_FE = ["package.json", "dist/remoteEntry.js", "dist/mf-manifest.json"];
+
+test("legacy-only bundle validates as legacy", () => {
+  const { systems, error } = validateFrontendBundle(makePlugin(LEGACY));
+  assert.equal(error, null);
+  assert.deepEqual(systems, ["legacy"]);
+});
+
+test("new-frontend-system-only bundle validates as new-frontend-system", () => {
+  const { systems, error } = validateFrontendBundle(makePlugin(NEW_FE));
+  assert.equal(error, null);
+  assert.deepEqual(systems, ["new-frontend-system"]);
+});
+
+test("dual bundle reports both systems", () => {
+  const { systems, error } = validateFrontendBundle(
+    makePlugin([...new Set([...LEGACY, ...NEW_FE])]),
+  );
+  assert.equal(error, null);
+  assert.deepEqual(systems, ["legacy", "new-frontend-system"]);
+});
+
+test("incomplete legacy layout fails even when the new-FE layout is valid", () => {
+  const plugin = makePlugin([...NEW_FE, "dist-scalprum/some-chunk.js"]);
+  const { error } = validateFrontendBundle(plugin);
+  assert.match(error ?? "", /missing plugin-manifest\.json/);
+});
+
+test("incomplete new-FE layout fails even when the legacy layout is valid", () => {
+  const plugin = makePlugin([...LEGACY, "dist/remoteEntry.js"]);
+  const { error } = validateFrontendBundle(plugin);
+  assert.match(error ?? "", /missing dist\/mf-manifest\.json/);
+});
+
+test("no bundle at all names both expected layouts in the error", () => {
+  const { systems, error } = validateFrontendBundle(makePlugin(["package.json"]));
+  assert.deepEqual(systems, []);
+  assert.match(error ?? "", /dist-scalprum/);
+  assert.match(error ?? "", /remoteEntry\.js/);
+});
+
+test("missing package.json is its own error", () => {
+  const { error } = validateFrontendBundle(makePlugin([]));
+  assert.equal(error, "missing package.json");
+});

--- a/smoke-tests-native/src/native-smoke.ts
+++ b/smoke-tests-native/src/native-smoke.ts
@@ -25,7 +25,11 @@
  *
  * Usage:
  *   yarn smoke --dynamic-plugins <dynamic-plugins.yaml> [--out results.json]
- *              [--app-config <app-config.test.yaml>] [--test-env <test.env>]
+ *   yarn smoke --workspace <name>                       [--out results.json]
+ *   ... either form also takes [--app-config <app-config.test.yaml>] [--test-env <test.env>]
+ *
+ * Workspace mode resolves ALL of `workspaces/<name>/metadata/*.yaml`'s oci://
+ * dynamicArtifact refs and validates them together (the Docker smoke's unit).
  *
  * --app-config / --test-env mirror what the Docker smoke passes to the container
  * (an extra --config mount and docker run --env-file) — see src/test-config.ts.
@@ -56,12 +60,18 @@ import {
 import { patchModuleResolution } from "./module-resolution";
 import { buildMergedConfig, KNOWN_FAILURES } from "./plugin-config";
 import { loadAppConfig, loadEnvFile } from "./test-config";
+import {
+  collectWorkspaceRefs,
+  discoverSmokeTestConfig,
+  isValidWorkspaceName,
+  writeDynamicPluginsConfig,
+} from "./workspace";
 
+const HARNESS_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 // This harness's own node_modules — extracted plugins resolve @backstage/* against it.
-const HARNESS_NODE_MODULES = join(
-  dirname(dirname(fileURLToPath(import.meta.url))),
-  "node_modules",
-);
+const HARNESS_NODE_MODULES = join(HARNESS_ROOT, "node_modules");
+// The harness lives at <repo>/smoke-tests-native, so workspaces/ sits one level up.
+const REPO_ROOT = dirname(HARNESS_ROOT);
 
 const CLI = "@red-hat-developer-hub/cli-module-install-dynamic-plugins";
 
@@ -87,8 +97,17 @@ type BackendStartResult = { ok: boolean; skipped?: boolean; error?: string };
 // Which frontend system(s) each bundle ships — the signal for tracking migration to
 // the new frontend system across the catalog.
 type FrontendBundleInfo = { name: string; version: string; systems: FrontendSystem[] };
+// Bump when the results.json shape changes — downstream tooling (e.g. the parity
+// runs comparing native vs Docker verdicts) parses this file.
+const REPORT_SCHEMA_VERSION = 1;
+
+// Workspace-mode provenance: which metadata files were skipped (non-oci artifacts),
+// so a "pass" can't silently hide that part of the workspace was never validated.
+type WorkspaceInfo = { name: string; refCount: number; skippedMetadata: string[] };
 type Report = {
+  schemaVersion: number;
   cliVersion: string;
+  workspace?: WorkspaceInfo;
   backend: {
     total: number;
     loaded: number;
@@ -119,6 +138,43 @@ function resolveOutPath(outArg: string): string | null {
   return resolved.startsWith(process.cwd() + sep) ? resolved : null;
 }
 
+// Resolve the effective test-config: workspace mode auto-discovers the workspace's
+// Docker-smoke files (smoke-tests/app-config.test.yaml + test.env), explicit flags
+// win. Env vars load first — the app-config layer's ${VAR} substitution reads
+// process.env. Returns the parsed app-config layer, if any.
+function resolveTestConfig(
+  inputs: CliInputs,
+  source: SmokeSource,
+): JsonObject | undefined {
+  if (source.kind === "workspace") {
+    const discovered = discoverSmokeTestConfig(REPO_ROOT, source.name);
+    inputs.appConfig ??= discovered.appConfig;
+    inputs.envFile ??= discovered.testEnv;
+  }
+  if (inputs.envFile) {
+    const applied = loadEnvFile(inputs.envFile);
+    console.log(`▶ test-env: ${inputs.envFile} (${applied.length} var(s) applied)`);
+  }
+  if (inputs.appConfig) console.log(`▶ app-config: ${inputs.appConfig}`);
+  return inputs.appConfig ? loadAppConfig(inputs.appConfig) : undefined;
+}
+
+// Workspace mode: resolve every published plugin of the workspace into a generated
+// dynamic-plugins.yaml the install CLI can consume, keeping the skip provenance
+// for results.json.
+async function materializeWorkspaceConfig(
+  workspace: string,
+  destDir: string,
+): Promise<{ path: string; info: WorkspaceInfo }> {
+  const { refs, skipped } = collectWorkspaceRefs(REPO_ROOT, workspace);
+  console.log(`▶ workspace '${workspace}': ${refs.length} oci plugin ref(s)`);
+  const path = await writeDynamicPluginsConfig(refs, destDir);
+  return {
+    path,
+    info: { name: workspace, refCount: refs.length, skippedMetadata: skipped },
+  };
+}
+
 // Partition backend entries into known-failure skips and loadable plugins in one
 // pass, so the two lists stay complementary.
 function partitionKnownFailures(entries: PluginEntry[]): {
@@ -143,6 +199,7 @@ async function writeErrorReport(
   message: string,
 ): Promise<void> {
   const report: Report = {
+    schemaVersion: REPORT_SCHEMA_VERSION,
     cliVersion,
     backend: { total: 0, loaded: 0, skipped: [], errors: [] },
     backendStart: { ok: false, error: message },
@@ -153,20 +210,26 @@ async function writeErrorReport(
   console.error(`▶ report → ${out} (status: error)\n${message}`);
 }
 
+type SmokeSource =
+  | { kind: "file"; path: string }
+  | { kind: "workspace"; name: string };
+
 type CliInputs = {
   out: string | null;
-  dynamicPlugins?: string;
+  source?: SmokeSource;
   appConfig?: string;
   envFile?: string;
   usageError?: string;
 };
 
-// Validate the CLI arguments up front: a sane --out, a required --dynamic-plugins,
-// and the optional --app-config/--test-env test-config inputs (see test-config.ts).
+// Validate the CLI arguments up front: a sane --out, exactly one plugin source
+// (--dynamic-plugins <file> XOR --workspace <name>), and the optional
+// --app-config/--test-env test-config inputs (see test-config.ts).
 function parseCliInputs(): CliInputs {
   const { values } = parseArgs({
     options: {
       "dynamic-plugins": { type: "string" },
+      workspace: { type: "string" },
       "app-config": { type: "string" },
       "test-env": { type: "string" },
       out: { type: "string" },
@@ -179,26 +242,40 @@ function parseCliInputs(): CliInputs {
     return { out: null, usageError: `--out must resolve inside the working directory: ${outArg}` };
   }
 
-  const dynamicPlugins = values["dynamic-plugins"];
-  if (!dynamicPlugins) {
-    return { out, usageError: "Provide --dynamic-plugins <dynamic-plugins.yaml>." };
-  }
-  const files: Array<[flag: string, file: string | undefined]> = [
-    ["--dynamic-plugins", dynamicPlugins],
+  const optionalFiles: Array<[flag: string, file: string | undefined]> = [
     ["--app-config", values["app-config"]],
     ["--test-env", values["test-env"]],
   ];
-  for (const [flag, file] of files) {
+  for (const [flag, file] of optionalFiles) {
     if (file && !existsSync(file)) {
       return { out, usageError: `${flag} file not found: ${file}` };
     }
   }
-  return {
+  const common = {
     out,
-    dynamicPlugins,
     appConfig: values["app-config"],
     envFile: values["test-env"],
   };
+
+  const file = values["dynamic-plugins"];
+  const workspace = values.workspace;
+  if (file && workspace) {
+    return { out, usageError: "Provide only one of --dynamic-plugins or --workspace." };
+  }
+  if (workspace) {
+    // Validated here, before ANY filesystem consumer (auto-discovery runs early).
+    if (!isValidWorkspaceName(workspace)) {
+      return { out, usageError: `invalid workspace name: '${workspace}'` };
+    }
+    return { ...common, source: { kind: "workspace", name: workspace } };
+  }
+  if (!file) {
+    return { out, usageError: "Provide --dynamic-plugins <dynamic-plugins.yaml> or --workspace <name>." };
+  }
+  if (!existsSync(file)) {
+    return { out, usageError: `dynamic-plugins file not found: ${file}` };
+  }
+  return { ...common, source: { kind: "file", path: file } };
 }
 
 function computeStatus(
@@ -281,8 +358,8 @@ async function main(): Promise<number> {
     console.error(inputs.usageError);
     return 2;
   }
-  const out = inputs.out;
-  if (inputs.usageError || !inputs.dynamicPlugins) {
+  const { out, source } = inputs;
+  if (inputs.usageError || !source) {
     await writeErrorReport(out, "unknown", inputs.usageError ?? "invalid arguments");
     return 2;
   }
@@ -294,13 +371,7 @@ async function main(): Promise<number> {
   try {
     // Everything fallible lives in the try, so any failure still writes a results.json
     // (status: error) instead of exiting with no report.
-    // Env vars first: the app-config layer's ${VAR} substitution reads process.env.
-    if (inputs.envFile) {
-      const applied = loadEnvFile(inputs.envFile);
-      console.log(`▶ test-env: ${inputs.envFile} (${applied.length} var(s) applied)`);
-    }
-    const appConfig = inputs.appConfig ? loadAppConfig(inputs.appConfig) : undefined;
-    if (inputs.appConfig) console.log(`▶ app-config: ${inputs.appConfig}`);
+    const appConfig = resolveTestConfig(inputs, source);
 
     cliVersion = run(process.execPath, [CLI_BIN, "--version"]);
     console.log(`▶ install CLI: ${CLI}@${cliVersion}`);
@@ -309,7 +380,11 @@ async function main(): Promise<number> {
     const root = join(tempDir, "dynamic-plugins-root");
     await mkdir(root, { recursive: true });
 
-    await extractPlugins(root, inputs.dynamicPlugins);
+    const materialized =
+      source.kind === "workspace"
+        ? await materializeWorkspaceConfig(source.name, tempDir)
+        : { path: source.path, info: undefined };
+    await extractPlugins(root, materialized.path);
 
     const manifest = discoverPlugins(root);
     console.log(
@@ -339,7 +414,10 @@ async function main(): Promise<number> {
     }
 
     const report: Report = {
+      schemaVersion: REPORT_SCHEMA_VERSION,
       cliVersion,
+      // undefined outside workspace mode — JSON.stringify omits it.
+      workspace: materialized.info,
       backend: {
         total: manifest.backend.length,
         loaded: loaded.length,

--- a/smoke-tests-native/src/test-config.test.ts
+++ b/smoke-tests-native/src/test-config.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadAppConfig, loadEnvFile } from "./test-config";
+
+const dir = mkdtempSync(join(tmpdir(), "test-config-"));
+
+function file(name: string, content: string): string {
+  const path = join(dir, name);
+  writeFileSync(path, content);
+  return path;
+}
+
+test("loadEnvFile applies KEY=VALUE lines, strips quotes, skips comments", () => {
+  const path = file(
+    "basic.env",
+    '# comment\nTC_FOO=bar\nTC_QUOTED="q v"\n\nTC_SINGLE=\'s v\'\n',
+  );
+  const applied = loadEnvFile(path);
+  assert.deepEqual(applied.sort(), ["TC_FOO", "TC_QUOTED", "TC_SINGLE"]);
+  assert.equal(process.env.TC_FOO, "bar");
+  assert.equal(process.env.TC_QUOTED, "q v");
+  assert.equal(process.env.TC_SINGLE, "s v");
+});
+
+test("loadEnvFile never overrides pre-set env (CI secrets win)", () => {
+  process.env.TC_PRESET = "from-ci";
+  const path = file("preset.env", "TC_PRESET=from-file\n");
+  assert.deepEqual(loadEnvFile(path), []);
+  assert.equal(process.env.TC_PRESET, "from-ci");
+});
+
+test("loadEnvFile ignores malformed lines without applying them", () => {
+  const path = file("broken.env", "BROKEN_LINE\n=novalue\nTC_OK=1\n");
+  assert.deepEqual(loadEnvFile(path), ["TC_OK"]);
+});
+
+test("loadAppConfig substitutes ${VAR} and ${VAR:-default}", () => {
+  process.env.TC_SET = "value";
+  const path = file(
+    "subst.yaml",
+    'a: "x ${TC_SET}"\nb: ${TC_UNSET_1:-fallback}\n',
+  );
+  const cfg = loadAppConfig(path) as { a: string; b: string };
+  assert.equal(cfg.a, "x value");
+  assert.equal(cfg.b, "fallback");
+});
+
+test("loadAppConfig: $$ escapes to a literal ${...}", () => {
+  const path = file("escape.yaml", 'a: "$${TC_SET}"\n');
+  assert.equal((loadAppConfig(path) as { a: string }).a, "${TC_SET}");
+});
+
+test("loadAppConfig drops keys and array items referencing unset vars with no default", () => {
+  const path = file(
+    "drop.yaml",
+    "kept: ok\ndropped: ${TC_UNSET_2}\nlist:\n  - ok\n  - ${TC_UNSET_2}\n",
+  );
+  const cfg = loadAppConfig(path) as { kept: string; list: string[] };
+  assert.equal(cfg.kept, "ok");
+  assert.equal("dropped" in cfg, false);
+  assert.deepEqual(cfg.list, ["ok"]);
+});
+
+test("loadAppConfig returns {} for an empty file and rejects non-mappings", () => {
+  assert.deepEqual(loadAppConfig(file("empty.yaml", "")), {});
+  assert.throws(
+    () => loadAppConfig(file("list.yaml", "- a\n- b\n")),
+    TypeError,
+  );
+});

--- a/smoke-tests-native/src/workspace.test.ts
+++ b/smoke-tests-native/src/workspace.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse } from "yaml";
+import {
+  collectWorkspaceRefs,
+  discoverSmokeTestConfig,
+  isValidWorkspaceName,
+  writeDynamicPluginsConfig,
+} from "./workspace";
+
+// Fake repo root: workspaces/<name>/{metadata,smoke-tests}
+const repoRoot = mkdtempSync(join(tmpdir(), "workspace-test-"));
+
+function makeWorkspace(
+  name: string,
+  metadata: Record<string, string>,
+  smokeTests?: Record<string, string>,
+): void {
+  const metadataDir = join(repoRoot, "workspaces", name, "metadata");
+  mkdirSync(metadataDir, { recursive: true });
+  for (const [file, content] of Object.entries(metadata)) {
+    writeFileSync(join(metadataDir, file), content);
+  }
+  if (smokeTests) {
+    const smokeDir = join(repoRoot, "workspaces", name, "smoke-tests");
+    mkdirSync(smokeDir, { recursive: true });
+    for (const [file, content] of Object.entries(smokeTests)) {
+      writeFileSync(join(smokeDir, file), content);
+    }
+  }
+}
+
+const OCI_REF = "oci://ghcr.io/example/plugin-a:tag!plugin-a";
+
+test("isValidWorkspaceName rejects separators and dot-only names", () => {
+  assert.equal(isValidWorkspaceName("mcp-integrations"), true);
+  assert.equal(isValidWorkspaceName("tech-radar.v2"), true);
+  assert.equal(isValidWorkspaceName(".."), false);
+  assert.equal(isValidWorkspaceName("."), false);
+  assert.equal(isValidWorkspaceName("a/b"), false);
+  assert.equal(isValidWorkspaceName("../workspaces/acs"), false);
+  assert.equal(isValidWorkspaceName(""), false);
+});
+
+test("collectWorkspaceRefs collects oci refs and skips local-path artifacts", () => {
+  makeWorkspace("mixed", {
+    "plugin-a.yaml": `spec:\n  dynamicArtifact: ${OCI_REF}\n`,
+    "plugin-b.yaml":
+      "spec:\n  dynamicArtifact: ./dynamic-plugins/dist/plugin-b-dynamic\n",
+  });
+  const { refs, skipped } = collectWorkspaceRefs(repoRoot, "mixed");
+  assert.deepEqual(refs, [OCI_REF]);
+  assert.deepEqual(skipped, ["plugin-b.yaml"]);
+});
+
+test("collectWorkspaceRefs throws when no oci refs remain", () => {
+  makeWorkspace("local-only", {
+    "plugin.yaml":
+      "spec:\n  dynamicArtifact: ./dynamic-plugins/dist/plugin-dynamic\n",
+  });
+  assert.throws(
+    () => collectWorkspaceRefs(repoRoot, "local-only"),
+    /nothing to validate/,
+  );
+});
+
+test("collectWorkspaceRefs throws on unknown workspace and invalid names", () => {
+  assert.throws(
+    () => collectWorkspaceRefs(repoRoot, "does-not-exist"),
+    /metadata not found/,
+  );
+  assert.throws(() => collectWorkspaceRefs(repoRoot, ".."), /invalid workspace name/);
+});
+
+test("discoverSmokeTestConfig finds only the files that exist", () => {
+  makeWorkspace(
+    "with-env",
+    { "plugin.yaml": `spec:\n  dynamicArtifact: ${OCI_REF}\n` },
+    { "test.env": "SOME_URL=https://example.com\n" },
+  );
+  const withEnv = discoverSmokeTestConfig(repoRoot, "with-env");
+  assert.equal(withEnv.appConfig, undefined);
+  assert.match(withEnv.testEnv ?? "", /with-env\/smoke-tests\/test\.env$/);
+
+  const none = discoverSmokeTestConfig(repoRoot, "mixed");
+  assert.deepEqual(none, { appConfig: undefined, testEnv: undefined });
+});
+
+test("writeDynamicPluginsConfig produces the yaml the install CLI consumes", async () => {
+  const dest = mkdtempSync(join(tmpdir(), "dp-out-"));
+  const path = await writeDynamicPluginsConfig([OCI_REF], dest);
+  const doc = parse(readFileSync(path, "utf8")) as {
+    plugins: Array<{ package: string }>;
+  };
+  assert.deepEqual(doc.plugins, [{ package: OCI_REF }]);
+});

--- a/smoke-tests-native/src/workspace.ts
+++ b/smoke-tests-native/src/workspace.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+/**
+ * Workspace mode: resolve ALL of a workspace's published plugins from its
+ * `workspaces/<name>/metadata/*.yaml` Package entities (`spec.dynamicArtifact`)
+ * and generate the dynamic-plugins.yaml the install CLI consumes.
+ *
+ * Only `oci://` artifacts are included — some workspaces (e.g.
+ * scaffolder-backend-module-kubernetes) declare a local `./dynamic-plugins/dist/…`
+ * path instead, meaning the plugin ships inside the RHDH image and has no OCI
+ * artifact to pull; those are skipped with a warning.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parse, stringify } from "yaml";
+
+type PackageMetadata = {
+  spec?: { dynamicArtifact?: unknown };
+};
+
+export type WorkspaceRefs = {
+  /** oci:// refs to install and validate. */
+  refs: string[];
+  /** metadata files skipped because their artifact is not an oci:// ref. */
+  skipped: string[];
+};
+
+/**
+ * The workspace name comes from the CLI / workflow dispatch and is joined into
+ * filesystem paths — only accept plain directory names (no separators, and not the
+ * dot-only names `.`/`..` that would walk out of workspaces/).
+ */
+export function isValidWorkspaceName(name: string): boolean {
+  return /^(?!\.+$)[A-Za-z0-9._-]+$/.test(name);
+}
+
+/** Collect the oci:// dynamicArtifact refs of every Package in the workspace. */
+export function collectWorkspaceRefs(
+  repoRoot: string,
+  workspace: string,
+): WorkspaceRefs {
+  // parseCliInputs already rejects invalid names; kept as defense-in-depth since
+  // this function is exported.
+  if (!isValidWorkspaceName(workspace)) {
+    throw new Error(`invalid workspace name: '${workspace}'`);
+  }
+  const metadataDir = join(repoRoot, "workspaces", workspace, "metadata");
+  if (!existsSync(metadataDir)) {
+    throw new Error(
+      `workspace metadata not found: ${metadataDir} — expected workspaces/${workspace}/metadata/*.yaml`,
+    );
+  }
+
+  const refs: string[] = [];
+  const skipped: string[] = [];
+  const files = readdirSync(metadataDir).filter(
+    (f) => f.endsWith(".yaml") || f.endsWith(".yml"),
+  );
+  for (const file of files) {
+    // Metadata files are repo-controlled; a malformed one deliberately throws and
+    // fails the run (unlike discoverPlugins' warn-and-continue for extracted
+    // package.json files) — a broken metadata file in a bump PR should fail loud.
+    const doc = parse(
+      readFileSync(join(metadataDir, file), "utf8"),
+    ) as PackageMetadata | null;
+    const artifact = doc?.spec?.dynamicArtifact;
+    if (typeof artifact === "string" && artifact.startsWith("oci://")) {
+      refs.push(artifact);
+    } else {
+      skipped.push(file);
+      console.warn(
+        `⚠ ${workspace}/${file}: dynamicArtifact is not an oci:// ref ` +
+          `(${typeof artifact === "string" ? artifact : "missing"}) — skipped`,
+      );
+    }
+  }
+
+  if (refs.length === 0) {
+    throw new Error(
+      `workspace '${workspace}' has no oci:// dynamicArtifact refs ` +
+        `(${files.length} metadata file(s), ${skipped.length} skipped) — nothing to validate`,
+    );
+  }
+  return { refs, skipped };
+}
+
+/**
+ * Locate the workspace's Docker-smoke test config files, if any — the same
+ * `smoke-tests/app-config.test.yaml` and `smoke-tests/test.env` the Docker smoke
+ * mounts into the container (run-workspace-smoke-tests.yaml).
+ */
+export function discoverSmokeTestConfig(
+  repoRoot: string,
+  workspace: string,
+): { appConfig?: string; testEnv?: string } {
+  const dir = join(repoRoot, "workspaces", workspace, "smoke-tests");
+  const appConfig = join(dir, "app-config.test.yaml");
+  const testEnv = join(dir, "test.env");
+  return {
+    appConfig: existsSync(appConfig) ? appConfig : undefined,
+    testEnv: existsSync(testEnv) ? testEnv : undefined,
+  };
+}
+
+/** Write the generated dynamic-plugins.yaml and return its path. */
+export async function writeDynamicPluginsConfig(
+  refs: string[],
+  destDir: string,
+): Promise<string> {
+  const path = join(destDir, "dynamic-plugins.workspace.yaml");
+  await writeFile(path, stringify({ plugins: refs.map((pkg) => ({ package: pkg })) }));
+  return path;
+}


### PR DESCRIPTION
## What

Follow-up to #2714: `yarn smoke --workspace <name>` validates ALL of a workspace's
published plugins in one run — the same per-workspace unit the Docker smoke covers.

- Resolves every `oci://` `spec.dynamicArtifact` from `workspaces/<name>/metadata/*.yaml`
  and installs/boots them together. Local `./dynamic-plugins/dist/…` artifacts (plugin
  ships inside the RHDH image, nothing published to pull) are skipped with a warning;
  a workspace with no `oci://` refs reports `status: error` (nothing to validate).
- Auto-discovers the workspace's Docker-smoke test config
  (`smoke-tests/app-config.test.yaml` + `smoke-tests/test.env`), reusing #2714's
  `--app-config`/`--test-env` machinery; explicit flags win over discovered files.
- The workflow gains an optional `workspace` dispatch input (takes precedence over
  `plugin_ref`).

## Why

The Docker smoke is per-workspace; single-ref validation can't replace it. This is the
prerequisite for the parity runs that let covered workspaces skip the Docker container
([RHIDP-13530](https://redhat.atlassian.net/browse/RHIDP-13530)).

## Verification (Node 24, released refs)

- `mcp-integrations`: 3/3 backend plugins loaded and booted together — pass
- `acs`: `smoke-tests/test.env` auto-discovered and applied, frontend bundle valid
  (legacy + new-frontend-system) — pass
- `github-notifications`, `scaffolder-backend-module-{servicenow,sonarqube}` — pass
- `scaffolder-backend-module-{kubernetes,regex}`: clean error — released
  `dynamicArtifact` is a local path, no OCI artifact to validate (exit 1)
- Usage errors (both flags, unknown workspace) exit 2/1 with `results.json` written

Tickets: [RHIDP-13530](https://redhat.atlassian.net/browse/RHIDP-13530) (epic [RHIDP-13501](https://redhat.atlassian.net/browse/RHIDP-13501)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)