### PR TITLE
feat: notify RHDH plugin sanity check after publishing plugins

### DIFF
--- a/.github/workflows/publish-workspace-plugins.yaml
+++ b/.github/workflows/publish-workspace-plugins.yaml
@@ -20,10 +20,13 @@ jobs:
   # side fingerprints the catalog index composition first, so redundant
   # dispatches are cheap (they short-circuit in ~1 min).
   #
-  # Requires the RHDH_REPO_DISPATCH_TOKEN secret: a token allowed to create
-  # repository_dispatch events on redhat-developer/rhdh (fine-grained PAT with
-  # "Contents: read and write" on that repo, or a GitHub App token). The job
-  # exits successfully without dispatching while the secret is not configured.
+  # Credentials (either works; the job exits successfully without dispatching
+  # while neither is configured):
+  #   - RHDH_GITHUB_APP_ID + RHDH_GITHUB_APP_PRIVATE_KEY (preferred): the RHDH
+  #     GitHub App already used by redhat-developer/rhdh workflows - mints a
+  #     short-lived token scoped to that single repo.
+  #   - RHDH_REPO_DISPATCH_TOKEN: fine-grained PAT with "Contents: read and
+  #     write" on redhat-developer/rhdh.
   notify-rhdh:
     name: Notify RHDH plugin sanity check
     runs-on: ubuntu-latest
@@ -31,16 +34,37 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Send repository_dispatch (catalog-plugins-published)
+      - name: Detect available credentials
+        id: creds
         env:
-          GH_TOKEN: ${{ secrets.RHDH_REPO_DISPATCH_TOKEN }}
-          BRANCH: ${{ github.ref_name }}
+          APP_ID: ${{ secrets.RHDH_GITHUB_APP_ID }}
+          DISPATCH_TOKEN: ${{ secrets.RHDH_REPO_DISPATCH_TOKEN }}
         run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "RHDH_REPO_DISPATCH_TOKEN not configured - skipping dispatch"
-            exit 0
+          if [ -n "$APP_ID" ]; then
+            echo "mode=app" >> "$GITHUB_OUTPUT"
+          elif [ -n "$DISPATCH_TOKEN" ]; then
+            echo "mode=pat" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+            echo "No dispatch credentials configured (RHDH_GITHUB_APP_ID/RHDH_GITHUB_APP_PRIVATE_KEY or RHDH_REPO_DISPATCH_TOKEN) - skipping dispatch"
           fi
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.creds.outputs.mode == 'app'
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ secrets.RHDH_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RHDH_GITHUB_APP_PRIVATE_KEY }}
+          owner: redhat-developer
+          repositories: rhdh
+
+      - name: Send repository_dispatch (catalog-plugins-published)
+        if: steps.creds.outputs.mode != 'none'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.RHDH_REPO_DISPATCH_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
           # Same branch->tag mapping as the RHDH CI pipelines:
           # main -> next, release-X.Y -> X.Y
           if [ "$BRANCH" = "main" ]; then

--- a/.github/workflows/publish-workspace-plugins.yaml
+++ b/.github/workflows/publish-workspace-plugins.yaml
@@ -13,3 +13,44 @@ jobs:
       attestations: write
       packages: write
       id-token: write
+
+  # Notify the RHDH repo that plugins were (re)published so its plugin sanity
+  # check (.github/workflows/plugin-sanity-check.yaml) can validate the new
+  # builds immediately instead of waiting for the next scheduled run. The RHDH
+  # side fingerprints the catalog index composition first, so redundant
+  # dispatches are cheap (they short-circuit in ~1 min).
+  #
+  # Requires the RHDH_REPO_DISPATCH_TOKEN secret: a token allowed to create
+  # repository_dispatch events on redhat-developer/rhdh (fine-grained PAT with
+  # "Contents: read and write" on that repo, or a GitHub App token). The job
+  # exits successfully without dispatching while the secret is not configured.
+  notify-rhdh:
+    name: Notify RHDH plugin sanity check
+    runs-on: ubuntu-latest
+    needs: export
+    permissions:
+      contents: read
+    steps:
+      - name: Send repository_dispatch (catalog-plugins-published)
+        env:
+          GH_TOKEN: ${{ secrets.RHDH_REPO_DISPATCH_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "RHDH_REPO_DISPATCH_TOKEN not configured - skipping dispatch"
+            exit 0
+          fi
+
+          # Same branch->tag mapping as the RHDH CI pipelines:
+          # main -> next, release-X.Y -> X.Y
+          if [ "$BRANCH" = "main" ]; then
+            TAG="next"
+          else
+            TAG="${BRANCH#release-}"
+          fi
+          IMAGE="quay.io/rhdh/plugin-catalog-index:${TAG}"
+
+          echo "Dispatching catalog-plugins-published to redhat-developer/rhdh (index: ${IMAGE})"
+          gh api repos/redhat-developer/rhdh/dispatches \
+            -f event_type=catalog-plugins-published \
+            -f "client_payload[catalog_index_image]=${IMAGE}"


### PR DESCRIPTION
## Summary

Adds a `notify-rhdh` job to the publish workflow that fires a `repository_dispatch` (`catalog-plugins-published`) at `redhat-developer/rhdh` after a successful export, carrying the branch-matched catalog index image (`main` → `next`, `release-X.Y` → `X.Y`) in the client payload.

## Why

RHDH is adding a cluster-free plugin sanity check (redhat-developer/rhdh#4967) that boots the real RHDH backend with every plugin enabled by the catalog index and verifies they all load. Its scheduled runs detect re-published plugins by fingerprinting image digests, but a dispatch from this publish pipeline validates new builds **immediately** instead of on the next cron tick.

Redundant dispatches are cheap: the RHDH side fingerprints the index composition first and short-circuits in about a minute when nothing effectively changed.

## Credentials (one secret setup needed)

This repo currently has no credential able to dispatch to `redhat-developer/rhdh` (repo secrets are CODECOV/FULLSEND/QUAY only; the only shared org secret is `NPM_TOKEN`). The job supports two modes and picks whichever is configured:

1. **Preferred — RHDH GitHub App**: add `RHDH_GITHUB_APP_ID` + `RHDH_GITHUB_APP_PRIVATE_KEY` to this repo (same App the `redhat-developer/rhdh` workflows already use, e.g. `update-backstage.yaml`). The job mints a short-lived installation token scoped to the single `rhdh` repository — no long-lived PAT.
2. **Fallback — `RHDH_REPO_DISPATCH_TOKEN`**: fine-grained PAT with **Contents: read and write** on `redhat-developer/rhdh`.

Until one of them is configured the job logs a notice and exits successfully — safe to merge before the secret exists.

## Notes

This is intentionally the only change: the per-plugin pre-publish gate stays with the native smoke harness work (#2714), and the whole-index validation lives on the RHDH side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)