### PR TITLE
feat: run the native smoke alongside the container smoke for validated workspaces

### DIFF
--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -11,10 +11,18 @@ on:
         description: Optional RHDH image tag override for quay.io/rhdh-community/rhdh:<tag>
         type: string
         required: false
+      workspace:
+        description: Workspace under test (workspaces/<name>) — selects the extra native smoke for allowlisted workspaces
+        type: string
+        required: false
+        default: ""
     outputs:
       success:
         description: Overall smoke test result
         value: ${{ jobs.run.outputs.success }}
+      native-result:
+        description: Native (in-process) smoke result for allowlisted workspaces on main — success/failure, empty when not applicable
+        value: ${{ jobs.native-smoke.outputs.result }}
       failed-plugins:
         description: Newline-separated list of plugins that failed to load
         value: ${{ jobs.run.outputs.failed-plugins }}
@@ -246,3 +254,102 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker rm -f rhdh || true
+
+  # Runs the Docker-free, in-process harness (smoke-tests-native/) on the same
+  # artifact the container smoke consumes. Gated to the workspaces empirically
+  # validated against it; for those it runs alongside the container job as a real
+  # check during the overlap window, after which the container job can skip them.
+  #
+  # Also gated to main. The harness is always checked out from main (this workflow
+  # is dispatched on the default branch), so its Backstage deps track main's
+  # versions.json — while the artifact under test carries the PR's target-branch
+  # versions. On a release line those diverge (main 1.52.x vs release-1.10 1.49.x)
+  # and the harness would boot release-built plugins in a newer test backend.
+  # Widen once a release line has been validated against the harness.
+  native-smoke:
+    if: >-
+      inputs.target-branch == 'main' &&
+      contains(fromJSON('[
+        "workspaces/github-notifications",
+        "workspaces/mcp-integrations",
+        "workspaces/scaffolder-backend-module-servicenow",
+        "workspaces/scaffolder-backend-module-sonarqube"
+      ]'), inputs.workspace)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      result: ${{ steps.outcome.outputs.result }}
+    steps:
+      - name: Checkout (harness source)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download smoke test artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: smoke-test-artifacts
+          path: ./artifacts
+
+      - name: Enable Corepack
+        # Before setup-node so its yarn-cache detection resolves Yarn 4 via corepack.
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: yarn
+          cache-dependency-path: smoke-tests-native/yarn.lock
+
+      - name: Install skopeo
+        # The install-dynamic-plugins CLI shells out to skopeo to pull OCI plugins.
+        run: sudo apt-get update && sudo apt-get install -y skopeo
+
+      - name: Log in to ghcr.io
+        # Public plugin images pull anonymously; authenticating only avoids rate limits.
+        # Non-fatal: fork PRs get a restricted token, and anonymous pulls still work.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
+        run: echo "$GH_TOKEN" | skopeo login ghcr.io -u "$GH_ACTOR" --password-stdin
+
+      - name: Install dependencies
+        working-directory: smoke-tests-native
+        # Build scripts must stay enabled: better-sqlite3 (transitively, via
+        # backend-test-utils) is a native addon and compiles its binding during
+        # install. --mode=skip-build makes startTestBackend fail at DB connect.
+        run: yarn install --immutable
+
+      - name: Run native smoke harness
+        id: native
+        working-directory: smoke-tests-native
+        # The container also consumes artifacts/app-config.yaml (backend.baseUrl,
+        # db, auth) — the native harness deliberately skips it: startTestBackend
+        # mocks the core services that config feeds. The plugin-relevant inputs
+        # are the same: dynamic-plugins.test.yaml plus the optional
+        # app-config.test.yaml (--config mount) and test.env (--env-file).
+        run: |
+          ARGS=(--dynamic-plugins ../artifacts/dynamic-plugins.test.yaml --out results-native.json)
+          [ -f ../artifacts/app-config.test.yaml ] && ARGS+=(--app-config ../artifacts/app-config.test.yaml)
+          [ -f ../artifacts/test.env ] && ARGS+=(--test-env ../artifacts/test.env)
+          yarn smoke "${ARGS[@]}"
+
+      - name: Record outcome
+        id: outcome
+        if: always()
+        env:
+          OUTCOME: ${{ steps.native.outcome }}
+        run: echo "result=$OUTCOME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload native results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-smoke-results
+          path: smoke-tests-native/results-native.json
+          if-no-files-found: warn

--- a/.github/workflows/workspace-tests.yaml
+++ b/.github/workflows/workspace-tests.yaml
@@ -311,6 +311,7 @@ jobs:
     with:
       target-branch: ${{ needs.resolve.outputs.target-branch }}
       rhdh-tag: ${{ needs.resolve.outputs.rhdh-tag }}
+      workspace: ${{ needs.resolve.outputs.workspace }}
 
   add-skipped-test-comment:
     if: ${{ always() && needs.resolve.outputs.pr-number != 'null' && needs.resolve.outputs.pr-number != '' && (needs.resolve.outputs.workspace == '' || (needs.prepare-test-config.result != 'skipped' && (needs.prepare-test-config.outputs.has-runnable-plugins != 'true' || needs.prepare-test-config.outputs.skip-tests-missing-env == 'true'))) }}
@@ -412,6 +413,7 @@ jobs:
         env:
           SMOKE_TESTS_RESULT: ${{ needs.run-smoke-tests.result }}
           SUCCESS: ${{ needs.run-smoke-tests.outputs.success }}
+          NATIVE_RESULT: ${{ needs.run-smoke-tests.outputs.native-result }}
           FAILED_PLUGINS: ${{ needs.run-smoke-tests.outputs.failed-plugins }}
           ERROR_LOGS: ${{ needs.run-smoke-tests.outputs.error-logs }}
           MISSING_METADATA_PLUGINS: ${{ needs.prepare-test-config.outputs.missing-metadata-plugins || '' }}
@@ -428,13 +430,25 @@ jobs:
             const pr = Number(process.env.PR_NUMBER);
             const overlayCommit = process.env.OVERLAY_COMMIT;
             
+            const nativeResult = process.env.NATIVE_RESULT || '';
             const success = smokeTestsResult === 'success' && successOutput === 'true';
             let failureReason = '';
-            
+
             if (!success) {
               switch (smokeTestsResult) {
                 case 'failure':
-                  failureReason = 'Smoke tests failed. Check the workflow logs for details.';
+                  // For allowlisted workspaces both smokes run; name the divergences
+                  // instead of reporting a generic failure — each direction points the
+                  // triage somewhere different.
+                  if (successOutput === 'true' && nativeResult === 'failure') {
+                    failureReason = 'The container smoke passed but the native (in-process) smoke failed — check the native-smoke job logs and its results artifact.';
+                  } else if (nativeResult === 'success') {
+                    failureReason = 'The container smoke failed but the native (in-process) smoke passed — the plugin loads and boots, so look for an environment/image issue in the container job logs.';
+                  } else if (nativeResult === 'failure') {
+                    failureReason = 'Both the container and the native (in-process) smoke failed — the plugin itself is the likely cause. Check both jobs\' logs.';
+                  } else {
+                    failureReason = 'Smoke tests failed. Check the workflow logs for details.';
+                  }
                   break;
                 case 'cancelled':
                   failureReason = 'Smoke tests were cancelled.';


### PR DESCRIPTION
## What

For the workspaces already validated end-to-end against the Docker-free harness
(#2714/#2731) — `github-notifications`, `mcp-integrations`,
`scaffolder-backend-module-{servicenow,sonarqube}` — bump-PR smoke runs now execute
the **native in-process smoke alongside the container smoke**, as a real check on the
same `smoke-test-artifacts` bundle.

- `run-workspace-smoke-tests.yaml`: new `workspace` input; allowlist-gated
  `native-smoke` job (blocking). It consumes the same plugin-relevant inputs as the
  container — `dynamic-plugins.test.yaml` + optional `app-config.test.yaml`/`test.env`
  — and deliberately skips `artifacts/app-config.yaml` (`startTestBackend` mocks the
  core services that config feeds). `results-native.json` is uploaded for debugging;
  a `native-result` output is exposed.
- `workspace-tests.yaml`: passes the workspace; the PR result comment names the
  "container passed / native failed" divergence explicitly instead of a generic
  failure message.
- The job is gated to the allowlist **and to `main`**. The harness is always checked
  out from main (this workflow is dispatched on the default branch), so its Backstage
  deps track main's `versions.json` while the artifact under test carries the PR's
  target-branch versions. On a release line those diverge (main 1.52.x vs
  release-1.10 1.49.x), and a blocking job must not fail a release bump PR on a
  cross-version mismatch. Widen once a release line is validated.

## Why (and why not an informational job)

This is the overlap window before the container job can skip these workspaces
(~104s → ~5s each). An informational-parity approach was tried first (#2735, closed):
per-run summaries and 90-day artifacts have no consumption story. Here the parity
evidence lands exactly where maintainers already look — two checks side by side on
real bump PRs of the affected workspaces. After a period of sustained agreement, a
trivial follow-up makes the container job skip the allowlisted workspaces.

## Verification

- Both workflow YAMLs parse; the allowlist `fromJSON` literal parses; the embedded
  `github-script` body syntax-checks; callers' workflow-level outputs unchanged
  (`native-result` is additive).
- The exact harness invocation (same flags, same artifact layout) was validated
  end-to-end on a fork against the real reusable workflow — container and native
  agreeing on the same artifact, plus failure-path classification:
  https://github.com/gustavolira/rhdh-plugin-export-overlays/actions/runs/28868518531
- The 4 allowlisted workspaces were each validated against the harness with their
  published refs (mcp-integrations boots its 3 plugins together).
- Note: `workflow_call`-only files — this PR's own checks don't exercise them; the
  first real run happens on the next `/publish`+`/smoketest` of an allowlisted
  workspace.

Tickets: [RHIDP-13530](https://redhat.atlassian.net/browse/RHIDP-13530) (epic [RHIDP-13501](https://redhat.atlassian.net/browse/RHIDP-13501)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
