### PR TITLE
chore(deps): [release-1.10] [orchestrator] bump protobufjs to 7.5.8 or higher

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -1,6 +1,75 @@
 --- yarn.lock
 +++ yarn.lock
-@@ -24775,29 +24775,29 @@
+@@ -10955,27 +10955,26 @@
+   languageName: node
+   linkType: hard
+ 
+-"@protobufjs/codegen@npm:^2.0.4":
+-  version: 2.0.4
+-  resolution: "@protobufjs/codegen@npm:2.0.4"
+-  checksum: 10c0/26ae337c5659e41f091606d16465bbcc1df1f37cc1ed462438b1f67be0c1e28dfb2ca9f294f39100c52161aef82edf758c95d6d75650a1ddf31f7ddee1440b43
++"@protobufjs/codegen@npm:^2.0.5":
++  version: 2.0.5
++  resolution: "@protobufjs/codegen@npm:2.0.5"
++  checksum: 10c0/1b8a2ae56ee60a56e9d205cd4b6072a1503c5069b8ebb905710f974ff0098a0d0700641c137e0a8d98dedf14423156a106a9433695cbf52574810f55000fdcab
+   languageName: node
+   linkType: hard
+ 
+-"@protobufjs/eventemitter@npm:^1.1.0":
+-  version: 1.1.0
+-  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+-  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
++"@protobufjs/eventemitter@npm:^1.1.1":
++  version: 1.1.1
++  resolution: "@protobufjs/eventemitter@npm:1.1.1"
++  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
+   languageName: node
+   linkType: hard
+ 
+-"@protobufjs/fetch@npm:^1.1.0":
+-  version: 1.1.0
+-  resolution: "@protobufjs/fetch@npm:1.1.0"
++"@protobufjs/fetch@npm:^1.1.1":
++  version: 1.1.1
++  resolution: "@protobufjs/fetch@npm:1.1.1"
+   dependencies:
+     "@protobufjs/aspromise": "npm:^1.1.1"
+-    "@protobufjs/inquire": "npm:^1.1.0"
+-  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
++  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
+   languageName: node
+   linkType: hard
+ 
+@@ -10986,13 +10985,6 @@
+   languageName: node
+   linkType: hard
+ 
+-"@protobufjs/inquire@npm:^1.1.0":
+-  version: 1.1.0
+-  resolution: "@protobufjs/inquire@npm:1.1.0"
+-  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
+@@ -11007,10 +10999,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"@protobufjs/utf8@npm:^1.1.0":
+-  version: 1.1.0
+-  resolution: "@protobufjs/utf8@npm:1.1.0"
+-  checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
++"@protobufjs/utf8@npm:^1.1.1":
++  version: 1.1.2
++  resolution: "@protobufjs/utf8@npm:1.1.2"
++  checksum: 10c0/975c6e2c0319bd50c17531d186b537a88cb4d3205e3ca9297cd842b631d341da0ee3ff16be8656cd2660756dc753b29c8a6a14c0ad8ed602c1f91ddf22e7b3f3
+   languageName: node
+   linkType: hard
+ 
+@@ -24775,29 +24767,29 @@
    linkType: hard
  
  "form-data@npm:^2.5.0":
@@ -39,7 +108,7 @@
    languageName: node
    linkType: hard
  
-@@ -25855,6 +25855,15 @@
+@@ -25855,6 +25847,15 @@
    dependencies:
      function-bind: "npm:^1.1.2"
    checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
@@ -55,7 +124,52 @@
    languageName: node
    linkType: hard
  
-@@ -38727,9 +38736,9 @@
+@@ -29430,6 +29431,13 @@
+   languageName: node
+   linkType: hard
+ 
++"long@npm:^5.3.2":
++  version: 5.3.2
++  resolution: "long@npm:5.3.2"
++  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
++  languageName: node
++  linkType: hard
++
+ "longest-streak@npm:^3.0.0":
+   version: 3.1.0
+   resolution: "longest-streak@npm:3.1.0"
+@@ -33625,22 +33633,21 @@
+   linkType: hard
+ 
+ "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
+-  version: 7.5.4
+-  resolution: "protobufjs@npm:7.5.4"
++  version: 7.6.5
++  resolution: "protobufjs@npm:7.6.5"
+   dependencies:
+     "@protobufjs/aspromise": "npm:^1.1.2"
+     "@protobufjs/base64": "npm:^1.1.2"
+-    "@protobufjs/codegen": "npm:^2.0.4"
+-    "@protobufjs/eventemitter": "npm:^1.1.0"
+-    "@protobufjs/fetch": "npm:^1.1.0"
++    "@protobufjs/codegen": "npm:^2.0.5"
++    "@protobufjs/eventemitter": "npm:^1.1.1"
++    "@protobufjs/fetch": "npm:^1.1.1"
+     "@protobufjs/float": "npm:^1.0.2"
+-    "@protobufjs/inquire": "npm:^1.1.0"
+     "@protobufjs/path": "npm:^1.1.2"
+     "@protobufjs/pool": "npm:^1.1.0"
+-    "@protobufjs/utf8": "npm:^1.1.0"
++    "@protobufjs/utf8": "npm:^1.1.1"
+     "@types/node": "npm:>=13.7.0"
+-    long: "npm:^5.0.0"
+-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
++    long: "npm:^5.3.2"
++  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
+   languageName: node
+   linkType: hard
+ 
+@@ -38727,9 +38734,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.2.3, undici@npm:^7.24.0":
@@ -67,4 +181,4 @@
 +  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
    languageName: node
    linkType: hard
-
+ 

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -3,6 +3,7 @@
 # Optional: add notes on any backport row (preserved when you re-run generate).
 
 patch_file: 0-cve-yarn-lock.patch
+repo_ref: eb6cce6110fc8bd532e717e9d995764481b36f1b
 backports:
   - cve_ids:
       - CVE-2026-12143
@@ -21,6 +22,10 @@ backports:
       - CVE-2026-42338
     package: ip-address
     patch_version: 10.2.0
+  - cve_ids:
+      - CVE-2026-45740
+    package: protobufjs
+    patch_version: 7.6.5
   - cve_ids:
       - CVE-2026-12151
       - CVE-2026-6734


### PR DESCRIPTION
It bumps protobufjs to 7.5.8 or higher to fix CVE-2026-45740
https://redhat.atlassian.net/browse/RHIDP-15197