### PR TITLE
chore(deps): [release-1.10] [lightspeed] bump protobufjs to 7.5.8 or higher

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -1,6 +1,49 @@
 --- yarn.lock
 +++ yarn.lock
-@@ -21220,13 +21220,13 @@
+@@ -8857,20 +8857,19 @@
+   languageName: node
+   linkType: hard
+ 
+-"@protobufjs/eventemitter@npm:^1.1.0":
+-  version: 1.1.0
+-  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+-  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
++"@protobufjs/eventemitter@npm:^1.1.1":
++  version: 1.1.1
++  resolution: "@protobufjs/eventemitter@npm:1.1.1"
++  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
+   languageName: node
+   linkType: hard
+ 
+-"@protobufjs/fetch@npm:^1.1.0":
+-  version: 1.1.0
+-  resolution: "@protobufjs/fetch@npm:1.1.0"
++"@protobufjs/fetch@npm:^1.1.1":
++  version: 1.1.1
++  resolution: "@protobufjs/fetch@npm:1.1.1"
+   dependencies:
+     "@protobufjs/aspromise": "npm:^1.1.1"
+-    "@protobufjs/inquire": "npm:^1.1.0"
+-  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
++  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
+   languageName: node
+   linkType: hard
+ 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
+-"@protobufjs/inquire@npm:1.1.0":
+-  version: 1.1.0
+-  resolution: "@protobufjs/inquire@npm:1.1.0"
+-  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+   languageName: node
+   linkType: hard
+ 
+@@ -21220,13 +21212,13 @@
    linkType: hard
  
  "express-rate-limit@npm:^8.2.2":
@@ -18,7 +61,7 @@
    languageName: node
    linkType: hard
  
-@@ -21802,29 +21802,29 @@
+@@ -21802,29 +21794,29 @@
    linkType: hard
  
  "form-data@npm:^2.5.5":
@@ -57,23 +100,23 @@
    languageName: node
    linkType: hard
  
-@@ -22822,6 +22822,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
+@@ -22825,6 +22817,15 @@
+   languageName: node
+   linkType: hard
+ 
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: "npm:^1.1.2"
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
-   languageName: node
-   linkType: hard
- 
-@@ -23818,20 +23827,10 @@
++  languageName: node
++  linkType: hard
++
+ "hast-util-from-parse5@npm:^7.0.0":
+   version: 7.1.2
+   resolution: "hast-util-from-parse5@npm:7.1.2"
+@@ -23818,20 +23819,10 @@
    languageName: node
    linkType: hard
  
@@ -98,7 +141,7 @@
    languageName: node
    linkType: hard
  
-@@ -25246,7 +25245,7 @@
+@@ -25246,7 +25237,7 @@
    languageName: node
    linkType: hard
  
@@ -107,7 +150,21 @@
    version: 1.1.0
    resolution: "jsbn@npm:1.1.0"
    checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
-@@ -27950,7 +27949,7 @@
+@@ -26426,6 +26417,13 @@
+   version: 5.2.3
+   resolution: "long@npm:5.2.3"
+   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++  languageName: node
++  linkType: hard
++
++"long@npm:^5.3.2":
++  version: 5.3.2
++  resolution: "long@npm:5.3.2"
++  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
+   languageName: node
+   linkType: hard
+ 
+@@ -27950,7 +27948,7 @@
    languageName: node
    linkType: hard
  
@@ -116,17 +173,45 @@
    version: 2.1.35
    resolution: "mime-types@npm:2.1.35"
    dependencies:
-@@ -33789,12 +33788,12 @@
+@@ -31078,22 +31076,21 @@
+   linkType: hard
+ 
+ "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
+-  version: 7.5.6
+-  resolution: "protobufjs@npm:7.5.6"
++  version: 7.6.5
++  resolution: "protobufjs@npm:7.6.5"
+   dependencies:
+     "@protobufjs/aspromise": "npm:^1.1.2"
+     "@protobufjs/base64": "npm:^1.1.2"
+     "@protobufjs/codegen": "npm:^2.0.5"
+-    "@protobufjs/eventemitter": "npm:^1.1.0"
+-    "@protobufjs/fetch": "npm:^1.1.0"
++    "@protobufjs/eventemitter": "npm:^1.1.1"
++    "@protobufjs/fetch": "npm:^1.1.1"
+     "@protobufjs/float": "npm:^1.0.2"
+-    "@protobufjs/inquire": "npm:^1.1.1"
+     "@protobufjs/path": "npm:^1.1.2"
+     "@protobufjs/pool": "npm:^1.1.0"
+     "@protobufjs/utf8": "npm:^1.1.1"
+     "@types/node": "npm:>=13.7.0"
+-    long: "npm:^5.0.0"
+-  checksum: 10c0/220df6c3cf6d2346748639a9b0b688fecc994bff9fee7018a93167e8cd45ab0ee3b4270d9eaa6be33a11adb46514ef9dce7e8217fd578c36726a9e70b96327cd
++    long: "npm:^5.3.2"
++  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
+   languageName: node
+   linkType: hard
+ 
+@@ -33789,12 +33786,12 @@
    linkType: hard
  
  "socks@npm:^2.6.2, socks@npm:^2.8.3":
 -  version: 2.8.3
 -  resolution: "socks@npm:2.8.3"
--  dependencies:
--    ip-address: "npm:^9.0.5"
 +  version: 2.8.9
 +  resolution: "socks@npm:2.8.9"
-+  dependencies:
+   dependencies:
+-    ip-address: "npm:^9.0.5"
 +    ip-address: "npm:^10.1.1"
      smart-buffer: "npm:^4.2.0"
 -  checksum: 10c0/d54a52bf9325165770b674a67241143a3d8b4e4c8884560c4e0e078aace2a728dffc7f70150660f51b85797c4e1a3b82f9b7aa25e0a0ceae1a243365da5c51a7
@@ -134,7 +219,7 @@
    languageName: node
    linkType: hard
  
-@@ -33958,7 +33957,7 @@
+@@ -33958,7 +33955,7 @@
    languageName: node
    linkType: hard
  
@@ -143,7 +228,7 @@
    version: 1.1.3
    resolution: "sprintf-js@npm:1.1.3"
    checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-@@ -35999,9 +35998,9 @@
+@@ -35999,9 +35996,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.24.5":
@@ -156,7 +241,7 @@
    languageName: node
    linkType: hard
  
-@@ -37294,8 +37293,8 @@
+@@ -37294,8 +37291,8 @@
    linkType: hard
  
  "ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
@@ -167,7 +252,7 @@
    peerDependencies:
      bufferutil: ^4.0.1
      utf-8-validate: ">=5.0.2"
-@@ -37304,7 +37303,7 @@
+@@ -37304,7 +37301,7 @@
        optional: true
      utf-8-validate:
        optional: true

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -3,6 +3,7 @@
 # Optional: add notes on any backport row (preserved when you re-run generate).
 
 patch_file: 0-cve-yarn-lock.patch
+repo_ref: 5a0ebed9cfa46b374225321d2678be36006e16ef
 backports:
   - cve_ids:
       - CVE-2026-12143
@@ -12,6 +13,10 @@ backports:
       - CVE-2026-42338
     package: ip-address
     patch_version: 10.2.0
+  - cve_ids:
+      - CVE-2026-45740
+    package: protobufjs
+    patch_version: 7.6.5
   - cve_ids:
       - CVE-2026-12151
       - CVE-2026-6734


### PR DESCRIPTION
It bumps protobufjs to 7.5.8 or higher to fix https://github.com/advisories/GHSA-jggg-4jg4-v7c6
https://redhat.atlassian.net/browse/RHIDP-15197