### PR TITLE
[release-1.9] chore(deps): bump form-data to 4.0.6 in Orchestrator workspace

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -40,20 +40,20 @@
    languageName: node
    linkType: hard
  
-@@ -10140,13 +10139,6 @@
-   version: 1.0.2
-   resolution: "@protobufjs/float@npm:1.0.2"
-   checksum: 5781e1241270b8bd1591d324ca9e3a3128d2f768077a446187a049e36505e91bc4156ed5ac3159c3ce3d2ba3743dbc757b051b2d723eea9cd367bfd54ab29b2f
--  languageName: node
--  linkType: hard
--
+@@ -10143,13 +10142,6 @@
+   languageName: node
+   linkType: hard
+ 
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: ca06f02eaf65ca36fb7498fc3492b7fc087bfcc85c702bac5b86fad34b692bdce4990e0ef444c1e2aea8c034227bd1f0484be02810d5d7e931c55445555646f4
-   languageName: node
-   linkType: hard
- 
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
 @@ -10164,10 +10156,10 @@
    languageName: node
    linkType: hard
@@ -106,7 +106,7 @@
    languageName: node
    linkType: hard
  
-@@ -23352,17 +23344,17 @@
+@@ -23352,30 +23344,30 @@
    languageName: node
    linkType: hard
  
@@ -129,36 +129,54 @@
    languageName: node
    linkType: hard
  
-@@ -24432,6 +24424,15 @@
+ "form-data@npm:^4.0.0, form-data@npm:^4.0.1, form-data@npm:^4.0.4, form-data@npm:^4.0.5":
+-  version: 4.0.5
+-  resolution: "form-data@npm:4.0.5"
++  version: 4.0.6
++  resolution: "form-data@npm:4.0.6"
    dependencies:
-     function-bind: ^1.1.2
-   checksum: e8516f776a15149ca6c6ed2ae3110c417a00b62260e222590e54aa367cbcd6ed99122020b37b7fbdf05748df57b265e70095d7bf35a47660587619b15ffb93db
-+  languageName: node
-+  linkType: hard
-+
+     asynckit: ^0.4.0
+     combined-stream: ^1.0.8
+     es-set-tostringtag: ^2.1.0
+-    hasown: ^2.0.2
+-    mime-types: ^2.1.12
+-  checksum: af8328413c16d0cded5fccc975a44d227c5120fd46a9e81de8acf619d43ed838414cc6d7792195b30b248f76a65246949a129a4dadd148721948f90cd6d4fb69
++    hasown: ^2.0.4
++    mime-types: ^2.1.35
++  checksum: e51b9e97678c250c872cd4ec3e5eaa8fa43bee4b1acf8274c337308aebc6aebb0553091ce0810612826601ffafed9dace12504a63c6ef16c57fffcd7dcfec457
+   languageName: node
+   linkType: hard
+ 
+@@ -24435,6 +24427,15 @@
+   languageName: node
+   linkType: hard
+ 
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: ^1.1.2
 +  checksum: 4bd8f916b629e06324853593ffbdd45e200022952a85ad0c967f3bd4c2e4c7e1f9a9766fbe6186f60bd394e0afc73e719730caa1da15cd9bd832b7cdf53fd26c
-   languageName: node
-   linkType: hard
- 
-@@ -27937,6 +27938,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 885ede7c3de4facccbd2cacc6168bae3a02c3e836159ea4252c87b6e34d40af819824b2d4edce330bfb5c4d6e8ce3ec5864bdcf9473fa1f53a4f8225860e5897
 +  languageName: node
 +  linkType: hard
 +
+ "hast-util-parse-selector@npm:^2.0.0":
+   version: 2.2.5
+   resolution: "hast-util-parse-selector@npm:2.2.5"
+@@ -27940,6 +27941,13 @@
+   languageName: node
+   linkType: hard
+ 
 +"long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: be215816b563f4ca27ad3677678b53415bc489f9e3466414e54d2d85f5f8e86768547fa58493bacfb363ffc57a664debc83403ccc2178aef0c40aca28bad47c9
-   languageName: node
-   linkType: hard
- 
++  languageName: node
++  linkType: hard
++
+ "longest-streak@npm:^3.0.0":
+   version: 3.1.0
+   resolution: "longest-streak@npm:3.1.0"
 @@ -32080,22 +32088,21 @@
    linkType: hard
  

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -19,7 +19,7 @@ backports:
   - cve_ids:
       - CVE-2026-12143
     package: form-data
-    patch_version: 2.3.3, 2.5.6, 4.0.5
+    patch_version: 2.3.3, 2.5.6, 4.0.6
     notes: |-
       [auto] form-data@2.3.3 is still in CVE affected range; verify dev-only
       └─┬ @internal/orchestrator@1.0.0
@@ -29,12 +29,6 @@ backports:
               └─┬ @kubernetes/client-node@0.22.3
                 └─┬ request@2.88.2
                   └── form-data@2.3.3
-      form-data@4.0.5 is still in CVE affected range; verify dev-only
-      └─┬ @internal/orchestrator@1.0.0
-        └─┬ @backstage/cli@0.34.5
-          └─┬ jest-environment-jsdom@29.7.0
-            └─┬ jsdom@20.0.3
-              └── form-data@4.0.5
   - cve_ids:
       - CVE-2026-45740
     package: protobufjs


### PR DESCRIPTION
### Description

Addresses this tree that was still vulnerable, `< 4.0.6` is affected  (missed in the [previous PR](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2740))
* Fixes [RHIDP-14996](https://redhat.atlassian.net/browse/RHIDP-14996)

```
├─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.4.5 
│ └─┬ axios@1.18.0
│   └── form-data@4.0.5
```

After this change:
```
├─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.4.5
│ └─┬ axios@1.18.0
│   └── form-data@4.0.6

```