### PR TITLE
feat(skill): add e2e-failure-analysis and playwright-trace skills

### DIFF
--- a/.claude/skills/e2e-failure-analysis
+++ b/.claude/skills/e2e-failure-analysis
@@ -1,0 +1,1 @@
+../../.fullsend/skills/e2e-failure-analysis

--- a/.claude/skills/playwright-trace
+++ b/.claude/skills/playwright-trace
@@ -1,0 +1,1 @@
+../../.fullsend/skills/playwright-trace

--- a/.fullsend/skills/e2e-failure-analysis/SKILL.md
+++ b/.fullsend/skills/e2e-failure-analysis/SKILL.md
@@ -146,59 +146,85 @@ the `secrets` parameter, causing it to fall back to the default path.
 
 ### Step 4: Trace Analysis
 
-**Use traces for UI interaction failures** — when the page loaded but an action failed
-(click, navigation, element interaction). **Skip traces ONLY when:**
-- Step 1 already revealed config/deployment warnings (missing YAML, missing config sections)
-- The failure is clearly a config issue (missing integration, wrong secret path)
+**MANDATORY for every UI test failure.** You MUST inspect the trace for each failed test
+that involves browser interaction (Playwright assertions, timeouts, element waits) before
+drawing any conclusions about root cause.
 
-In those cases, the root cause is in the deployment config, not the browser interaction.
-Traces add no value — go straight to Step 3 (config comparison) or Step 5 (cluster logs).
+Screenshots and error-context show the *end state* — what the page looked like when the
+test failed. Traces show the *timeline* — what happened between navigation and failure.
+You cannot distinguish a timing flake from a real bug without the timeline. Specific
+things only traces reveal:
+- Background async operations (popup listeners, event waiters) running concurrently
+  with test actions — these can interfere with or mask the actual failure
+- The exact duration of each step in the action chain — pinpoints which step is slow
+  vs which step actually fails
+- Network request timing relative to UI actions — shows whether data arrived but
+  rendering was slow, or data never arrived
+- Console errors that fire during the test (not just at page load)
 
-**When traces ARE valuable:**
-- Login failures, click/navigation issues, popup handling problems
-- Element interaction timeouts where the page state is ambiguous, flaky timing issues
-- **Element not found / timeout when the page loaded correctly** — use
-  `trace snapshot <action-id>` to get the accessibility tree and discover what IS on the
-  page (search fields, filters, pagination controls, alternative elements) that could
-  inform the fix. Don't just diagnose why the element is missing — look for what the test
-  COULD use instead.
+**Skip traces ONLY when ALL of these are true:**
+- The failure is a setup/beforeAll error with no browser involvement (exit code from a
+  shell script, deployment failure, pod crash)
+- No trace.zip file exists in the test's artifact directory
+- Step 1 revealed config/deployment warnings that fully explain the failure AND the
+  error-context confirms the page never loaded (blank page, error page, config error)
+
+**If in doubt, open the trace.** A 30-second `trace actions` check is cheaper than a
+wrong classification.
 
 #### Finding traces
-
-Traces live in `e2e-test-results/specs-<slug>/trace.zip`:
 
 ```bash
 find "$ARTIFACTS/e2e-test-results" -name "trace.zip" | sort
 ```
 
-#### Using traces
+#### Invoking the playwright-trace skill
 
-Use `npx playwright trace` — the official Playwright CLI for trace inspection. See the
-**playwright-trace** skill for full command reference. Quick workflow:
+**You MUST invoke `/playwright-trace` before running any trace commands.** The skill
+provides the complete command reference for `npx playwright trace` — all subcommands,
+flags, filters, and workflows. Do not rely on memory for trace CLI usage.
 
-```bash
-# 1. Open trace and see metadata
-npx playwright trace open <path/to/trace.zip>
+#### Minimum trace inspection for every UI failure
 
-# 2. List all actions — find the failed ones
-npx playwright trace actions --errors-only
+After invoking the skill and opening a trace, do at minimum:
 
-# 3. Drill into the failed action
-npx playwright trace action <action-id>
+1. `trace actions` — the **full** action list, not just `--errors-only`. Background
+   operations that succeed but take a long time (like a 15s popup listener) won't
+   show up in errors-only but are critical for understanding the failure timeline.
+2. `trace action <id>` — for each failed action and any action with a suspiciously
+   long duration
+3. `trace console --errors-only` — browser errors during the test
+4. `trace requests --failed` — failed network requests
 
-# 4. Inspect DOM at that action
-npx playwright trace snapshot <action-id>
+Then go deeper based on what you find (snapshots, request details, filtered requests).
+The playwright-trace skill documents all available commands.
 
-# 5. Query DOM for specific elements
-npx playwright trace snapshot <action-id> -- eval "document.querySelector('.error-message').textContent"
+#### What to look for in traces
 
-# 6. Check for console errors and failed network requests
-npx playwright trace console --errors-only
-npx playwright trace requests --failed
+1. **The full action timeline** — not just errors. Look for:
+   - Actions with unexpectedly long durations (> 5s for simple operations)
+   - Background operations running in parallel with the main test flow
+   - Gaps in the timeline where nothing happens (rendering delays, polling)
 
-# 7. Close when done
-npx playwright trace close
-```
+2. **Concurrent async operations** — `waitForEvent`, popup listeners, parallel
+   promises. These appear as overlapping actions in the timeline. If a background
+   operation times out during your main test action, it can disrupt the test even
+   if the main action would otherwise succeed.
+
+3. **Network timing vs UI timing** — compare when API responses arrive (fulfill
+   requests, 200s) against when UI elements appear (expect toBeVisible resolves).
+   A large gap between "data available" and "UI renders" indicates browser CPU
+   saturation or widget rendering delays, not network issues.
+
+4. **Retry accumulation** — check the trace metadata for page count and total
+   requests. Multiple pages (e.g., Pages: 11) means the test was retried many
+   times. Each retry loads a new page with hundreds of requests, degrading browser
+   performance. The last attempt may fail purely from accumulated browser load.
+
+5. **Element not found / timeout when the page loaded correctly** — use
+   `trace snapshot <action-id>` to get the accessibility tree and discover what IS
+   on the page that could inform the fix. Don't just diagnose why the element is
+   missing — look for what the test COULD use instead.
 
 ### Step 5: Cluster Log Search
 

--- a/.fullsend/skills/e2e-failure-analysis/SKILL.md
+++ b/.fullsend/skills/e2e-failure-analysis/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: e2e-failure-analysis
+description: "Debug and analyze E2E test failures when the user shares a gcsweb URL or asks to investigate a PR check / e2e-ocp-helm failure."
+---
+
+# E2E Failure Analysis
+
+Debug test failures in the rhdh-plugin-export-overlays E2E testing system.
+
+## CRITICAL: Context Management Rules
+
+**Always check file size (`wc -l`) before reading any log file.**
+
+- **Small files (under ~200 lines)**: read in full — complete context beats targeted grep.
+- **Large files (200+ lines)**: grep for error patterns first, note line numbers, then
+  read narrow ranges around them. Never read a large file in full.
+  - **grep + tail** — `grep -i "error\|fail\|crash" file.log | tail -30`
+  - **tail** — `tail -50 file.log` for most-recent entries
+  - **Read with offset+limit** — `Read(file, offset=N, limit=50)` for targeted sections
+  - **grep -n** — find line numbers first, then read narrow ranges
+
+Files like backstage-backend.log and build-log.txt can be 5,000–50,000+ lines.
+Auxiliary pod logs are often under 200 lines and safe to read entirely.
+
+## Investigation Workflow
+
+### Step 0: Download Artifacts
+
+```bash
+SKILL_DIR="${SKILL_DIR:-.claude/skills/e2e-failure-analysis}"
+ARTIFACTS=$(python3 "$SKILL_DIR/scripts/download-artifacts.py" "<PROW_OR_GCSWEB_URL>")
+```
+
+The script parses both PR check and nightly (periodic) prow/gcsweb URLs, downloads
+artifacts via the public GCS JSON API (no gcloud dependency), caches them locally,
+and prints the `ARTIFACTS` path. Subsequent runs with the same URL skip the download
+(cache is validated for completeness, not just directory existence).
+
+### Step 1: Diagnostic Summary
+
+Run the diagnostics script from the skill's scripts directory:
+
+```bash
+SKILL_DIR="${SKILL_DIR:-.claude/skills/e2e-failure-analysis}"
+python3 "$SKILL_DIR/scripts/diagnostics.py" "$ARTIFACTS"
+
+# Filter to a specific project:
+python3 "$SKILL_DIR/scripts/diagnostics.py" "$ARTIFACTS" --project techdocs
+```
+
+This script gives you:
+- All failed tests with error messages
+- Config table dumps (App Config, Dynamic Plugins, deployment config)
+- Deployment warnings auto-filtered (missing YAML files, errors, CrashLoopBackOff, etc.)
+
+**Key warnings to watch for in the output:**
+- `YAML file ... does not exist` — Missing config/secrets file (wrong path or missing `secrets:` in configure())
+- Config dump missing expected sections (e.g., no `integrations:`) — config file not loaded
+- `CrashLoopBackOff` / `ImagePullBackOff` — pod-level failures
+- Failed helm install or pod readiness timeout
+
+**Classify each failure before proceeding:**
+- **UI failure** (Playwright assertions) → proceed to Step 2
+- **Setup/beforeAll failure** (CLI commands, deployment errors) → skip to **Step 5, build-log.txt**
+
+Setup failures have no useful page snapshots, screenshots, or traces. **Go to
+build-log.txt first** — it captures the full stdout/stderr of every deployment script
+and CLI command, so it shows *why* the setup failed. Cluster logs only show the
+resulting state (what was or wasn't running). The cause is almost always in the build
+log, not the cluster logs.
+
+### Step 2: Read error-context.md for Failed Tests
+
+**This is the PRIMARY artifact for understanding UI failures.** Each failed test has an
+auto-generated `error-context.md` containing:
+- Test source code with the failing line marked
+- Full error message and call log
+- YAML page snapshot showing exactly what was on screen at failure time
+
+```bash
+# Find all error-context files for failed tests
+find "$ARTIFACTS/e2e-test-results" -name "error-context.md" | sort
+```
+
+**IMPORTANT: Read ONE error-context first, then deduplicate.** Page snapshots can be very large
+(500-1000+ lines for content-heavy pages like TechDocs). Before reading a second error-context:
+- Check if it's from the same project and spec file as one you already read
+- Check if the error message is the same (visible from Step 1 output)
+- If both match, **skip it** — the root cause is the same
+
+Read the first error-context.md. The page snapshot tells you immediately:
+- Is the page loaded? Or is it a blank/error page?
+- Is the expected element missing, or is it present with different text?
+- Did login succeed? (Check for user button vs login form)
+- Are sidebar items visible? (Plugin loaded vs not)
+
+#### ALWAYS view screenshots for UI failures
+
+Each failed test also saves a screenshot (`test-failed-1.png`) captured at the moment of
+failure. **Always read screenshots for every UI test failure** — don't skip them. They are
+small files (5-130KB) and give instant visual context that page snapshots can miss.
+
+```bash
+# Find screenshots for failed tests
+find "$ARTIFACTS/e2e-test-results" -name "test-failed-*.png" | sort
+```
+
+Read each screenshot file with the Read tool to see exactly what the browser showed.
+Screenshots reveal things the YAML page snapshot may not:
+- Visual layout, styling, or overlay positioning
+- Popups, modals, or dropdowns that the YAML snapshot doesn't capture well
+- UI controls (search fields, filters, pagination) that inform fix suggestions
+- Loading states, spinners, or partially rendered content
+- The overall page context at a glance vs parsing hundreds of YAML lines
+
+**Do this alongside reading error-context.md, not as a fallback.**
+
+### Step 3: Compare Expected vs Deployed Config
+
+**When Step 1 shows config warnings** (missing YAML files, missing config sections), compare
+what the workspace's config files define against what was actually deployed:
+
+```bash
+# Read the workspace's config files to see what SHOULD be deployed
+cat workspaces/<WORKSPACE>/e2e-tests/tests/config/<SUBDIR>/app-config-rhdh.yaml 2>/dev/null
+cat workspaces/<WORKSPACE>/e2e-tests/tests/config/<SUBDIR>/rhdh-secrets.yaml 2>/dev/null
+
+# Compare against the App Config dump from Step 1 output
+# Look for sections present in the file but missing from the dump
+```
+
+Common mismatches:
+- **Missing `integrations:` section** — secrets file not loaded, so token env vars unavailable
+- **Missing `catalog.providers:` section** — app-config file path wrong in configure()
+- **Secret path mismatch** — configure() uses default `tests/config/rhdh-secrets.yaml` but
+  the file is in a subdirectory like `tests/config/techdocs/rhdh-secrets.yaml`
+
+**Check the configure() call in the spec file:**
+```bash
+grep -A10 'rhdh.configure' workspaces/<WORKSPACE>/e2e-tests/tests/specs/<SPEC>.spec.ts
+```
+
+Verify that `appConfig`, `dynamicPlugins`, AND `secrets` all point to the correct paths.
+A common bug is specifying `appConfig` and `dynamicPlugins` with a subdirectory but forgetting
+the `secrets` parameter, causing it to fall back to the default path.
+
+### Step 4: Trace Analysis
+
+**Use traces for UI interaction failures** — when the page loaded but an action failed
+(click, navigation, element interaction). **Skip traces ONLY when:**
+- Step 1 already revealed config/deployment warnings (missing YAML, missing config sections)
+- The failure is clearly a config issue (missing integration, wrong secret path)
+
+In those cases, the root cause is in the deployment config, not the browser interaction.
+Traces add no value — go straight to Step 3 (config comparison) or Step 5 (cluster logs).
+
+**When traces ARE valuable:**
+- Login failures, click/navigation issues, popup handling problems
+- Element interaction timeouts where the page state is ambiguous, flaky timing issues
+- **Element not found / timeout when the page loaded correctly** — use
+  `trace snapshot <action-id>` to get the accessibility tree and discover what IS on the
+  page (search fields, filters, pagination controls, alternative elements) that could
+  inform the fix. Don't just diagnose why the element is missing — look for what the test
+  COULD use instead.
+
+#### Finding traces
+
+Traces live in `e2e-test-results/specs-<slug>/trace.zip`:
+
+```bash
+find "$ARTIFACTS/e2e-test-results" -name "trace.zip" | sort
+```
+
+#### Using traces
+
+Use `npx playwright trace` — the official Playwright CLI for trace inspection. See the
+**playwright-trace** skill for full command reference. Quick workflow:
+
+```bash
+# 1. Open trace and see metadata
+npx playwright trace open <path/to/trace.zip>
+
+# 2. List all actions — find the failed ones
+npx playwright trace actions --errors-only
+
+# 3. Drill into the failed action
+npx playwright trace action <action-id>
+
+# 4. Inspect DOM at that action
+npx playwright trace snapshot <action-id>
+
+# 5. Query DOM for specific elements
+npx playwright trace snapshot <action-id> -- eval "document.querySelector('.error-message').textContent"
+
+# 6. Check for console errors and failed network requests
+npx playwright trace console --errors-only
+npx playwright trace requests --failed
+
+# 7. Close when done
+npx playwright trace close
+```
+
+### Step 5: Cluster Log Search
+
+Check cluster logs **alongside** other steps, not only as a last resort. UI failures
+often originate from backend issues (plugin load failures, missing config, crashed pods)
+that only show up in cluster logs.
+
+Logs are at `$ARTIFACTS/e2e-test-results/logs/<project>/`. Start with `pods.txt` to see
+what's running, then investigate relevant pod logs.
+
+#### What to check and what it tells you
+
+- **`pods.txt`** — pod status, restarts, readiness. Always safe to read in full.
+- **`events.txt`** — K8s events: ImagePullBackOff, CrashLoopBackOff, probe failures.
+  Most recent events are at the bottom.
+- **`backstage-backend.log`** — RHDH startup errors, plugin failures, config issues.
+  Almost always a large file — grep first. Filter out `node_modules` and `trace_id` noise.
+- **`install-dynamic-plugins.log`** — plugin installation: OCI pull failures, version
+  mismatches, disabled wrappers. Usually medium-sized.
+- **Pod restarts** — if `RESTARTS` is non-zero in `pods.txt`, check the `.previous.log`
+  for that pod. Work that started in the killed instance but never completed explains
+  what's missing in the current pod.
+
+**When to check early (alongside Steps 1-2):**
+- UI test timed out waiting for a plugin element → plugin install log
+- Page shows error/blank state → backstage-backend log
+- Pod never became ready → events.txt
+
+#### Auxiliary pod logs
+
+Namespaces often contain pods beyond RHDH (workflow engines, databases, mock services).
+When RHDH pod logs don't explain the failure, scan all other pod logs in the namespace
+for errors. Check `pods.txt` to see what's running, then grep their logs the same way
+you would for RHDH pods.
+
+**When to check:**
+- RHDH logs are clean but the test expects data from an external service
+- Test interacts with a service deployed by the workspace (workflows, APIs)
+- The error message references a non-RHDH service endpoint or component
+
+#### build-log.txt
+
+The build log contains the full CI output — deployment sequences, config dumps, and
+the complete stdout/stderr of every CLI command run during setup. It is a single file
+covering all projects, so one grep pass can surface context for multiple failures.
+
+**For setup/beforeAll failures, start here — before cluster logs.** The build log shows
+*why* something failed. Cluster logs only show the resulting state.
+
+Location: `$(dirname "$ARTIFACTS")/build-log.txt`
+
+The build log covers all projects in one file. Filter by project name to avoid noise
+from other projects. Also check env vars (`GIT_PR_NUMBER`, `E2E_NIGHTLY_MODE`) to
+determine the deployment mode — it affects how plugins are resolved.
+
+## Architecture Reference
+
+### e2e-test-utils
+
+All E2E tests use `@red-hat-developer-hub/e2e-test-utils` — a shared package that provides
+fixtures (`rhdh`, `uiHelper`, `loginHelper`), RHDH deployment logic, K8s helpers, and
+Playwright configuration. When debugging unexpected deployment behavior, config merging,
+or fixture internals, consult the source and docs:
+- **Repo**: https://github.com/redhat-developer/rhdh-e2e-test-utils
+- **Docs**: https://github.com/redhat-developer/rhdh-e2e-test-utils/tree/main/docs
+
+To check which version a failing run used:
+```bash
+grep -i "e2e-test-utils" "$BUILD_LOG" | head -5
+```
+
+### Project = Namespace = RHDH Deployment
+
+Each Playwright project creates a separate K8s namespace. Project name = namespace name.
+The project name tells you which log directory to check.
+
+### Deployment Modes
+
+| Mode | Detection | Plugins | Config Injection |
+|------|-----------|---------|-----------------|
+| PR check | `GIT_PR_NUMBER` set | OCI `pr_{N}__{version}` | Yes — metadata appConfigExamples |
+| Nightly | `E2E_NIGHTLY_MODE=true` | Released OCI refs | No |
+| Local | Neither | Local paths | Yes |
+
+### Deployment Flow (rhdh.deploy())
+
+```
+1. Config Merge: Package defaults → Auth config → Workspace overrides (deep merge)
+2. Secrets: envsubst on rhdh-secrets.yaml only ($VAR → value)
+3. Dynamic Plugins: auto-generate from metadata or use explicit file; resolve OCI URLs
+4. Helm Install: helm upgrade -i
+5. Readiness: Pod Ready + HTTP health check → sets RHDH_BASE_URL
+```
+
+### Secret Flow
+
+```
+CI env ($VAULT_TOKEN=abc) → rhdh-secrets.yaml (TOKEN: $VAULT_TOKEN) → app-config (token: ${TOKEN})
+                                ↓ envsubst                                ↓ K8s Secret reference
+                            TOKEN: abc                                token: abc (runtime)
+```
+
+## Common Failure Patterns
+
+### Plugin Not Loading
+**Grep for**: `grep -i "error\|fail" install-dynamic-plugins.log | tail -20`
+**Causes**: OCI not published (`/publish` not run), version mismatch, wrapper not disabled
+
+### Deployment Failure (CrashLoopBackOff)
+**Grep for**: `tail -50 events.txt` + `grep -i "error\|crash" backstage-backend.log | tail -20`
+**Causes**: Bad plugin config, missing env var, image pull failure
+
+### Login Failure
+**Check**: error-context.md page snapshot — is it login page or error?
+**Causes**: Keycloak not deployed, wrong secret, RHDH not ready
+
+### Timeout Waiting for Element
+**Check**: error-context.md → screenshot → `trace snapshot <action-id>` → adjacent tests in spec file
+**Causes**: Data not loaded, backend failing, wrong selector, element not on visible page
+**Before suggesting a fix**: `grep -A5 '<element text>' <spec-file>` — check if sibling
+tests already handle this element.
+
+### Config/Secret Mismatch
+**Detected in Step 1**: `YAML file ... does not exist` warning or missing config sections in dump
+**Causes**: Inconsistent paths in `rhdh.configure()` — one param points to a subdirectory
+while another falls back to the default path, or secrets file not loaded at all
+**Fix pattern**: Verify `appConfig`, `dynamicPlugins`, and `secrets` all use consistent paths
+
+### Worker Restart Lost State
+**Symptom**: Retry fails differently than first attempt
+**Check**: Was env var set inside runOnce? It's lost on worker restart.
+
+## Artifact Directory Structure
+
+```
+artifacts/
+├── playwright-report/
+│   ├── results.json             # Test results with stdout/stderr + trace attachment mappings
+│   └── data/                    # Hash-named trace/screenshot data (same content as e2e-test-results)
+│       └── <sha1-hash>.zip      # Trace files
+├── e2e-test-results/
+│   ├── logs/<project>/          # Per-namespace cluster diagnostics
+│   │   ├── events.txt
+│   │   ├── pods.txt
+│   │   └── pods/<pod>/              # One directory per pod in the namespace
+│   │       ├── backstage-backend.log
+│   │       ├── install-dynamic-plugins.log
+│   │       └── ...                  # Other pods: workflow engines, databases, services
+│   └── specs-<slug>-<project>/  # Per-test failure artifacts
+│       ├── error-context.md     # Page snapshot (START HERE)
+│       ├── trace.zip            # Playwright trace
+│       ├── test-failed-1.png    # Screenshot
+│       └── video.webm           # Recording
+```
+
+**Trace locations:** Both `e2e-test-results/specs-*/trace.zip` and `playwright-report/data/*.zip`
+contain traces. The `e2e-test-results` traces are named by test slug (easier to identify).
+Use `find "$ARTIFACTS/e2e-test-results" -name "trace.zip"` to locate them.
+
+## Discovery Commands
+
+```bash
+# Workspaces with e2e tests
+ls -d workspaces/*/e2e-tests 2>/dev/null | cut -d'/' -f2
+
+# What config a project uses
+grep -A10 'rhdh.configure' workspaces/<name>/e2e-tests/tests/specs/*.spec.ts
+
+# What secrets a workspace needs
+cat workspaces/<name>/e2e-tests/.env.sample 2>/dev/null
+```
+
+## When the structured steps don't resolve the RCA
+
+If after following the steps above you still don't have a clear root cause — or your
+conclusion feels uncertain — set aside the hypothesis you've formed and reason freely.
+
+Keep the context of what you've already looked at: it tells you what's been ruled out
+and where the answer isn't. What you discard is the conclusion drawn from those steps,
+not the investigation history.
+
+1. **Ask: did the operation succeed but produce wrong results?** If logs are clean and
+   all inputs were accepted, don't assume "slow." The operation may have completed
+   and produced the wrong outcome. Read the test helpers and the code that processes
+   the trigger to understand what it actually did with the input.
+2. **Re-read only the original error message** from Step 1.
+3. **Reason from the error outward**: what has to be true for this error to occur? Work
+   forward from the error itself, not backward from what the steps led you to look at.
+4. **Use what you've already seen to eliminate paths** — if you've checked cluster logs
+   and they were clean, the cause is upstream of runtime. If error-context showed the
+   page loaded fine, the issue isn't deployment. Let ruled-out evidence narrow the space.
+5. **Identify what you haven't checked yet** that could still explain the error, and go
+   there directly.
+6. **Confirm with one cross-check** before concluding — a single additional artifact that
+   either supports or contradicts the new hypothesis.

--- a/.fullsend/skills/e2e-failure-analysis/scripts/diagnostics.py
+++ b/.fullsend/skills/e2e-failure-analysis/scripts/diagnostics.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Extract test results, deployment warnings, and config dumps from results.json.
+
+Usage:
+    python3 diagnostics.py <ARTIFACTS_DIR> [--project <name>]
+
+Arguments:
+    ARTIFACTS_DIR   Path to the artifacts directory containing playwright-report/results.json
+    --project       Filter output to a specific Playwright project name (case-insensitive substring match)
+
+Output sections:
+    1. TEST RESULTS — pass/fail/skip counts and failed test details
+    2. DIAGNOSTICS PER FAILED PROJECT — config table dumps and filtered warnings/errors
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def walk_suites(suite, specs=None):
+    if specs is None:
+        specs = []
+    for spec in suite.get("specs", []):
+        specs.append(spec)
+    for child in suite.get("suites", []):
+        walk_suites(child, specs)
+    return specs
+
+
+WARNING_PATTERNS = re.compile(
+    r"YAML file.*does not exist|"
+    r"error|Error|ERROR|"
+    r"WARN|warn|Warning|"
+    r"does not exist|not found|"
+    r"missing|Missing|"
+    r"failed|Failed|FAILED|"
+    r"CrashLoopBackOff|ImagePullBackOff|"
+    r"secret.*not|Secret.*not",
+    re.IGNORECASE,
+)
+NOISE = re.compile(r"node_modules|trace_id|Download|Extracting|integrity checksum")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <ARTIFACTS_DIR> [--project <name>]", file=sys.stderr)
+        sys.exit(1)
+
+    artifacts = Path(sys.argv[1])
+    project_filter = None
+    if "--project" in sys.argv:
+        idx = sys.argv.index("--project")
+        if idx + 1 < len(sys.argv):
+            project_filter = sys.argv[idx + 1].lower()
+
+    results_file = artifacts / "playwright-report" / "results.json"
+    if not results_file.exists():
+        print(f"ERROR: {results_file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    r = json.loads(results_file.read_text())
+    stats = r.get("stats", {})
+    all_specs = []
+    for s in r.get("suites", []):
+        walk_suites(s, all_specs)
+
+    # Section 1: Test Results
+    print("=" * 70)
+    print("TEST RESULTS")
+    print("=" * 70)
+    print(
+        f"Passed: {stats.get('expected', 0)}  "
+        f"Failed: {stats.get('unexpected', 0)}  "
+        f"Skipped: {stats.get('skipped', 0)}  "
+        f"Flaky: {stats.get('flaky', 0)}"
+    )
+    print()
+
+    failed_projects = set()
+    for spec in all_specs:
+        for test in spec.get("tests", []):
+            proj = test.get("projectName", "?")
+            if project_filter and project_filter not in proj.lower():
+                continue
+            for result in test.get("results", []):
+                status = result["status"]
+                if status not in ("passed", "skipped"):
+                    failed_projects.add(proj)
+                    err = result.get("error", {}).get("message", "no error")
+                    print(f"FAILED [{proj}] {spec['title']}")
+                    print(f"  {err[:400]}")
+                    print()
+                elif project_filter:
+                    print(f"{status.upper()} [{proj}] {spec['title']}")
+
+    # Section 2: Diagnostics per failed project
+    for proj in sorted(failed_projects):
+        print("=" * 70)
+        print(f"DIAGNOSTICS FOR PROJECT: {proj}")
+        print("=" * 70)
+        for spec in all_specs:
+            for test in spec.get("tests", []):
+                if test.get("projectName") != proj:
+                    continue
+                for result in test.get("results", []):
+                    stdout = "".join(
+                        s.get("text", "") for s in result.get("stdout", [])
+                    )
+                    if not stdout:
+                        continue
+
+                    title = spec["title"][:50]
+
+                    # Config tables
+                    for match in re.finditer(
+                        r"(┌─[^\n]*(?:Config|Plugins|Deployment|Value|Backstage)[^\n]*\n)(.*?)(└─+)",
+                        stdout,
+                        re.DOTALL,
+                    ):
+                        header = match.group(1).strip()
+                        body = match.group(2)
+                        if len(body) < 5000:
+                            print(f"--- {header} [{title}] ---")
+                            print(body.rstrip())
+                            print()
+
+                    # Warnings and errors
+                    warnings = []
+                    for line in stdout.split("\n"):
+                        if WARNING_PATTERNS.search(line) and not NOISE.search(line):
+                            warnings.append(line.rstrip())
+                    if warnings:
+                        print(f"--- Warnings/Errors [{title}] ---")
+                        for w in warnings[-40:]:
+                            print(w)
+                        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.fullsend/skills/e2e-failure-analysis/scripts/download-artifacts.py
+++ b/.fullsend/skills/e2e-failure-analysis/scripts/download-artifacts.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Download E2E test artifacts from a prow/gcsweb URL via the public GCS JSON API."""
+
+import gzip
+import json
+import os
+import re
+import shutil
+import ssl
+import sys
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib.parse import urlparse
+
+BUCKET = "test-platform-results"
+API_URL = f"https://storage.googleapis.com/storage/v1/b/{BUCKET}/o"
+DL_URL = f"https://storage.googleapis.com/{BUCKET}"
+MAX_WORKERS = 8
+
+EXCLUDE_RE = re.compile(r"\.webm$|/playwright-report/data/|/playwright-report/trace/")
+INCLUDE_RE = re.compile(r"/e2e-test-results/.*/trace\.zip$")
+
+
+def _ssl_ctx():
+    for ca in (os.environ.get("SSL_CERT_FILE"), os.environ.get("REQUESTS_CA_BUNDLE"),
+               "/etc/openshell-tls/ca-bundle.pem", "/etc/ssl/certs/ca-certificates.crt"):
+        if ca and Path(ca).is_file():
+            return ssl.create_default_context(cafile=ca)
+    return ssl.create_default_context()
+
+
+CTX = _ssl_ctx()
+
+
+def parse_url(url):
+    path = urlparse(url.rstrip("/")).path
+    for pfx in ("/view/gs/", "/gcs/"):
+        if path.startswith(pfx):
+            path = path[len(pfx):]
+            break
+    parts = path.split("/")
+
+    if "pr-logs" in parts:
+        i = parts.index("pull") + 1
+        pr, job, jid = parts[i + 1], parts[i + 2], parts[i + 3]
+        sub = job.split("-main-")[-1] if "-main-" in job else "e2e-ocp-helm"
+        return {"type": "pr", "pr": pr, "job_id": jid, "subdir": sub,
+                "gcs": f"pr-logs/pull/redhat-developer_rhdh-plugin-export-overlays/{pr}/{job}/{jid}"}
+
+    if "/logs/" in "/" + "/".join(parts):
+        i = parts.index("logs")
+        job, jid = parts[i + 1], parts[i + 2]
+        sub = job.split("-main-")[-1] if "-main-" in job else "e2e-ocp-helm-nightly"
+        return {"type": "nightly", "job_id": jid, "subdir": sub,
+                "gcs": f"logs/{job}/{jid}"}
+
+    return None
+
+
+def gcs_list(prefix):
+    items, token = [], None
+    while True:
+        p = {"prefix": prefix, "maxResults": "1000"}
+        if token:
+            p["pageToken"] = token
+        with urllib.request.urlopen(f"{API_URL}?{urllib.parse.urlencode(p)}", context=CTX) as r:
+            data = json.loads(r.read())
+        items.extend(data.get("items", []))
+        token = data.get("nextPageToken")
+        if not token:
+            return items
+
+
+def download(gcs_prefix, dest):
+    dest.mkdir(parents=True, exist_ok=True)
+
+    print("Listing objects...", file=sys.stderr)
+    all_items = gcs_list(gcs_prefix + "/")
+    keep = [i for i in all_items if INCLUDE_RE.search(i["name"]) or not EXCLUDE_RE.search(i["name"])]
+    total_mb = sum(int(i.get("size", 0)) for i in keep) / 1024 / 1024
+    print(f"Downloading {len(keep)}/{len(all_items)} files ({total_mb:.1f} MB)...", file=sys.stderr)
+
+    plen = len(gcs_prefix) + 1
+
+    def _dl(item):
+        rel = item["name"][plen:]
+        local = dest / rel
+        local.parent.mkdir(parents=True, exist_ok=True)
+        urllib.request.urlretrieve(f"{DL_URL}/{urllib.parse.quote(item['name'], safe='/')}", str(local))
+
+    failed = 0
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futs = {pool.submit(_dl, i): i for i in keep}
+        for f in as_completed(futs):
+            try:
+                f.result()
+            except Exception as e:
+                failed += 1
+                print(f"  FAILED: {futs[f]['name'].split('/')[-1]}: {e}", file=sys.stderr)
+
+    print(f"Done: {len(keep) - failed}/{len(keep)} files.", file=sys.stderr)
+
+    # Decompress gzipped text files (GCS serves them with raw gzip encoding)
+    for path in dest.rglob("*"):
+        if not path.is_file() or path.suffix in (".zip", ".gz", ".png", ".webm"):
+            continue
+        with open(path, "rb") as f:
+            if f.read(2) != b"\x1f\x8b":
+                continue
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with gzip.open(path, "rb") as fi, open(tmp, "wb") as fo:
+            shutil.copyfileobj(fi, fo)
+        tmp.replace(path)
+
+
+def is_cache_valid(artifacts_dir):
+    if not artifacts_dir.exists():
+        return False
+    has = lambda g: any(artifacts_dir.rglob(g))
+    return sum([has("logs/*/pods.txt"), has("results.json"), has("error-context.md")]) >= 2
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 download-artifacts.py <PROW_URL>", file=sys.stderr)
+        sys.exit(1)
+
+    info = parse_url(sys.argv[1])
+    if not info:
+        print(f"ERROR: Could not parse URL: {sys.argv[1]}", file=sys.stderr)
+        sys.exit(1)
+
+    base = Path("node_modules/.cache/e2e-artifacts")
+    cache_dir = base / info.get("pr", "nightly") / info["job_id"]
+    container = "redhat-developer-rhdh-plugin-export-overlays-ocp-helm"
+    artifacts_dir = cache_dir / container / "artifacts"
+
+    if is_cache_valid(artifacts_dir):
+        print("Artifacts already downloaded, using cache.", file=sys.stderr)
+        print(artifacts_dir)
+        return
+
+    if cache_dir.exists():
+        print("Cache incomplete, re-downloading...", file=sys.stderr)
+        shutil.rmtree(cache_dir)
+
+    gcs_src = f"{info['gcs']}/artifacts/{info['subdir']}/{container}"
+    download(gcs_src, cache_dir / container)
+
+    if not artifacts_dir.exists():
+        print(f"ERROR: Artifacts dir not found: {artifacts_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Download complete.", file=sys.stderr)
+    print(artifacts_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/.fullsend/skills/playwright-trace/SKILL.md
+++ b/.fullsend/skills/playwright-trace/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: playwright-trace
+description: Inspect Playwright trace files from the command line — list actions, view requests, console, errors, snapshots and screenshots.
+allowed-tools: Bash(npx:*)
+---
+
+# Playwright Trace CLI
+
+Inspect `.zip` trace files produced by Playwright tests without opening a browser.
+
+## Workflow
+
+1. Start with `trace open <trace.zip>` to extract the trace and see its metadata.
+2. Use `trace actions` to see all actions with their action IDs.
+3. Use `trace action <action-id>` to drill into a specific action — see parameters, logs, source location, and available snapshots.
+4. Use `trace requests`, `trace console`, or `trace errors` for cross-cutting views.
+5. Use `trace snapshot <action-id>` to get the DOM snapshot, or run a browser command against it.
+6. Use `trace close` to remove the extracted trace data when done.
+
+All commands after `open` operate on the currently opened trace — no need to pass the trace file again. Opening a new trace replaces the previous one.
+
+## Commands
+
+### Open a trace
+
+```bash
+# Extract trace and show metadata: browser, viewport, duration, action/error counts
+npx playwright trace open <trace.zip>
+```
+
+### Close a trace
+
+```bash
+# Remove extracted trace data
+npx playwright trace close
+```
+
+### Actions
+
+```bash
+# List all actions as a tree with action IDs and timing
+npx playwright trace actions
+
+# Filter by action title (regex, case-insensitive)
+npx playwright trace actions --grep "click"
+
+# Only failed actions
+npx playwright trace actions --errors-only
+```
+
+### Action details
+
+```bash
+# Show full details for one action: params, result, logs, source, snapshots
+npx playwright trace action <action-id>
+```
+
+The `action` command displays available snapshot phases (before, input, after) and the exact command to extract them.
+
+### Requests
+
+```bash
+# All network requests: method, status, URL, duration, size
+npx playwright trace requests
+
+# Filter by URL pattern
+npx playwright trace requests --grep "api"
+
+# Filter by HTTP method
+npx playwright trace requests --method POST
+
+# Only failed requests (status >= 400)
+npx playwright trace requests --failed
+```
+
+### Request details
+
+```bash
+# Show full details for one request: headers, body, security
+npx playwright trace request <request-id>
+```
+
+### Console
+
+```bash
+# All console messages and stdout/stderr
+npx playwright trace console
+
+# Only errors
+npx playwright trace console --errors-only
+
+# Only browser console (no stdout/stderr)
+npx playwright trace console --browser
+
+# Only stdout/stderr (no browser console)
+npx playwright trace console --stdio
+```
+
+### Errors
+
+```bash
+# All errors with stack traces and associated actions
+npx playwright trace errors
+```
+
+### Snapshots
+
+The `snapshot` command loads the DOM snapshot for an action into a headless browser and runs a single browser command against it. Without a browser command, it returns the accessibility snapshot.
+
+```bash
+# Get the accessibility snapshot (default)
+npx playwright trace snapshot <action-id>
+
+# Use a specific phase
+npx playwright trace snapshot <action-id> --name before
+
+# Run eval to query the DOM
+npx playwright trace snapshot <action-id> -- eval "document.title"
+npx playwright trace snapshot <action-id> -- eval "document.querySelector('#error').textContent"
+
+# Eval on a specific element ref (from the snapshot)
+npx playwright trace snapshot <action-id> -- eval "el => el.getAttribute('data-testid')" e5
+
+# Take a screenshot of the snapshot
+npx playwright trace snapshot <action-id> -- screenshot
+
+# Redirect output to a file
+npx playwright trace snapshot <action-id> -- eval "document.body.outerHTML" --filename=page.html
+npx playwright trace snapshot <action-id> -- screenshot --filename=screenshot.png
+```
+
+Only three browser commands are useful on a frozen snapshot: `snapshot`, `eval`, and `screenshot`.
+
+### Attachments
+
+```bash
+# List all trace attachments
+npx playwright trace attachments
+
+# Extract an attachment by its number
+npx playwright trace attachment 1
+npx playwright trace attachment 1 -o out.png
+```
+
+## Typical investigation
+
+```bash
+# 1. Open the trace and see what's inside
+npx playwright trace open test-results/my-test/trace.zip
+
+# 2. What actions ran?
+npx playwright trace actions
+
+# 3. Which action failed?
+npx playwright trace actions --errors-only
+
+# 4. What went wrong?
+npx playwright trace action 12
+
+# 5. What did the page look like at that moment?
+npx playwright trace snapshot 12
+
+# 6. Query the DOM for more detail
+npx playwright trace snapshot 12 -- eval "document.querySelector('.error-message').textContent"
+
+# 7. Any relevant network failures?
+npx playwright trace requests --failed
+
+# 8. Any console errors?
+npx playwright trace console --errors-only
+```

--- a/.fullsend/skills/playwright-trace/SKILL.md
+++ b/.fullsend/skills/playwright-trace/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: playwright-trace
 description: Inspect Playwright trace files from the command line — list actions, view requests, console, errors, snapshots and screenshots.
-allowed-tools: Bash(npx:*)
+allowed-tools: Bash(playwright:*),Bash(npx:*)
 ---
 
 # Playwright Trace CLI
 
 Inspect `.zip` trace files produced by Playwright tests without opening a browser.
+
+`playwright` is installed globally at `/usr/bin/playwright` in the sandbox — use it directly (fallback on `npx` when needed). The harness sets `PLAYWRIGHT_BROWSERS_PATH=/tmp/playwright-browsers` which points to pre-installed Chromium for `trace snapshot`.
+
+Use `playwright trace <cmd>` for everything below. Fall back to `playwright trace <cmd>` only if the global binary is unavailable.
 
 ## Workflow
 
@@ -25,34 +29,34 @@ All commands after `open` operate on the currently opened trace — no need to p
 
 ```bash
 # Extract trace and show metadata: browser, viewport, duration, action/error counts
-npx playwright trace open <trace.zip>
+playwright trace open <trace.zip>
 ```
 
 ### Close a trace
 
 ```bash
 # Remove extracted trace data
-npx playwright trace close
+playwright trace close
 ```
 
 ### Actions
 
 ```bash
 # List all actions as a tree with action IDs and timing
-npx playwright trace actions
+playwright trace actions
 
 # Filter by action title (regex, case-insensitive)
-npx playwright trace actions --grep "click"
+playwright trace actions --grep "click"
 
 # Only failed actions
-npx playwright trace actions --errors-only
+playwright trace actions --errors-only
 ```
 
 ### Action details
 
 ```bash
 # Show full details for one action: params, result, logs, source, snapshots
-npx playwright trace action <action-id>
+playwright trace action <action-id>
 ```
 
 The `action` command displays available snapshot phases (before, input, after) and the exact command to extract them.
@@ -61,46 +65,46 @@ The `action` command displays available snapshot phases (before, input, after) a
 
 ```bash
 # All network requests: method, status, URL, duration, size
-npx playwright trace requests
+playwright trace requests
 
 # Filter by URL pattern
-npx playwright trace requests --grep "api"
+playwright trace requests --grep "api"
 
 # Filter by HTTP method
-npx playwright trace requests --method POST
+playwright trace requests --method POST
 
 # Only failed requests (status >= 400)
-npx playwright trace requests --failed
+playwright trace requests --failed
 ```
 
 ### Request details
 
 ```bash
 # Show full details for one request: headers, body, security
-npx playwright trace request <request-id>
+playwright trace request <request-id>
 ```
 
 ### Console
 
 ```bash
 # All console messages and stdout/stderr
-npx playwright trace console
+playwright trace console
 
 # Only errors
-npx playwright trace console --errors-only
+playwright trace console --errors-only
 
 # Only browser console (no stdout/stderr)
-npx playwright trace console --browser
+playwright trace console --browser
 
 # Only stdout/stderr (no browser console)
-npx playwright trace console --stdio
+playwright trace console --stdio
 ```
 
 ### Errors
 
 ```bash
 # All errors with stack traces and associated actions
-npx playwright trace errors
+playwright trace errors
 ```
 
 ### Snapshots
@@ -109,24 +113,24 @@ The `snapshot` command loads the DOM snapshot for an action into a headless brow
 
 ```bash
 # Get the accessibility snapshot (default)
-npx playwright trace snapshot <action-id>
+playwright trace snapshot <action-id>
 
 # Use a specific phase
-npx playwright trace snapshot <action-id> --name before
+playwright trace snapshot <action-id> --name before
 
 # Run eval to query the DOM
-npx playwright trace snapshot <action-id> -- eval "document.title"
-npx playwright trace snapshot <action-id> -- eval "document.querySelector('#error').textContent"
+playwright trace snapshot <action-id> -- eval "document.title"
+playwright trace snapshot <action-id> -- eval "document.querySelector('#error').textContent"
 
 # Eval on a specific element ref (from the snapshot)
-npx playwright trace snapshot <action-id> -- eval "el => el.getAttribute('data-testid')" e5
+playwright trace snapshot <action-id> -- eval "el => el.getAttribute('data-testid')" e5
 
 # Take a screenshot of the snapshot
-npx playwright trace snapshot <action-id> -- screenshot
+playwright trace snapshot <action-id> -- screenshot
 
 # Redirect output to a file
-npx playwright trace snapshot <action-id> -- eval "document.body.outerHTML" --filename=page.html
-npx playwright trace snapshot <action-id> -- screenshot --filename=screenshot.png
+playwright trace snapshot <action-id> -- eval "document.body.outerHTML" --filename=page.html
+playwright trace snapshot <action-id> -- screenshot --filename=screenshot.png
 ```
 
 Only three browser commands are useful on a frozen snapshot: `snapshot`, `eval`, and `screenshot`.
@@ -135,37 +139,37 @@ Only three browser commands are useful on a frozen snapshot: `snapshot`, `eval`,
 
 ```bash
 # List all trace attachments
-npx playwright trace attachments
+playwright trace attachments
 
 # Extract an attachment by its number
-npx playwright trace attachment 1
-npx playwright trace attachment 1 -o out.png
+playwright trace attachment 1
+playwright trace attachment 1 -o out.png
 ```
 
 ## Typical investigation
 
 ```bash
 # 1. Open the trace and see what's inside
-npx playwright trace open test-results/my-test/trace.zip
+playwright trace open test-results/my-test/trace.zip
 
 # 2. What actions ran?
-npx playwright trace actions
+playwright trace actions
 
 # 3. Which action failed?
-npx playwright trace actions --errors-only
+playwright trace actions --errors-only
 
 # 4. What went wrong?
-npx playwright trace action 12
+playwright trace action 12
 
 # 5. What did the page look like at that moment?
-npx playwright trace snapshot 12
+playwright trace snapshot 12
 
 # 6. Query the DOM for more detail
-npx playwright trace snapshot 12 -- eval "document.querySelector('.error-message').textContent"
+playwright trace snapshot 12 -- eval "document.querySelector('.error-message').textContent"
 
 # 7. Any relevant network failures?
-npx playwright trace requests --failed
+playwright trace requests --failed
 
 # 8. Any console errors?
-npx playwright trace console --errors-only
+playwright trace console --errors-only
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,6 +410,13 @@ oc delete project <namespace>
 
 Trigger nightly manually: comment `/test e2e-ocp-helm-nightly` on a PR.
 
+### Failure Analysis
+
+Two Claude Code skills are available at `.claude/skills/` for investigating E2E failures:
+
+- **`e2e-failure-analysis`** — structured workflow: artifact download, diagnostics, trace correlation, cluster log search, and config comparison
+- **`playwright-trace`** — Playwright trace CLI for inspecting trace ZIP files (actions, DOM snapshots, requests, console, errors)
+
 ## Documentation
 
 - `README.md` — Repo overview, PR workflow, testing procedures


### PR DESCRIPTION
## Summary

- Add **e2e-failure-analysis** skill — structured investigation workflow for E2E test failures: artifact download, diagnostics script, error-context analysis, trace inspection, cluster log search, and config comparison
- Add **playwright-trace** skill — official Playwright trace CLI skill (`npx playwright trace`) for inspecting trace files (actions, snapshots, DOM queries, requests, console, errors)
- Both live in `.fullsend/skills/` with a `.claude/skills/` symlink for the trace skill

## Test plan

- [ ] Verify `diagnostics.py` runs against a downloaded nightly artifact
- [ ] Verify `npx playwright trace open <trace.zip>` + subcommands work
- [ ] Confirm `.claude/skills/playwright-trace` symlink resolves correctly

Assisted-by: Claude Code