### PR TITLE
fix(orchestrator): drop module from translationResources example

### DIFF
--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
@@ -36,7 +36,7 @@ spec:
             red-hat-developer-hub.backstage-plugin-orchestrator:
               translationResources:
                 - importName: orchestratorTranslations
-                  module: Alpha
+                  module: PluginRoot
                   ref: orchestratorTranslationRef
               appIcons:
                 - importName: OrchestratorIcon

--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
@@ -36,7 +36,6 @@ spec:
             red-hat-developer-hub.backstage-plugin-orchestrator:
               translationResources:
                 - importName: orchestratorTranslations
-                  module: PluginRoot
                   ref: orchestratorTranslationRef
               appIcons:
                 - importName: OrchestratorIcon


### PR DESCRIPTION
## Summary
- Remove the explicit `module` from Orchestrator `appConfigExamples` in `rhdh-bsp-orchestrator.yaml`
- RHDH defaults to `PluginRoot` when `module` is omitted, matching the fix in [rhdh-plugins#3729](https://github.com/redhat-developer/rhdh-plugins/pull/3729)

## Context
The previous example used `module: Alpha` for `translationResources`, which can cause intermittent page load failures due to a module initialization race on the Alpha `default` export. Omitting `module` is the preferred RHDH convention (same pattern as scorecard and other plugins).

## Test plan
- [ ] Verify metadata YAML is valid
- [ ] Confirm example config matches updated orchestrator plugin `app-config.yaml`