### PR TITLE
chore(deps): [release-1.10] [lightspeed] bump fast-uri to 3.1.3 or higher

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,20 +29,20 @@
    languageName: node
    linkType: hard
  
-@@ -8878,13 +8877,6 @@
-   version: 1.0.2
-   resolution: "@protobufjs/float@npm:1.0.2"
-   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
--  languageName: node
--  linkType: hard
--
+@@ -8881,13 +8880,6 @@
+   languageName: node
+   linkType: hard
+ 
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
-   languageName: node
-   linkType: hard
- 
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
 @@ -21220,13 +21212,13 @@
    linkType: hard
  
@@ -58,6 +58,19 @@
      express: ">= 4.11"
 -  checksum: 10c0/e3229938457cec617460c54ef4e90c8c254facc884729325d20ea35e3838bd273e4c611fc1f4a76f6d14c411e30d31b15e88eb4be87408615ff0aacc142511a2
 +  checksum: 10c0/c98c49b93e94627940cf5e7c2578718b94d77163357161c3343d148e46257136c988933a96d6e1e728a010683133a58f68cad46928b063cf8d99521c8772578d
+   languageName: node
+   linkType: hard
+ 
+@@ -21408,9 +21400,9 @@
+   linkType: hard
+ 
+ "fast-uri@npm:^3.0.1":
+-  version: 3.0.3
+-  resolution: "fast-uri@npm:3.0.3"
+-  checksum: 10c0/4b2c5ce681a062425eae4f15cdc8fc151fd310b2f69b1f96680677820a8b49c3cd6e80661a406e19d50f0c40a3f8bffdd458791baf66f4a879d80be28e10a320
++  version: 3.1.3
++  resolution: "fast-uri@npm:3.1.3"
++  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
    languageName: node
    linkType: hard
  
@@ -100,22 +113,22 @@
    languageName: node
    linkType: hard
  
-@@ -22825,6 +22817,15 @@
-   languageName: node
-   linkType: hard
- 
+@@ -22822,6 +22814,15 @@
+   dependencies:
+     function-bind: "npm:^1.1.2"
+   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
++  languageName: node
++  linkType: hard
++
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: "npm:^1.1.2"
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
-+  languageName: node
-+  linkType: hard
-+
- "hast-util-from-parse5@npm:^7.0.0":
-   version: 7.1.2
-   resolution: "hast-util-from-parse5@npm:7.1.2"
+   languageName: node
+   linkType: hard
+ 
 @@ -23818,20 +23819,10 @@
    languageName: node
    linkType: hard

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -6,6 +6,10 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: 5a0ebed9cfa46b374225321d2678be36006e16ef
 backports:
   - cve_ids:
+      - CVE-2026-13676
+    package: fast-uri
+    patch_version: 3.1.3
+  - cve_ids:
       - CVE-2026-12143
     package: form-data
     patch_version: 2.5.6, 4.0.6


### PR DESCRIPTION
bump fast-uri to 3.1.3 or higher to fix CVE-2026-13676
https://redhat.atlassian.net/browse/RHIDP-15162