### PR TITLE
chore(deps): [release-1.10] [orchestrator] bump fast-uri to 3.1.3 or higher

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -40,20 +40,20 @@
    languageName: node
    linkType: hard
  
-@@ -10986,13 +10985,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -10983,13 +10982,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
+   languageName: node
+   linkType: hard
+ 
 @@ -11007,10 +10999,10 @@
    languageName: node
    linkType: hard
@@ -66,6 +66,19 @@
 +  version: 1.1.2
 +  resolution: "@protobufjs/utf8@npm:1.1.2"
 +  checksum: 10c0/975c6e2c0319bd50c17531d186b537a88cb4d3205e3ca9297cd842b631d341da0ee3ff16be8656cd2660756dc753b29c8a6a14c0ad8ed602c1f91ddf22e7b3f3
+   languageName: node
+   linkType: hard
+ 
+@@ -24337,9 +24329,9 @@
+   linkType: hard
+ 
+ "fast-uri@npm:^3.0.1":
+-  version: 3.1.2
+-  resolution: "fast-uri@npm:3.1.2"
+-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
++  version: 3.1.3
++  resolution: "fast-uri@npm:3.1.3"
++  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
    languageName: node
    linkType: hard
  
@@ -124,20 +137,20 @@
    languageName: node
    linkType: hard
  
-@@ -29430,6 +29431,13 @@
-   languageName: node
-   linkType: hard
- 
+@@ -29427,6 +29428,13 @@
+   version: 5.2.3
+   resolution: "long@npm:5.2.3"
+   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++  languageName: node
++  linkType: hard
++
 +"long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
-+  languageName: node
-+  linkType: hard
-+
- "longest-streak@npm:^3.0.0":
-   version: 3.1.0
-   resolution: "longest-streak@npm:3.1.0"
+   languageName: node
+   linkType: hard
+ 
 @@ -33625,22 +33633,21 @@
    linkType: hard
  

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -6,6 +6,10 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: eb6cce6110fc8bd532e717e9d995764481b36f1b
 backports:
   - cve_ids:
+      - CVE-2026-13676
+    package: fast-uri
+    patch_version: 3.1.3
+  - cve_ids:
       - CVE-2026-12143
     package: form-data
     patch_version: 2.3.3, 2.5.6, 4.0.6


### PR DESCRIPTION
bump fast-uri to 3.1.3 or higher to fix CVE-2026-13676
https://redhat.atlassian.net/browse/RHIDP-15162