### PR TITLE
chore: re-add missing adoption-insights...

### DIFF
--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -4,7 +4,7 @@
 #
 # New packages *support* level should only be "tech-preview" or "generally-available"
 #    16 are tech-preview, and should be promoted via a PM-sponsored Feature to generally-available at some point
-#    06 are community, and should be removed over time
+#    06 are community, and should be removed in 2.1 - https://redhat.atlassian.net/browse/RHIDP-13261
 packages:
   enabled: # should only include GA (or TP with a path to GA) content here
   - package: '@backstage-community/plugin-analytics-provider-segment'
@@ -19,6 +19,10 @@ packages:
     support: "generally-available"
   - package: '@red-hat-developer-hub/backstage-plugin-adoption-insights'
     support: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-adoption-insights-backend'
+    support: "generally-available"
+  - package: '@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights'
+    support: "generally-available"
   - package: '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions'
     support: "tech-preview"
   - package: '@red-hat-developer-hub/backstage-plugin-dynamic-home-page'
@@ -32,7 +36,7 @@ packages:
   - package: '@red-hat-developer-hub/backstage-plugin-quickstart'
     support: "generally-available"
 
-  disabled: # should ideally contain no community content; TODO: remove some community or TP stuff in 2.1?
+  disabled: # should contain no community content; TODO: remove all community and TP stuff in 2.1 - https://redhat.atlassian.net/browse/RHIDP-13261
   - package: '@backstage-community/plugin-catalog-backend-module-keycloak'
     support: "generally-available"
   - package: '@backstage-community/plugin-catalog-backend-module-pingidentity'
@@ -104,7 +108,7 @@ packages:
   - package: '@roadiehq/scaffolder-backend-module-http-request'
     support: "generally-available"
 
-  # these community supported plugins do not have a downstream analogue in overlays repo's rhdh-supported-packages.txt
+  # TODO: remove all community and TP stuff in 2.1 - https://redhat.atlassian.net/browse/RHIDP-13261
   - package: '@backstage-community/plugin-quay'
     support: "community"
   - package: '@backstage-community/plugin-quay-backend'


### PR DESCRIPTION
### What does this PR do?

chore: re-add missing adoption-insights plugins which were GA in 1.10 (and continue in 2.1)

add TODO marker for TP/Community plugins to remove in 2.1 - https://redhat.atlassian.net/browse/RHIDP-13261

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.