### PR TITLE
fix(orchestrator): drop module from translationResources example (release-1.10)

### DIFF
--- a/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
+++ b/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator.yaml
@@ -36,7 +36,6 @@ spec:
             red-hat-developer-hub.backstage-plugin-orchestrator:
               translationResources:
                 - importName: orchestratorTranslations
-                  module: Alpha
                   ref: orchestratorTranslationRef
               appIcons:
                 - importName: OrchestratorIcon


### PR DESCRIPTION
## Summary
- Remove the explicit `module: Alpha` from Orchestrator `appConfigExamples` in `rhdh-bsp-orchestrator.yaml` on the `release-1.10` branch
- RHDH defaults to `PluginRoot` when `module` is omitted, avoiding intermittent page load failures caused by a module initialization race on the Alpha `default` export

## Context
Related to [RHDHBUGS-3459](https://redhat.atlassian.net/browse/RHDHBUGS-3459) and the same fix on `main` in [#2753](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2753).

The plugin runtime fix is in [rhdh-plugins#3729](https://github.com/redhat-developer/rhdh-plugins/pull/3729).

## Test plan
- [ ] Verify metadata YAML is valid
- [ ] Confirm example config matches updated orchestrator plugin `app-config.yaml`


Made with [Cursor](https://cursor.com)