### PR TITLE
chore(deps): [release-1.10] [orchestrator] Bump brace-expansion to 1.1.16, 2.1.2 or 5.0.6, or higher 

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -40,20 +40,20 @@
    languageName: node
    linkType: hard
  
-@@ -10986,13 +10985,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -10983,13 +10982,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
+   languageName: node
+   linkType: hard
+ 
 @@ -11007,10 +10999,10 @@
    languageName: node
    linkType: hard
@@ -66,6 +66,46 @@
 +  version: 1.1.2
 +  resolution: "@protobufjs/utf8@npm:1.1.2"
 +  checksum: 10c0/975c6e2c0319bd50c17531d186b537a88cb4d3205e3ca9297cd842b631d341da0ee3ff16be8656cd2660756dc753b29c8a6a14c0ad8ed602c1f91ddf22e7b3f3
+   languageName: node
+   linkType: hard
+ 
+@@ -19811,30 +19803,30 @@
+   linkType: hard
+ 
+ "brace-expansion@npm:^1.1.7":
+-  version: 1.1.11
+-  resolution: "brace-expansion@npm:1.1.11"
++  version: 1.1.16
++  resolution: "brace-expansion@npm:1.1.16"
+   dependencies:
+     balanced-match: "npm:^1.0.0"
+     concat-map: "npm:0.0.1"
+-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
++  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+   languageName: node
+   linkType: hard
+ 
+ "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
+-  version: 2.1.0
+-  resolution: "brace-expansion@npm:2.1.0"
++  version: 2.1.2
++  resolution: "brace-expansion@npm:2.1.2"
+   dependencies:
+     balanced-match: "npm:^1.0.0"
+-  checksum: 10c0/439cedf3e23d7993b37919f1d6fdc653ec21a42437ec3e7460bea9ca8b17edf7a24a633273c31d61aa4335877cf29a443f1871814131c87997a1e6223e1f1502
++  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+   languageName: node
+   linkType: hard
+ 
+ "brace-expansion@npm:^5.0.2, brace-expansion@npm:^5.0.5":
+-  version: 5.0.5
+-  resolution: "brace-expansion@npm:5.0.5"
++  version: 5.0.7
++  resolution: "brace-expansion@npm:5.0.7"
+   dependencies:
+     balanced-match: "npm:^4.0.2"
+-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
++  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
    languageName: node
    linkType: hard
  
@@ -124,20 +164,20 @@
    languageName: node
    linkType: hard
  
-@@ -29430,6 +29431,13 @@
-   languageName: node
-   linkType: hard
- 
+@@ -29427,6 +29428,13 @@
+   version: 5.2.3
+   resolution: "long@npm:5.2.3"
+   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++  languageName: node
++  linkType: hard
++
 +"long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
-+  languageName: node
-+  linkType: hard
-+
- "longest-streak@npm:^3.0.0":
-   version: 3.1.0
-   resolution: "longest-streak@npm:3.1.0"
+   languageName: node
+   linkType: hard
+ 
 @@ -33625,22 +33633,21 @@
    linkType: hard
  

--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -106,8 +106,11 @@
      balanced-match: "npm:^4.0.2"
 -  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
 +  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
-@@ -24337,9 +24329,9 @@
+   languageName: node
    linkType: hard
+ 
+@@ -24337,9 +24329,9 @@
+  linkType: hard
  
  "fast-uri@npm:^3.0.1":
 -  version: 3.1.2
@@ -118,7 +121,7 @@
 +  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
    languageName: node
    linkType: hard
- 
+
 @@ -24775,29 +24767,29 @@
    linkType: hard
  

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -6,6 +6,26 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: eb6cce6110fc8bd532e717e9d995764481b36f1b
 backports:
   - cve_ids:
+      - CVE-2026-13149
+    package: brace-expansion
+    patch_version: 1.1.16, 2.1.2, 5.0.7
+    notes: |-
+      [auto] brace-expansion@1.1.16 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ @backstage/cli@0.36.0
+          └─┬ eslint-plugin-import@2.31.0
+            └─┬ minimatch@3.1.5
+              └── brace-expansion@1.1.16
+      brace-expansion@2.1.2 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ @backstage/cli@0.36.0
+          └─┬ @backstage/cli-defaults@0.1.0
+            └─┬ @backstage/cli-module-migrate@0.1.0
+              └─┬ replace-in-file@7.2.0
+                └─┬ glob@8.1.0
+                  └─┬ minimatch@5.1.9
+                    └── brace-expansion@2.1.2
+  - cve_ids:
       - CVE-2026-12143
     package: form-data
     patch_version: 2.3.3, 2.5.6, 4.0.6


### PR DESCRIPTION
Bump brace-expansion to 1.1.16, 2.1.2 or 5.0.6, or higher to fix CVE-2026-13149
https://redhat.atlassian.net/browse/RHIDP-15243

The fix has been applied, tagged, and released to the following versions:

1. v1.x: 1.1.16 (via PR [#123](https://github.com/juliangruber/brace-expansion/pull/123))
1. v2.x: 2.1.2 (via PR [#122](https://github.com/juliangruber/brace-expansion/pull/122))
1. v5.x: 5.0.7 (via PR [#126](https://github.com/juliangruber/brace-expansion/pull/126))