### PR TITLE
chore(deps): [release-1.10] [lightspeed] patch Bump brace-expansion to 1.1.16, 2.1.2 or 5.0.6, or higher 

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,20 +29,60 @@
    languageName: node
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
+   languageName: node
+   linkType: hard
+ 
+@@ -17283,30 +17275,30 @@
+   linkType: hard
+ 
+ "brace-expansion@npm:^1.1.7":
+-  version: 1.1.11
+-  resolution: "brace-expansion@npm:1.1.11"
++  version: 1.1.16
++  resolution: "brace-expansion@npm:1.1.16"
+   dependencies:
+     balanced-match: "npm:^1.0.0"
+     concat-map: "npm:0.0.1"
+-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
++  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+   languageName: node
+   linkType: hard
+ 
+ "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
+-  version: 2.0.3
+-  resolution: "brace-expansion@npm:2.0.3"
++  version: 2.1.2
++  resolution: "brace-expansion@npm:2.1.2"
+   dependencies:
+     balanced-match: "npm:^1.0.0"
+-  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
++  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+   languageName: node
+   linkType: hard
+ 
+ "brace-expansion@npm:^5.0.2, brace-expansion@npm:^5.0.5":
+-  version: 5.0.5
+-  resolution: "brace-expansion@npm:5.0.5"
++  version: 5.0.7
++  resolution: "brace-expansion@npm:5.0.7"
+   dependencies:
+     balanced-match: "npm:^4.0.2"
+-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
++  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+   languageName: node
+   linkType: hard
+ 
 @@ -21220,13 +21212,13 @@
    linkType: hard
  
@@ -113,33 +153,36 @@
    languageName: node
    linkType: hard
  
-@@ -22822,6 +22814,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
+@@ -22825,6 +22817,15 @@
+   languageName: node
+   linkType: hard
+ 
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: "npm:^1.1.2"
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
-   languageName: node
-   linkType: hard
- 
-@@ -23818,20 +23819,10 @@
-   languageName: node
-   linkType: hard
- 
++  languageName: node
++  linkType: hard
++
+ "hast-util-from-parse5@npm:^7.0.0":
+   version: 7.1.2
+   resolution: "hast-util-from-parse5@npm:7.1.2"
+@@ -23815,23 +23816,13 @@
+     redis-parser: "npm:^3.0.0"
+     standard-as-callback: "npm:^2.1.0"
+   checksum: 10c0/0884103c9f569b598a3024edc8cae6fea3ece85559a3b1eeb84d8fdb52c4b2ed097eb4e082b8a66b3fae65b38f0e305026979c95e6990ae9a2e07c9b3df5da8b
+-  languageName: node
+-  linkType: hard
+-
 -"ip-address@npm:10.1.0":
 -  version: 10.1.0
 -  resolution: "ip-address@npm:10.1.0"
 -  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
--  languageName: node
--  linkType: hard
--
+   languageName: node
+   linkType: hard
+ 
 -"ip-address@npm:^9.0.5":
 -  version: 9.0.5
 -  resolution: "ip-address@npm:9.0.5"

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -6,6 +6,25 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: 5a0ebed9cfa46b374225321d2678be36006e16ef
 backports:
   - cve_ids:
+      - CVE-2026-13149
+    package: brace-expansion
+    patch_version: 1.1.16, 2.1.2, 5.0.7
+    notes: |-
+      [auto] brace-expansion@1.1.16 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ @backstage/cli@0.36.0
+          └─┬ eslint-plugin-import@2.31.0
+            └─┬ minimatch@3.1.5
+              └── brace-expansion@1.1.16
+      brace-expansion@2.1.2 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ @backstage/cli-defaults@0.1.0
+          └─┬ @backstage/cli-module-build@0.1.2
+            └─┬ npm-packlist@5.1.3
+              └─┬ glob@8.1.0
+                └─┬ minimatch@5.1.9
+                  └── brace-expansion@2.1.2
+  - cve_ids:
       - CVE-2026-13676
     package: fast-uri
     patch_version: 3.1.3


### PR DESCRIPTION
partial patch brace-expansion to 1.1.16, 2.1.2 or 5.0.6 or higher to fix CVE-2026-13149
https://redhat.atlassian.net/browse/RHIDP-15243

The fix has been applied, tagged, and released to the following versions:

v1.x: 1.1.16 (via PR https://github.com/juliangruber/brace-expansion/pull/123)
v2.x: 2.1.2 (via PR https://github.com/juliangruber/brace-expansion/pull/122)
v5.x: 5.0.7 (via PR https://github.com/juliangruber/brace-expansion/pull/126)