### PR TITLE
chore: remove stale entries from all.yaml for deleted plugins

### DIFF
--- a/catalog-entities/extensions/plugins/all.yaml
+++ b/catalog-entities/extensions/plugins/all.yaml
@@ -17,7 +17,6 @@ spec:
     - ./aws-ecs.yaml
     - ./azure-container-registry.yaml
     - ./azure-devops.yaml
-    - ./azure-repositories.yaml
     - ./azure-scaffolder-actions.yaml
     - ./backstage-community-plugin-quay.yaml
     - ./bitbucket-cloud-catalog-integration.yaml
@@ -61,7 +60,6 @@ spec:
     - ./nexus-repository-manager.yaml
     - ./notifications-email.yaml
     - ./notifications.yaml
-    - ./openshift-cluster-manager.yaml
     - ./orchestrator-scaffolder-actions.yaml
     - ./orchestrator.yaml
     - ./pagerduty.yaml

--- a/catalog-entities/extensions/plugins/all.yaml
+++ b/catalog-entities/extensions/plugins/all.yaml
@@ -20,13 +20,17 @@ spec:
     - ./azure-scaffolder-actions.yaml
     - ./backstage-community-plugin-quay.yaml
     - ./bitbucket-cloud-catalog-integration.yaml
+    - ./bitbucket-cloud-scaffolder-actions.yaml
     - ./bitbucket-server-catalog-integration.yaml
+    - ./bitbucket-server-scaffolder-actions.yaml
     - ./bulk-import.yaml
     - ./contrib-techdocs-addons.yaml
     - ./cost-management.yaml
     - ./datadog.yaml
     - ./dynatrace-commercial.yaml
     - ./dynatrace-community.yaml
+    - ./events-backend-module-github.yaml
+    - ./events-backend-module-gitlab.yaml
     - ./extensions.yaml
     - ./gerrit-scaffolder-actions.yaml
     - ./github-actions.yaml


### PR DESCRIPTION
## Summary
- Removes stale references to `./azure-repositories.yaml` and `./openshift-cluster-manager.yaml` from `catalog-entities/extensions/plugins/all.yaml`
- These files were deleted in PR #2240 and PR #2059 respectively, but their entries in `all.yaml` were not cleaned up
- This causes catalog warnings on every startup/refresh cycle:
  ```
  catalog warn Unable to read url, no matching files found for .../azure-repositories.yaml
  catalog warn Unable to read url, no matching files found for .../openshift-cluster-manager.yaml
  ```
  Also added the four missing entries to all.yaml:
```
./bitbucket-cloud-scaffolder-actions.yaml
./bitbucket-server-scaffolder-actions.yaml
./events-backend-module-github.yaml
./events-backend-module-gitlab.yaml
```

## Fixed 
- https://redhat.atlassian.net/browse/RHDHBUGS-3467

## Test plan
- [ ] Verify no catalog warnings for these two files on startup after deploying this change

Made with [Cursor](https://cursor.com)