### PR TITLE
test

### DIFF
--- a/workspaces/argocd/e2e-tests/tests/specs/deploy-openshift-gitops.sh
+++ b/workspaces/argocd/e2e-tests/tests/specs/deploy-openshift-gitops.sh
@@ -80,6 +80,9 @@ configure_rbac() {
 get_argocd_credentials() {
   echo "=== Retrieving ArgoCD credentials ==="
 
+  wait_for "ArgoCD server route" \
+    "oc get route openshift-gitops-server -n ${GITOPS_NAMESPACE}" 120 10
+
   ARGOCD_URL="https://$(oc get route openshift-gitops-server -n "${GITOPS_NAMESPACE}" -o jsonpath='{.spec.host}')"
   echo "ArgoCD URL: ${ARGOCD_URL}"
 


### PR DESCRIPTION
Root cause: deploy-openshift-gitops.sh fails because the ArgoCD server
route is not yet created by the operator when get_argocd_credentials()
runs immediately after the deployment becomes ready. Add a wait_for call
(120s timeout) to poll for the route before attempting to read it.
Fixes: #ISSUE_PLACEHOLDER

Closes #2769