### PR TITLE
fix(e2e): orchestrator — handle OIDC auto-redirect in login fallback

### DIFF
--- a/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-rbac.tests.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-rbac.tests.ts
@@ -147,6 +147,17 @@ export async function loginAsKeycloakUserWithRetry(
           });
           return;
         }
+
+        // OIDC auto-redirect may have completed without showing the
+        // Keycloak form (e.g. SSO session). Check if already logged in.
+        if (
+          await page
+            .locator("nav a")
+            .first()
+            .isVisible({ timeout: LOGIN_SUCCESS_TIMEOUT_MS })
+        ) {
+          return;
+        }
       } catch (fallbackError) {
         lastError = fallbackError;
       }


### PR DESCRIPTION
Root cause: loginAsKeycloakUserWithRetry fails because the OIDC
auth flow auto-redirects (no popup, no Sign In button). The fallback
checks for a Keycloak form (#username) but when Keycloak's SSO session
auto-authenticates, no form appears either. After 3 retries, the test
throws even though the user IS authenticated (confirmed by screenshots).
Add a nav element visibility check after the form check to detect when
the OIDC redirect has already completed authentication successfully.
Fixes: #ISSUE_PLACEHOLDER

Closes #2770