### PR TITLE
fix(e2e): [fullsend] argocd — wait for route before retrieving credentials

### DIFF
--- a/workspaces/argocd/e2e-tests/tests/specs/deploy-openshift-gitops.sh
+++ b/workspaces/argocd/e2e-tests/tests/specs/deploy-openshift-gitops.sh
@@ -80,6 +80,9 @@ configure_rbac() {
 get_argocd_credentials() {
   echo "=== Retrieving ArgoCD credentials ==="
 
+  wait_for "ArgoCD server route" \
+    "oc get route openshift-gitops-server -n ${GITOPS_NAMESPACE}" 120 10
+
   ARGOCD_URL="https://$(oc get route openshift-gitops-server -n "${GITOPS_NAMESPACE}" -o jsonpath='{.spec.host}')"
   echo "ArgoCD URL: ${ARGOCD_URL}"
 


### PR DESCRIPTION
Root cause: get_argocd_credentials() immediately accesses the
openshift-gitops-server route after the deployment is ready, but
the route is created asynchronously by the GitOps operator and may
not exist yet. With set -euo pipefail, the missing route causes
an immediate script exit, failing all 7 argocd tests.
Fixes: #2773
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Closes #2773