### PR TITLE
fix(e2e): [fullsend] orchestrator — handle OIDC auto-redirect in login fallback

### DIFF
--- a/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-rbac.tests.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-rbac.tests.ts
@@ -147,6 +147,17 @@ export async function loginAsKeycloakUserWithRetry(
           });
           return;
         }
+
+        // OIDC auto-redirect may have silently authenticated the user
+        // without showing a login form or popup.
+        if (
+          await page
+            .locator("nav a")
+            .first()
+            .isVisible({ timeout: LOGIN_SUCCESS_TIMEOUT_MS })
+        ) {
+          return;
+        }
       } catch (fallbackError) {
         lastError = fallbackError;
       }


### PR DESCRIPTION
Root cause: loginAsKeycloakUserWithRetry's fallback path checks for
a Keycloak #username form after the popup login fails, but with OIDC
prompt:auto the browser can auto-redirect through Keycloak and back,
silently authenticating the user without showing any form. The
function doesn't detect this already-logged-in state, wastes all 3
retry attempts on popup timeouts, and fails despite the user being
successfully authenticated.
Fixes: #2774
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Closes #2774