### PR TITLE
chore: clean up EOL release references

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ You can also create PRs manually. For adding a **new workspace**, your PR should
 To add a new workspace with plugins:
 
 1. Create a new workspace in the overlay repository.
-2. Add a `plugins-list.yaml` file that lists all plugins included in the target workspace of the source repository. ([See example](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/workspaces/adoption-insights/plugins-list.yaml))
-3. Add a `source.json` file with the following fields ([See example](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/workspaces/adoption-insights/source.json)):
+2. Add a `plugins-list.yaml` file that lists all plugins included in the target workspace of the source repository. ([See example](./workspaces/adoption-insights/plugins-list.yaml))
+3. Add a `source.json` file with the following fields ([See example](./workspaces/adoption-insights/source.json)):
    - `repo`: URL of the source repository (only `https://github.com/xxx` URLs are supported for now)
    - `repo-ref`: Specific tag or commit for the target plugin/workspace version
    - `repo-flat`:
@@ -103,13 +103,13 @@ To add a new workspace with plugins:
 Sometimes, additional configuration is required in the PR:
 
 - **Frontend plugins** may need:
-   - `app-config.dynamic.yaml` (Eg: [techdocs plugin](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/release-1.5/workspaces/backstage/plugins/techdocs/app-config.dynamic.yaml))
-   - `scalprum-config.json` (Eg: [api-docs-module-protoc-gen-doc plugin](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/release-1.5/workspaces/backstage/plugins/api-docs-module-protoc-gen-doc/scalprum-config.json))
+   - `app-config.dynamic.yaml` (Eg: [techdocs plugin](./workspaces/backstage/plugins/techdocs/app-config.dynamic.yaml))
+   - `scalprum-config.json` (Eg: [api-docs-module-protoc-gen-doc plugin](./workspaces/backstage/plugins/api-docs-module-protoc-gen-doc/scalprum-config.json))
 
 - **Any plugin** may need:
    - Overlay source files in an `overlay` directory
-  (e.g., [`api-docs-module-protoc-gen-doc`](https://github.com/redhat-developer/rhdh-plugin-export-overlays/tree/release-1.5/workspaces/backstage/plugins/api-docs-module-protoc-gen-doc/overlay))
-  - Patches (`*.patch`) in the `patches` directory of the workspace folder, to modify the workspace source code before the whole build and packaging process. (Example: [roadie backstage plugins](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/150c9d98830039315df6b4f23bf9f85b1cf5ae55/workspaces/roadie-backstage-plugins/patches/1-avoid-double-wildcards.patch))
+  (e.g., [`api-docs-module-protoc-gen-doc`](./workspaces/backstage/plugins/api-docs-module-protoc-gen-doc/overlay))
+  - Patches (`*.patch`) in the `patches` directory of the workspace folder, to modify the workspace source code before the whole build and packaging process. (Example: [roadie backstage plugins](./workspaces/roadie-backstage-plugins/patches/1-avoid-double-wildcards.patch))
 
 > **Overlay vs. Patch**
 > - **Overlay**: Replaces or adds entire files during the packaging process.

--- a/catalog-entities/extensions/README.md
+++ b/catalog-entities/extensions/README.md
@@ -144,7 +144,7 @@ You **must** add your plugin yaml file to the list in the `plugins/all.yaml` fil
 
 # Using RHDH-local
 
-You need to reconfigure a few bits for the rhdh-1.5 image build, but when you do your local edits will show up within 15 secs...
+You need to reconfigure a few bits for a local RHDH image build, but when you do your local edits will show up within 15 secs...
 
 In `app-config.yaml` do this:
 


### PR DESCRIPTION
Refs: [RHIDP-13595](https://redhat.atlassian.net/browse/RHIDP-13595)

Converts self-referencing absolute GitHub links in `README.md` to relative paths. Three of these pointed to the deleted `release-1.5` branch and would 404; the remaining three (pinned to `main` or a commit SHA) are made relative for consistency so they always resolve against the viewer's current branch.

Also removes the stale `rhdh-1.5` version qualifier from `catalog-entities/extensions/README.md` — the local dev instructions are version-agnostic.