### PR TITLE
chore: migrate metadata `dynamicArtifact` from wrapper paths to OCI refs

### DIFF
--- a/workspaces/acr/metadata/backstage-community-plugin-acr.yaml
+++ b/workspaces/acr/metadata/backstage-community-plugin-acr.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage-community/plugin-acr"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-acr
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-acr:bs_1.52.0__1.26.0!backstage-community-plugin-acr
   version: 1.26.0
   backstage:
     role: frontend-plugin

--- a/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights-backend.yaml
+++ b/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend"
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights-backend:bs_1.49.4__0.8.3!red-hat-developer-hub-backstage-plugin-adoption-insights-backend
   version: 0.8.3
   backstage:
     role: backend-plugin

--- a/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights.yaml
+++ b/workspaces/adoption-insights/metadata/rhdh-bsp-adoption-insights.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-adoption-insights'
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-adoption-insights
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-adoption-insights:bs_1.49.4__0.8.3!red-hat-developer-hub-backstage-plugin-adoption-insights
   version: 0.8.3
   backstage:
     role: frontend-plugin

--- a/workspaces/adoption-insights/metadata/rhdh-bsp-analytics-mod-adoption-insights.yaml
+++ b/workspaces/adoption-insights/metadata/rhdh-bsp-analytics-mod-adoption-insights.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights"
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights:bs_1.49.4__0.8.3!red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights
   version: 0.8.3
   backstage:
     role: frontend-plugin-module

--- a/workspaces/analytics/metadata/backstage-community-plugin-analytics-provider-segment.yaml
+++ b/workspaces/analytics/metadata/backstage-community-plugin-analytics-provider-segment.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage-community/plugin-analytics-provider-segment"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-analytics-provider-segment:bs_1.49.4__1.27.0!backstage-community-plugin-analytics-provider-segment
   version: 1.27.0
   backstage:
     role: frontend-plugin

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-github-org.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-github-org.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-catalog
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-github-org"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-github-org:bs_1.52.0__0.3.23!backstage-plugin-catalog-backend-module-github-org
   version: 0.3.23
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-github.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-github.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-catalog
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-github"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-github:bs_1.52.0__0.13.3!backstage-plugin-catalog-backend-module-github
   version: 0.13.3
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-gitlab-org.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-gitlab-org.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-catalog
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-gitlab-org"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-gitlab-org:bs_1.52.0__0.2.22!backstage-plugin-catalog-backend-module-gitlab-org
   version: 0.2.22
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-gitlab.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-gitlab.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-catalog
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-gitlab"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-gitlab:bs_1.52.0__0.8.4!backstage-plugin-catalog-backend-module-gitlab
   version: 0.8.4
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-ldap.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-ldap.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-catalog
 spec:
   packageName: '@backstage/plugin-catalog-backend-module-ldap'
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-ldap-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-ldap:bs_1.52.0__0.12.6!backstage-plugin-catalog-backend-module-ldap
   version: 0.12.6
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-msgraph.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-catalog-backend-module-msgraph.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-catalog
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-msgraph"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-msgraph-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-msgraph:bs_1.52.0__0.10.3!backstage-plugin-catalog-backend-module-msgraph
   version: 0.10.3
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-kubernetes-backend.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-kubernetes-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-kubernetes-backend"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-kubernetes-backend:bs_1.52.0__0.21.5!backstage-plugin-kubernetes-backend
   version: 0.21.5
   backstage:
     role: backend-plugin

--- a/workspaces/backstage/metadata/backstage-plugin-kubernetes.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-kubernetes.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-kubernetes"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-kubernetes:bs_1.52.0__0.12.20!backstage-plugin-kubernetes
   version: 0.12.20
   backstage:
     role: frontend-plugin

--- a/workspaces/backstage/metadata/backstage-plugin-notifications-backend-module-email.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-notifications-backend-module-email.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-notifications-backend-module-email"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-module-email-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-notifications-backend-module-email:bs_1.52.0__0.3.22!backstage-plugin-notifications-backend-module-email
   version: 0.3.22
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-notifications-backend.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-notifications-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-notifications-backend"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-notifications-backend:bs_1.52.0__0.6.6!backstage-plugin-notifications-backend
   version: 0.6.6
   backstage:
     role: backend-plugin

--- a/workspaces/backstage/metadata/backstage-plugin-notifications.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-notifications.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-notifications"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-notifications
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-notifications:bs_1.52.0__0.5.18!backstage-plugin-notifications
   version: 0.5.18
   backstage:
     role: frontend-plugin

--- a/workspaces/backstage/metadata/backstage-plugin-scaffolder-backend-module-github.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-scaffolder-backend-module-github.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-templates
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-github"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-github:bs_1.52.0__0.9.10!backstage-plugin-scaffolder-backend-module-github
   version: 0.9.10
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-scaffolder-backend-module-gitlab.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-scaffolder-backend-module-gitlab.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-templates
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-gitlab"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-gitlab:bs_1.52.0__0.11.7!backstage-plugin-scaffolder-backend-module-gitlab
   version: 0.11.7
   backstage:
     role: backend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-signals-backend.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-signals-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-signals-backend"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-signals-backend:bs_1.52.0__0.3.16!backstage-plugin-signals-backend
   version: 0.3.16
   backstage:
     role: backend-plugin

--- a/workspaces/backstage/metadata/backstage-plugin-signals.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-signals.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-signals"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-signals
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-signals:bs_1.52.0__0.0.32!backstage-plugin-signals
   version: 0.0.32
   backstage:
     role: frontend-plugin

--- a/workspaces/backstage/metadata/backstage-plugin-techdocs-backend.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-techdocs-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-techdocs-backend"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs-backend:bs_1.52.0__2.2.1!backstage-plugin-techdocs-backend
   version: 2.2.1
   backstage:
     role: backend-plugin

--- a/workspaces/backstage/metadata/backstage-plugin-techdocs-module-addons-contrib.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-techdocs-module-addons-contrib.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage/plugin-techdocs-module-addons-contrib"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs-module-addons-contrib:bs_1.52.0__1.1.37!backstage-plugin-techdocs-module-addons-contrib
   version: 1.1.37
   backstage:
     role: frontend-plugin-module

--- a/workspaces/backstage/metadata/backstage-plugin-techdocs.yaml
+++ b/workspaces/backstage/metadata/backstage-plugin-techdocs.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@backstage/plugin-techdocs'
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-techdocs
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs:bs_1.52.0__1.17.7!backstage-plugin-techdocs
   version: 1.17.7
   backstage:
     role: frontend-plugin

--- a/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml
+++ b/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-bulk-import-backend"
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-bulk-import-backend:bs_1.49.4__7.3.5!red-hat-developer-hub-backstage-plugin-bulk-import-backend
   version: 7.3.5
   backstage:
     role: backend-plugin

--- a/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import.yaml
+++ b/workspaces/bulk-import/metadata/red-hat-developer-hub-backstage-plugin-bulk-import.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-bulk-import'
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-bulk-import:bs_1.49.4__7.3.5!red-hat-developer-hub-backstage-plugin-bulk-import
   version: 7.3.5
   backstage:
     role: frontend-plugin

--- a/workspaces/extensions/metadata/rhdh-bsp-ctlg-backend-mod-extensions.yaml
+++ b/workspaces/extensions/metadata/rhdh-bsp-ctlg-backend-mod-extensions.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions"
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions:bs_1.49.4__0.17.1!red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions
   version: 0.17.1
   backstage:
     role: backend-plugin-module

--- a/workspaces/extensions/metadata/rhdh-bsp-extensions-backend.yaml
+++ b/workspaces/extensions/metadata/rhdh-bsp-extensions-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-extensions-backend"
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-extensions-backend:bs_1.49.4__0.17.1!red-hat-developer-hub-backstage-plugin-extensions-backend
   version: 0.17.1
   backstage:
     role: backend-plugin

--- a/workspaces/extensions/metadata/rhdh-bsp-extensions.yaml
+++ b/workspaces/extensions/metadata/rhdh-bsp-extensions.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-extensions'
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-extensions:bs_1.49.4__0.17.1!red-hat-developer-hub-backstage-plugin-extensions
   version: 0.17.1
   backstage:
     role: frontend-plugin

--- a/workspaces/global-header/metadata/red-hat-developer-hub-backstage-plugin-global-header.yaml
+++ b/workspaces/global-header/metadata/red-hat-developer-hub-backstage-plugin-global-header.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-global-header'
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-global-header:bs_1.49.4__1.21.6!red-hat-developer-hub-backstage-plugin-global-header
   version: 1.21.6
   backstage:
     role: frontend-plugin

--- a/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-dynamic-home-page.yaml
+++ b/workspaces/homepage/metadata/red-hat-developer-hub-backstage-plugin-dynamic-home-page.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-dynamic-home-page'
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-dynamic-home-page:bs_1.49.4__1.13.1!red-hat-developer-hub-backstage-plugin-dynamic-home-page
   version: 1.13.1
   backstage:
     role: frontend-plugin

--- a/workspaces/keycloak/metadata/backstage-community-plugin-catalog-backend-module-keycloak.yaml
+++ b/workspaces/keycloak/metadata/backstage-community-plugin-catalog-backend-module-keycloak.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-catalog
 spec:
   packageName: "@backstage-community/plugin-catalog-backend-module-keycloak"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-keycloak:bs_1.49.4__3.19.2!backstage-community-plugin-catalog-backend-module-keycloak
   version: 3.19.2
   backstage:
     role: backend-plugin-module

--- a/workspaces/pingidentity/metadata/backstage-community-plugin-catalog-backend-module-pingidentity.yaml
+++ b/workspaces/pingidentity/metadata/backstage-community-plugin-catalog-backend-module-pingidentity.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-catalog
 spec:
   packageName: "@backstage-community/plugin-catalog-backend-module-pingidentity"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-pingidentity:bs_1.52.0__0.13.0!backstage-community-plugin-catalog-backend-module-pingidentity
   version: 0.13.0
   backstage:
     role: backend-plugin-module

--- a/workspaces/quickstart/metadata/rhdh-bsp-quickstart.yaml
+++ b/workspaces/quickstart/metadata/rhdh-bsp-quickstart.yaml
@@ -15,7 +15,7 @@ metadata:
     backstage.io/source-location: url:https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/quickstart
 spec:
   packageName: '@red-hat-developer-hub/backstage-plugin-quickstart'
-  dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-quickstart
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-quickstart:bs_1.49.4__1.9.6!red-hat-developer-hub-backstage-plugin-quickstart
   version: 1.9.6
   backstage:
     role: frontend-plugin

--- a/workspaces/rbac/metadata/backstage-community-plugin-rbac.yaml
+++ b/workspaces/rbac/metadata/backstage-community-plugin-rbac.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@backstage-community/plugin-rbac'
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-rbac:bs_1.52.0__1.55.1!backstage-community-plugin-rbac
   version: 1.55.1
   backstage:
     role: frontend-plugin

--- a/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd.yaml
+++ b/workspaces/roadie-backstage-plugins/metadata/roadiehq-backstage-plugin-argo-cd.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@roadiehq/backstage-plugin-argo-cd"
-  dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-argo-cd:bs_1.49.4__2.12.5!roadiehq-backstage-plugin-argo-cd
   version: 2.12.5
   backstage:
     role: frontend-plugin

--- a/workspaces/scaffolder-backend-module-kubernetes/metadata/backstage-community-plugin-scaffolder-backend-module-kubernetes.yaml
+++ b/workspaces/scaffolder-backend-module-kubernetes/metadata/backstage-community-plugin-scaffolder-backend-module-kubernetes.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-templates
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-kubernetes"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-kubernetes:bs_1.49.4__2.17.1!backstage-community-plugin-scaffolder-backend-module-kubernetes
   version: 2.17.1
   backstage:
     role: backend-plugin-module

--- a/workspaces/scaffolder-backend-module-regex/metadata/backstage-community-plugin-scaffolder-backend-module-regex.yaml
+++ b/workspaces/scaffolder-backend-module-regex/metadata/backstage-community-plugin-scaffolder-backend-module-regex.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-templates
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-regex"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-regex-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-regex:bs_1.52.0__2.17.0!backstage-community-plugin-scaffolder-backend-module-regex
   version: 2.17.0
   backstage:
     role: backend-plugin-module

--- a/workspaces/scaffolder-relation-processor/metadata/bcp-ctlg-backend-mod-scaffolder-relation-processor.yaml
+++ b/workspaces/scaffolder-relation-processor/metadata/bcp-ctlg-backend-mod-scaffolder-relation-processor.yaml
@@ -17,7 +17,7 @@ metadata:
     - software-templates
 spec:
   packageName: "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor:bs_1.52.0__2.15.0!backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor
   version: 2.15.0
   backstage:
     role: backend-plugin-module

--- a/workspaces/tech-radar/metadata/backstage-community-plugin-tech-radar-backend.yaml
+++ b/workspaces/tech-radar/metadata/backstage-community-plugin-tech-radar-backend.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage-community/plugin-tech-radar-backend"
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-tech-radar-backend:bs_1.52.0__1.19.0!backstage-community-plugin-tech-radar-backend
   version: 1.19.0
   backstage:
     role: backend-plugin

--- a/workspaces/tech-radar/metadata/backstage-community-plugin-tech-radar.yaml
+++ b/workspaces/tech-radar/metadata/backstage-community-plugin-tech-radar.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@backstage-community/plugin-tech-radar'
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-tech-radar:bs_1.52.0__1.20.0!backstage-community-plugin-tech-radar
   version: 1.20.0
   backstage:
     role: frontend-plugin

--- a/workspaces/topology/metadata/backstage-community-plugin-topology.yaml
+++ b/workspaces/topology/metadata/backstage-community-plugin-topology.yaml
@@ -16,7 +16,7 @@ metadata:
   tags: []
 spec:
   packageName: '@backstage-community/plugin-topology'
-  dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-topology
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-topology:bs_1.52.0__2.15.0!backstage-community-plugin-topology
   version: 2.15.0
   backstage:
     role: frontend-plugin


### PR DESCRIPTION
Replace all `./dynamic-plugins/dist/` wrapper paths in metadata with `oci://ghcr.io` references, using the latest published tags from the container registry. This is a prerequisite for removing the wrapper source code from the rhdh repo.

Refs: [RHDHPLAN-256](https://redhat.atlassian.net/browse/RHDHPLAN-256), [RHDHPLAN-934](https://redhat.atlassian.net/browse/RHDHPLAN-934)