### PR TITLE
[release-1.9] chore(orchestrator): bump js-cookie to 3.0.8

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -69,6 +69,21 @@
    languageName: node
    linkType: hard
  
+@@ -15803,10 +15795,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"@types/js-cookie@npm:^2.2.6":
+-  version: 2.2.7
+-  resolution: "@types/js-cookie@npm:2.2.7"
+-  checksum: 851f47e94ca1fc43661d8f51614d67a613e7810c91b876d0a3b311ce72f7df800107fd02a08cb6948184e12c120b4f058edca2f50424d8798bdcffd6627281e3
++"@types/js-cookie@npm:^3.0.0":
++  version: 3.0.6
++  resolution: "@types/js-cookie@npm:3.0.6"
++  checksum: 272d551687547445cb210213c73e72e0e5d58ad73e2e444a65d688b8ff9425529779ee0cd6492aaa1f070161916d4254ef2b1a76d64179100437f60749d094ef
+   languageName: node
+   linkType: hard
+ 
 @@ -16112,14 +16104,14 @@
    linkType: hard
  
@@ -163,6 +178,21 @@
  "hast-util-parse-selector@npm:^2.0.0":
    version: 2.2.5
    resolution: "hast-util-parse-selector@npm:2.2.5"
+@@ -26578,10 +26579,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-cookie@npm:^2.2.1":
+-  version: 2.2.1
+-  resolution: "js-cookie@npm:2.2.1"
+-  checksum: 9b1fb980a1c5e624fd4b28ea4867bb30c71e04c4484bb3a42766344c533faa684de9498e443425479ec68609e96e27b60614bfe354877c449c631529b6d932f2
++"js-cookie@npm:^3.0.0":
++  version: 3.0.8
++  resolution: "js-cookie@npm:3.0.8"
++  checksum: 73ce2e57d352caf01b4ff40406fd474e7e2edd545a6fdcecbe8fb1d764ef761db99b40a2ca990473064f0519a6af0f2cfae30410c93fcb8bf2a4bc4215c5395d
+   languageName: node
+   linkType: hard
+ 
 @@ -27940,6 +27941,13 @@
    languageName: node
    linkType: hard
@@ -205,6 +235,35 @@
 -  checksum: 53bf83b9a726b05d43da35bb990dba7536759787dccea9a67b8f31be9df470ba17f1f1b982ca19956cfc7726f3ec7e0e883ca4ad93b5ec753cc025a637fc704f
 +    long: ^5.3.2
 +  checksum: 6d3f18324942f8cabf003b68b81a445e8089a3f89cfae227feedbe4bfe8aea8629f6332cbe6176842cbe645704e4a25d4773b55c3b63d923034b3e6b4eacbb78
+   languageName: node
+   linkType: hard
+ 
+@@ -33075,15 +33082,15 @@
+   linkType: hard
+ 
+ "react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0, react-use@npm:^17.5.0":
+-  version: 17.6.0
+-  resolution: "react-use@npm:17.6.0"
++  version: 17.6.1
++  resolution: "react-use@npm:17.6.1"
+   dependencies:
+-    "@types/js-cookie": ^2.2.6
++    "@types/js-cookie": ^3.0.0
+     "@xobotyi/scrollbar-width": ^1.9.5
+     copy-to-clipboard: ^3.3.1
+     fast-deep-equal: ^3.1.3
+     fast-shallow-equal: ^1.0.0
+-    js-cookie: ^2.2.1
++    js-cookie: ^3.0.0
+     nano-css: ^5.6.2
+     react-universal-interface: ^0.6.2
+     resize-observer-polyfill: ^1.5.1
+@@ -33095,7 +33102,7 @@
+   peerDependencies:
+     react: "*"
+     react-dom: "*"
+-  checksum: c76de18b56b554bfbb28199e4ad4098f4e4ab15f0d3cefef661a7a5e6a4c167ae85390fc7bc648c34b80c17498abf1e8223d7078f3e51c09e4da70e11a41a54e
++  checksum: 6c30dd1878ba4f3c18284f1de1eca3c7f5350c9e99b1cdd254b77d809eac6c1fc273edb6ac49a5e281ec64ea36ea515e011b53d1af857a3505c8dd0f6e8b557b
    languageName: node
    linkType: hard
  

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -30,6 +30,10 @@ backports:
                 └─┬ request@2.88.2
                   └── form-data@2.3.3
   - cve_ids:
+      - CVE-2026-46625
+    package: js-cookie
+    patch_version: 3.0.8
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5


### PR DESCRIPTION
- Bumps js-cookie to 3.0.8 to fix CVE-2026-46625
- Fixes [RHIDP-15066](https://redhat.atlassian.net/browse/RHIDP-15066)