### PR TITLE
chore: update loki to GA status in DPY

### DIFF
--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -104,8 +104,8 @@ packages:
     support: "generally-available"
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend'
     support: "generally-available"
-  # - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki'
-  #   support: "tech-preview"
+  - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki'
+    support: "generally-available"
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets'
     support: "generally-available"
   - package: '@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-orchestrator'


### PR DESCRIPTION
Loki has been GA since 1.10 (see [metadata](https://github.com/redhat-developer/rhdh-plugin-export-overlays/blob/main/workspaces/orchestrator/metadata/rhdh-bsp-orchestrator-backend-mod-loki.yaml#L26)).  We should update DPY to reflect this.  

Needs backport to 1.10