### PR TITLE
chore: bump e2e-test-utils to 2.1.3 across all workspaces

### DIFF
--- a/workspaces/acr/e2e-tests/package.json
+++ b/workspaces/acr/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/acr/e2e-tests/yarn.lock
+++ b/workspaces/acr/e2e-tests/yarn.lock
@@ -282,9 +282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -307,7 +307,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -551,7 +551,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/adoption-insights/e2e-tests/package.json
+++ b/workspaces/adoption-insights/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "1.57.0",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/adoption-insights/e2e-tests/yarn.lock
+++ b/workspaces/adoption-insights/e2e-tests/yarn.lock
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -379,7 +379,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -765,7 +765,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:1.57.0"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/analytics/e2e-tests/package.json
+++ b/workspaces/analytics/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/analytics/e2e-tests/yarn.lock
+++ b/workspaces/analytics/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -577,7 +577,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/app-defaults/e2e-tests/package.json
+++ b/workspaces/app-defaults/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/app-defaults/e2e-tests/yarn.lock
+++ b/workspaces/app-defaults/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -567,7 +567,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/argocd/e2e-tests/package.json
+++ b/workspaces/argocd/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/argocd/e2e-tests/yarn.lock
+++ b/workspaces/argocd/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -572,7 +572,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/backstage/e2e-tests/package.json
+++ b/workspaces/backstage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/backstage/e2e-tests/yarn.lock
+++ b/workspaces/backstage/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -626,7 +626,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/bulk-import/e2e-tests/package.json
+++ b/workspaces/bulk-import/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "^1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/bulk-import/e2e-tests/yarn.lock
+++ b/workspaces/bulk-import/e2e-tests/yarn.lock
@@ -361,9 +361,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -386,7 +386,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -991,7 +991,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:^1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/extensions/e2e-tests/package.json
+++ b/workspaces/extensions/e2e-tests/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "dotenv": "17.4.1",
     "eslint": "10.2.0",

--- a/workspaces/extensions/e2e-tests/yarn.lock
+++ b/workspaces/extensions/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1021,7 +1021,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:17.4.1"
     eslint: "npm:10.2.0"

--- a/workspaces/github/e2e-tests/package.json
+++ b/workspaces/github/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/github/e2e-tests/yarn.lock
+++ b/workspaces/github/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1187,7 +1187,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/global-header/e2e-tests/package.json
+++ b/workspaces/global-header/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/global-header/e2e-tests/yarn.lock
+++ b/workspaces/global-header/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1246,7 +1246,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/homepage/e2e-tests/package.json
+++ b/workspaces/homepage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/homepage/e2e-tests/yarn.lock
+++ b/workspaces/homepage/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1312,7 +1312,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/keycloak/e2e-tests/package.json
+++ b/workspaces/keycloak/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/keycloak/e2e-tests/yarn.lock
+++ b/workspaces/keycloak/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1482,7 +1482,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/lightspeed/e2e-tests/package.json
+++ b/workspaces/lightspeed/e2e-tests/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/lightspeed/e2e-tests/yarn.lock
+++ b/workspaces/lightspeed/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1415,7 +1415,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/orchestrator/e2e-tests/package.json
+++ b/workspaces/orchestrator/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "dotenv": "16.6.1",
     "eslint": "10.2.0",

--- a/workspaces/orchestrator/e2e-tests/yarn.lock
+++ b/workspaces/orchestrator/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1771,7 +1771,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:16.6.1"
     eslint: "npm:10.2.0"

--- a/workspaces/quay/e2e-tests/package.json
+++ b/workspaces/quay/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quay/e2e-tests/yarn.lock
+++ b/workspaces/quay/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/quickstart/e2e-tests/package.json
+++ b/workspaces/quickstart/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quickstart/e2e-tests/yarn.lock
+++ b/workspaces/quickstart/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1955,7 +1955,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/rbac/e2e-tests/package.json
+++ b/workspaces/rbac/e2e-tests/package.json
@@ -26,7 +26,7 @@
     "@backstage-community/plugin-rbac-common": "1.26.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/rbac/e2e-tests/yarn.lock
+++ b/workspaces/rbac/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1933,7 +1933,7 @@ __metadata:
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/roadie-backstage-plugins/e2e-tests/package.json
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10c0/baa4ac45c6daa9c11831d5dec40b423d071754ad148c6217b6ef1be2051c7d8cbfab55fb11778dc6957a2cc8b854f5f97b39ede7e48d5f41187f4462c0ff9e11
+  checksum: 10c0/1af02f980aaadde041c110f827788187e360b498be5dec0aef18e6862e9d2f8f070df3c7dee97380b5bef1a95f353feae4db0d08b133a2f41453764ca4fffda9
   languageName: node
   linkType: hard
 
@@ -1936,7 +1936,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scorecard/e2e-tests/package.json
+++ b/workspaces/scorecard/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scorecard/e2e-tests/yarn.lock
+++ b/workspaces/scorecard/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tekton/e2e-tests/package.json
+++ b/workspaces/tekton/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tekton/e2e-tests/yarn.lock
+++ b/workspaces/tekton/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -2097,7 +2097,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/theme/e2e-tests/package.json
+++ b/workspaces/theme/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/theme/e2e-tests/yarn.lock
+++ b/workspaces/theme/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -2106,7 +2106,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/topology/e2e-tests/package.json
+++ b/workspaces/topology/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.2",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/topology/e2e-tests/yarn.lock
+++ b/workspaces/topology/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.2"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/4b2682d13de67fe2c16a197580d7579ddc71928f95589460404494403bbdbef91e617b5d9eb075c79517973fc2866ddb1d4b55f24f377a89d603ca0490b2ff6b
+  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
   languageName: node
   linkType: hard
 
@@ -2133,7 +2133,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.2"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
## Summary
- Bumps `@red-hat-developer-hub/e2e-test-utils` to `2.1.3` in all 24 workspace e2e-tests
- Updates all `yarn.lock` files accordingly
- `2.1.3` restores `catalog.providers.keycloakOrg` on the Keycloak auth profile so OIDC sign-in can resolve `User` entities after the OCI metadata migration (fixes `unable to resolve user identity`)

## Related
- e2e-test-utils fix: https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/125

## Test plan
- [ ] Comment `/test e2e-ocp-helm-nightly` on this PR to run E2E across **all** workspaces (nightly mode uses released OCI refs from metadata)
- [ ] Optionally also `/test e2e-ocp-helm` — PR check runs workspaces with e2e changes (this PR touches all of them)
- [ ] Spot-check Keycloak-auth suites (e.g. backstage notifications / github-events / kubernetes) for successful login past `User/default/test1`


Made with [Cursor](https://cursor.com)