### PR TITLE
chore(fullsend): register review agent with E2E skills

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -12,6 +12,8 @@ agents:
       source: rhdh/harness/code.yaml
     - name: fix
       source: rhdh/harness/fix.yaml
+    - name: review
+      source: rhdh/harness/review.yaml
 roles:
     - triage
     - coder

--- a/.fullsend/rhdh/harness/review.yaml
+++ b/.fullsend/rhdh/harness/review.yaml
@@ -1,0 +1,4 @@
+base: https://raw.githubusercontent.com/fullsend-ai/agents/4bbe4f50ed8e33c60539eaa30ddc320edf8bcda0/harness/review.yaml#sha256=08456e534c7d1251b3a3b2bc1236643403809ecab27832c273764769f219a45b
+skills:
+  - skills/e2e-failure-analysis
+  - skills/playwright-trace


### PR DESCRIPTION
## Summary

- Add repo-level review harness (`.fullsend/rhdh/harness/review.yaml`) extending upstream base with `e2e-failure-analysis` and `playwright-trace` skills
- Register `review` as a repo-owned agent in `.fullsend/config.yaml`

Previously, `/fs-review` resolved to the upstream review harness which only includes 4 standard review skills. When asked to analyze E2E failures (e.g. `/fs-review analyze last failed e2e-ocp-helm check`), the agent couldn't use the repo's E2E skills because they weren't wired into its harness.

See discussion on [PR #2778](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2778).

## Test plan

- [ ] `/fs-review` on a PR with an E2E failure instruction loads `e2e-failure-analysis` skill
- [ ] Standard `/fs-review` (no E2E instruction) still works normally with all 6 skills available

🤖 Generated with [Claude Code](https://claude.com/claude-code)