### PR TITLE
[release-1.9] chore: bump rhdh-cli version to 1.9.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
     "backstage": "1.45.3",
     "node": "22.19.0",
-    "cli": "1.9.1",
+    "cli": "1.9.2",
     "cliPackage": "@red-hat-developer-hub/cli"
 }


### PR DESCRIPTION
## Summary
- Bumps the `cli` version in `versions.json` from `1.9.1` to `1.9.2` to pick up https://github.com/redhat-developer/rhdh-cli/pull/138 to resolve https://redhat.atlassian.net/browse/RHDHBUGS-3474 on release-1.9 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)