### PR TITLE
[release-1.10] chore: bump rhdh-cli version to 1.10.8

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
     "backstage": "1.49.4",
     "node": "24.14.0",
-    "cli": "1.10.7",
+    "cli": "1.10.8",
     "cliPackage": "@red-hat-developer-hub/cli"
 }


### PR DESCRIPTION
## Summary
- Bumps `@red-hat-developer-hub/cli` version from 1.10.7 to 1.10.8 in `versions.json` to pick up https://github.com/redhat-developer/rhdh-cli/pull/140 to resolve https://redhat.atlassian.net/browse/RHDHBUGS-3474 on release-1.10 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)