### PR TITLE
chore: bump rhdh-cli to 1.11.2 (and Backstage 1.52.0)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
     "backstage": "1.52.0",
     "node": "24.14.0",
-    "cli": "1.10.7",
+    "cli": "1.11.2",
     "cliPackage": "@red-hat-developer-hub/cli"
 }


### PR DESCRIPTION
## Summary
- Bumps `@red-hat-developer-hub/cli` from 1.10.7 to 1.11.2 in `versions.json` to pick up https://github.com/redhat-developer/rhdh-cli/pull/141 to resolve https://redhat.atlassian.net/browse/RHDHBUGS-3474 on main and use Backstage 1.52 based CLI tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)