### PR TITLE
chore(deps): [release-1.10][lightspeed] fix for js-cookie 3.0.8

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,20 +29,35 @@
    languageName: node
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
+   languageName: node
+   linkType: hard
+ 
+@@ -14587,10 +14579,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"@types/js-cookie@npm:^2.2.6":
+-  version: 2.2.7
+-  resolution: "@types/js-cookie@npm:2.2.7"
+-  checksum: 10c0/29196c6829982b5efa79117122a7d62cf4bc2f6397ce8eac1539319ff5dce3b44b2d86f2ac064f2ed3488fb24439358f24af6914fde5c5c4bab9a85728a13a6f
++"@types/js-cookie@npm:^3.0.0":
++  version: 3.0.6
++  resolution: "@types/js-cookie@npm:3.0.6"
++  checksum: 10c0/173afaf5ea9d86c22395b9d2a00b6adb0006dcfef165d6dcb0395cdc32f5a5dcf9c3c60f97194119963a15849b8f85121e1ae730b03e40bc0c29b84396ba22f9
+   languageName: node
+   linkType: hard
+ 
 @@ -21220,13 +21212,13 @@
    linkType: hard
  
@@ -113,22 +128,22 @@
    languageName: node
    linkType: hard
  
-@@ -22822,6 +22814,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
+@@ -22825,6 +22817,15 @@
+   languageName: node
+   linkType: hard
+ 
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: "npm:^1.1.2"
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
-   languageName: node
-   linkType: hard
- 
++  languageName: node
++  linkType: hard
++
+ "hast-util-from-parse5@npm:^7.0.0":
+   version: 7.1.2
+   resolution: "hast-util-from-parse5@npm:7.1.2"
 @@ -23818,20 +23819,10 @@
    languageName: node
    linkType: hard
@@ -154,6 +169,21 @@
    languageName: node
    linkType: hard
  
+@@ -25177,10 +25168,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-cookie@npm:^2.2.1":
+-  version: 2.2.1
+-  resolution: "js-cookie@npm:2.2.1"
+-  checksum: 10c0/ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
++"js-cookie@npm:^3.0.0":
++  version: 3.0.8
++  resolution: "js-cookie@npm:3.0.8"
++  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
+   languageName: node
+   linkType: hard
+ 
 @@ -25246,7 +25237,7 @@
    languageName: node
    linkType: hard
@@ -163,20 +193,20 @@
    version: 1.1.0
    resolution: "jsbn@npm:1.1.0"
    checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
-@@ -26426,6 +26417,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
-+  languageName: node
-+  linkType: hard
-+
+@@ -26429,6 +26420,13 @@
+   languageName: node
+   linkType: hard
+ 
 +"long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
-   languageName: node
-   linkType: hard
- 
++  languageName: node
++  linkType: hard
++
+ "longest-streak@npm:^3.0.0":
+   version: 3.1.0
+   resolution: "longest-streak@npm:3.1.0"
 @@ -27950,7 +27948,7 @@
    languageName: node
    linkType: hard
@@ -212,6 +242,37 @@
 -  checksum: 10c0/220df6c3cf6d2346748639a9b0b688fecc994bff9fee7018a93167e8cd45ab0ee3b4270d9eaa6be33a11adb46514ef9dce7e8217fd578c36726a9e70b96327cd
 +    long: "npm:^5.3.2"
 +  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
+   languageName: node
+   linkType: hard
+ 
+@@ -32102,16 +32099,16 @@
+   languageName: node
+   linkType: hard
+ 
+-"react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0":
+-  version: 17.5.1
+-  resolution: "react-use@npm:17.5.1"
++"react-use@npm:17.6.1":
++  version: 17.6.1
++  resolution: "react-use@npm:17.6.1"
+   dependencies:
+-    "@types/js-cookie": "npm:^2.2.6"
++    "@types/js-cookie": "npm:^3.0.0"
+     "@xobotyi/scrollbar-width": "npm:^1.9.5"
+     copy-to-clipboard: "npm:^3.3.1"
+     fast-deep-equal: "npm:^3.1.3"
+     fast-shallow-equal: "npm:^1.0.0"
+-    js-cookie: "npm:^2.2.1"
++    js-cookie: "npm:^3.0.0"
+     nano-css: "npm:^5.6.2"
+     react-universal-interface: "npm:^0.6.2"
+     resize-observer-polyfill: "npm:^1.5.1"
+@@ -32123,7 +32120,7 @@
+   peerDependencies:
+     react: "*"
+     react-dom: "*"
+-  checksum: 10c0/3d6a8f46539b32698d31600239e72b5c23376a5343d0d687c6520e14532ed7f5c72c9b99d222be4eeacb0401ce3ae763d5648d0476440c8b4a6afbd56dc98bfa
++  checksum: 10c0/8b3babd9f7db14624e172d22c2fb30f091d785e97d0aed84e47e52a3ca8dbdc0c094ab797bbd0e754ff2f92be82357c7a46e08dbc85244edfefa21475f760cdf
    languageName: node
    linkType: hard
  

--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,21 +29,92 @@
    languageName: node
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
-@@ -21220,13 +21212,13 @@
+   languageName: node
+   linkType: hard
+ 
+@@ -12019,15 +12011,15 @@
+   languageName: node
+   linkType: hard
+ 
+-"@segment/analytics-core@npm:1.8.1":
+-  version: 1.8.1
+-  resolution: "@segment/analytics-core@npm:1.8.1"
++"@segment/analytics-core@npm:1.8.3":
++  version: 1.8.3
++  resolution: "@segment/analytics-core@npm:1.8.3"
+   dependencies:
+     "@lukeed/uuid": "npm:^2.0.0"
+     "@segment/analytics-generic-utils": "npm:1.2.0"
+     dset: "npm:^3.1.4"
+     tslib: "npm:^2.4.1"
+-  checksum: 10c0/b842ea655b3c703059c0ab453d486127c4587fb372cd398f8543b7ce04d970301a0621bcd40c59d596ce0bbad6b8e36c87f25d3c0599eecf65890e1ae155fa36
++  checksum: 10c0/ae1a807a093b6e20a429e80b95fc3869ddcf7e8c4e37751d607476835df82a331583c092bee4f7f0116ae9a3f550d687fa5478165c8c2583177249aa628eb2e1
+   languageName: node
+   linkType: hard
+ 
+@@ -12041,20 +12033,30 @@
+   linkType: hard
+ 
+ "@segment/analytics-next@npm:^1.76.0":
+-  version: 1.79.0
+-  resolution: "@segment/analytics-next@npm:1.79.0"
++  version: 1.84.1
++  resolution: "@segment/analytics-next@npm:1.84.1"
+   dependencies:
+     "@lukeed/uuid": "npm:^2.0.0"
+-    "@segment/analytics-core": "npm:1.8.1"
++    "@segment/analytics-core": "npm:1.8.3"
+     "@segment/analytics-generic-utils": "npm:1.2.0"
++    "@segment/analytics-page-tools": "npm:1.0.0"
+     "@segment/analytics.js-video-plugins": "npm:^0.2.1"
+     "@segment/facade": "npm:^3.4.9"
+     dset: "npm:^3.1.4"
+-    js-cookie: "npm:3.0.1"
++    js-cookie: "npm:^3.0.7"
+     node-fetch: "npm:^2.6.7"
+     tslib: "npm:^2.4.1"
+     unfetch: "npm:^4.1.0"
+-  checksum: 10c0/49413e549af8aef20e62486b1e3117526fa55f87dcf290ff19eadc14067c494b5aedeb280c607d7cbfe9fd1911e54c5aad655029566e31d392a0432ee1b6235e
++  checksum: 10c0/fb10b9ed649055bdf72e0cc365de7f7906fa77f4c4a0ca7e0ce440b7b0821a5c2ef232c9f6d3a5dfcd252520b5f660db11c00a8cec1cc356b34e8db588002f3f
++  languageName: node
++  linkType: hard
++
++"@segment/analytics-page-tools@npm:1.0.0":
++  version: 1.0.0
++  resolution: "@segment/analytics-page-tools@npm:1.0.0"
++  dependencies:
++    tslib: "npm:^2.4.1"
++  checksum: 10c0/4f9fa9489c7a299501bbbf646f6b791de97932dd55a5486e9aa8b19d182b632991defabb33b8c2914f719876591871cef85b94ee1fe1158851b21d3bd88a229a
+   languageName: node
+   linkType: hard
+ 
+@@ -14587,10 +14589,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"@types/js-cookie@npm:^2.2.6":
+-  version: 2.2.7
+-  resolution: "@types/js-cookie@npm:2.2.7"
+-  checksum: 10c0/29196c6829982b5efa79117122a7d62cf4bc2f6397ce8eac1539319ff5dce3b44b2d86f2ac064f2ed3488fb24439358f24af6914fde5c5c4bab9a85728a13a6f
++"@types/js-cookie@npm:^3.0.0":
++  version: 3.0.6
++  resolution: "@types/js-cookie@npm:3.0.6"
++  checksum: 10c0/173afaf5ea9d86c22395b9d2a00b6adb0006dcfef165d6dcb0395cdc32f5a5dcf9c3c60f97194119963a15849b8f85121e1ae730b03e40bc0c29b84396ba22f9
+   languageName: node
+   linkType: hard
+ 
+@@ -21220,13 +21222,13 @@
    linkType: hard
  
  "express-rate-limit@npm:^8.2.2":
@@ -61,7 +132,7 @@
    languageName: node
    linkType: hard
  
-@@ -21408,9 +21400,9 @@
+@@ -21408,9 +21410,9 @@
    linkType: hard
  
  "fast-uri@npm:^3.0.1":
@@ -74,7 +145,7 @@
    languageName: node
    linkType: hard
  
-@@ -21802,29 +21794,29 @@
+@@ -21802,29 +21804,29 @@
    linkType: hard
  
  "form-data@npm:^2.5.5":
@@ -113,33 +184,37 @@
    languageName: node
    linkType: hard
  
-@@ -22822,6 +22814,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
-+"hasown@npm:^2.0.4":
+@@ -22816,12 +22818,12 @@
+   languageName: node
+   linkType: hard
+ 
+-"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
+-  version: 2.0.2
+-  resolution: "hasown@npm:2.0.2"
++"hasown@npm:^2.0.0, hasown@npm:^2.0.2, hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
-+  dependencies:
-+    function-bind: "npm:^1.1.2"
+   dependencies:
+     function-bind: "npm:^1.1.2"
+-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
    languageName: node
    linkType: hard
  
-@@ -23818,20 +23819,10 @@
-   languageName: node
-   linkType: hard
- 
+@@ -23815,23 +23817,13 @@
+     redis-parser: "npm:^3.0.0"
+     standard-as-callback: "npm:^2.1.0"
+   checksum: 10c0/0884103c9f569b598a3024edc8cae6fea3ece85559a3b1eeb84d8fdb52c4b2ed097eb4e082b8a66b3fae65b38f0e305026979c95e6990ae9a2e07c9b3df5da8b
+-  languageName: node
+-  linkType: hard
+-
 -"ip-address@npm:10.1.0":
 -  version: 10.1.0
 -  resolution: "ip-address@npm:10.1.0"
 -  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
--  languageName: node
--  linkType: hard
--
+   languageName: node
+   linkType: hard
+ 
 -"ip-address@npm:^9.0.5":
 -  version: 9.0.5
 -  resolution: "ip-address@npm:9.0.5"
@@ -154,7 +229,29 @@
    languageName: node
    linkType: hard
  
-@@ -25246,7 +25237,7 @@
+@@ -25170,17 +25162,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-cookie@npm:3.0.1":
+-  version: 3.0.1
+-  resolution: "js-cookie@npm:3.0.1"
+-  checksum: 10c0/a7dab91286c49610fb198bcc0d78fbafe9be869cf3cea6f7eaea515abdfdc9d347982fe22316e34666b479a0701119482d46faa3a350a3a3404eb954405edf72
+-  languageName: node
+-  linkType: hard
+-
+-"js-cookie@npm:^2.2.1":
+-  version: 2.2.1
+-  resolution: "js-cookie@npm:2.2.1"
+-  checksum: 10c0/ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
++"js-cookie@npm:^3.0.0, js-cookie@npm:^3.0.7":
++  version: 3.0.8
++  resolution: "js-cookie@npm:3.0.8"
++  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
+   languageName: node
+   linkType: hard
+ 
+@@ -25246,7 +25231,7 @@
    languageName: node
    linkType: hard
  
@@ -163,21 +260,22 @@
    version: 1.1.0
    resolution: "jsbn@npm:1.1.0"
    checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
-@@ -26426,6 +26417,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
-+  languageName: node
-+  linkType: hard
-+
-+"long@npm:^5.3.2":
+@@ -26422,10 +26407,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"long@npm:^5.0.0, long@npm:^5.2.1":
+-  version: 5.2.3
+-  resolution: "long@npm:5.2.3"
+-  checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++"long@npm:^5.0.0, long@npm:^5.2.1, long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
    languageName: node
    linkType: hard
  
-@@ -27950,7 +27948,7 @@
+@@ -27950,7 +27935,7 @@
    languageName: node
    linkType: hard
  
@@ -186,7 +284,7 @@
    version: 2.1.35
    resolution: "mime-types@npm:2.1.35"
    dependencies:
-@@ -31078,22 +31076,21 @@
+@@ -31078,22 +31063,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
@@ -215,7 +313,36 @@
    languageName: node
    linkType: hard
  
-@@ -33789,12 +33786,12 @@
+@@ -32103,15 +32087,15 @@
+   linkType: hard
+ 
+ "react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0":
+-  version: 17.5.1
+-  resolution: "react-use@npm:17.5.1"
++  version: 17.6.1
++  resolution: "react-use@npm:17.6.1"
+   dependencies:
+-    "@types/js-cookie": "npm:^2.2.6"
++    "@types/js-cookie": "npm:^3.0.0"
+     "@xobotyi/scrollbar-width": "npm:^1.9.5"
+     copy-to-clipboard: "npm:^3.3.1"
+     fast-deep-equal: "npm:^3.1.3"
+     fast-shallow-equal: "npm:^1.0.0"
+-    js-cookie: "npm:^2.2.1"
++    js-cookie: "npm:^3.0.0"
+     nano-css: "npm:^5.6.2"
+     react-universal-interface: "npm:^0.6.2"
+     resize-observer-polyfill: "npm:^1.5.1"
+@@ -32123,7 +32107,7 @@
+   peerDependencies:
+     react: "*"
+     react-dom: "*"
+-  checksum: 10c0/3d6a8f46539b32698d31600239e72b5c23376a5343d0d687c6520e14532ed7f5c72c9b99d222be4eeacb0401ce3ae763d5648d0476440c8b4a6afbd56dc98bfa
++  checksum: 10c0/8b3babd9f7db14624e172d22c2fb30f091d785e97d0aed84e47e52a3ca8dbdc0c094ab797bbd0e754ff2f92be82357c7a46e08dbc85244edfefa21475f760cdf
+   languageName: node
+   linkType: hard
+ 
+@@ -33789,12 +33773,12 @@
    linkType: hard
  
  "socks@npm:^2.6.2, socks@npm:^2.8.3":
@@ -232,7 +359,7 @@
    languageName: node
    linkType: hard
  
-@@ -33958,7 +33955,7 @@
+@@ -33958,7 +33942,7 @@
    languageName: node
    linkType: hard
  
@@ -241,7 +368,7 @@
    version: 1.1.3
    resolution: "sprintf-js@npm:1.1.3"
    checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-@@ -35999,9 +35996,9 @@
+@@ -35999,9 +35983,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.24.5":
@@ -254,7 +381,7 @@
    languageName: node
    linkType: hard
  
-@@ -37294,8 +37291,8 @@
+@@ -37294,8 +37278,8 @@
    linkType: hard
  
  "ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
@@ -265,7 +392,7 @@
    peerDependencies:
      bufferutil: ^4.0.1
      utf-8-validate: ">=5.0.2"
-@@ -37304,7 +37301,7 @@
+@@ -37304,7 +37288,7 @@
        optional: true
      utf-8-validate:
        optional: true

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -18,6 +18,10 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-46625
+    package: js-cookie
+    patch_version: 3.0.8
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -18,6 +18,17 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-46625
+    package: js-cookie
+    patch_version: 3.0.1, 3.0.8
+    notes: |-
+      [auto] js-cookie@3.0.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ @red-hat-developer-hub/backstage-plugin-lightspeed@2.8.6
+          └─┬ @patternfly/chatbot@6.6.0-prerelease.6
+            └─┬ @segment/analytics-next@1.79.0
+              └── js-cookie@3.0.1
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5


### PR DESCRIPTION
It partial fixes js-cookie by upgrading it to 3.0.8 or higher.
Fixing CVE-2026-46625 
https://redhat.atlassian.net/browse/RHIDP-15065

**dependency status**
```
@internal/lightspeed@1.0.0 /Users/alizardo/Documents/engineering/github/rhdh-plugins/workspaces/lightspeed
└─┬ @red-hat-developer-hub/backstage-plugin-lightspeed@2.8.6 -> ./plugins/lightspeed
  ├─┬ @backstage/core-components@0.18.8
  │ └─┬ @react-hookz/web@24.0.4
  │   └── js-cookie@3.0.8 deduped
  ├─┬ @patternfly/chatbot@6.6.0-prerelease.6
  │ └─┬ @segment/analytics-next@1.84.1
  │   └── js-cookie@3.0.8 deduped
  └─┬ react-use@17.6.1
    └── js-cookie@3.0.8
```