### PR TITLE
chore(deps): [release-1.10][orchestrator] patch js-cookie v3.0.8

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -40,20 +40,20 @@
    languageName: node
    linkType: hard
  
-@@ -10983,13 +10982,6 @@
-   version: 1.0.2
-   resolution: "@protobufjs/float@npm:1.0.2"
-   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
--  languageName: node
--  linkType: hard
--
+@@ -10986,13 +10985,6 @@
+   languageName: node
+   linkType: hard
+ 
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
-   languageName: node
-   linkType: hard
- 
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
 @@ -11007,10 +10999,10 @@
    languageName: node
    linkType: hard
@@ -66,6 +66,21 @@
 +  version: 1.1.2
 +  resolution: "@protobufjs/utf8@npm:1.1.2"
 +  checksum: 10c0/975c6e2c0319bd50c17531d186b537a88cb4d3205e3ca9297cd842b631d341da0ee3ff16be8656cd2660756dc753b29c8a6a14c0ad8ed602c1f91ddf22e7b3f3
+   languageName: node
+   linkType: hard
+ 
+@@ -16995,10 +16987,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"@types/js-cookie@npm:^2.2.6":
+-  version: 2.2.7
+-  resolution: "@types/js-cookie@npm:2.2.7"
+-  checksum: 10c0/29196c6829982b5efa79117122a7d62cf4bc2f6397ce8eac1539319ff5dce3b44b2d86f2ac064f2ed3488fb24439358f24af6914fde5c5c4bab9a85728a13a6f
++"@types/js-cookie@npm:^3.0.0":
++  version: 3.0.6
++  resolution: "@types/js-cookie@npm:3.0.6"
++  checksum: 10c0/173afaf5ea9d86c22395b9d2a00b6adb0006dcfef165d6dcb0395cdc32f5a5dcf9c3c60f97194119963a15849b8f85121e1ae730b03e40bc0c29b84396ba22f9
    languageName: node
    linkType: hard
  
@@ -137,6 +152,21 @@
    languageName: node
    linkType: hard
  
+@@ -28080,10 +28081,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-cookie@npm:^2.2.1":
+-  version: 2.2.1
+-  resolution: "js-cookie@npm:2.2.1"
+-  checksum: 10c0/ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
++"js-cookie@npm:^3.0.0":
++  version: 3.0.8
++  resolution: "js-cookie@npm:3.0.8"
++  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
+   languageName: node
+   linkType: hard
+ 
 @@ -29427,6 +29428,13 @@
    version: 5.2.3
    resolution: "long@npm:5.2.3"
@@ -179,6 +209,37 @@
 -  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
 +    long: "npm:^5.3.2"
 +  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
+   languageName: node
+   linkType: hard
+ 
+@@ -34660,16 +34667,16 @@
+   languageName: node
+   linkType: hard
+ 
+-"react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0, react-use@npm:^17.5.0":
+-  version: 17.6.0
+-  resolution: "react-use@npm:17.6.0"
++"react-use@npm:17.6.1":
++  version: 17.6.1
++  resolution: "react-use@npm:17.6.1"
+   dependencies:
+-    "@types/js-cookie": "npm:^2.2.6"
++    "@types/js-cookie": "npm:^3.0.0"
+     "@xobotyi/scrollbar-width": "npm:^1.9.5"
+     copy-to-clipboard: "npm:^3.3.1"
+     fast-deep-equal: "npm:^3.1.3"
+     fast-shallow-equal: "npm:^1.0.0"
+-    js-cookie: "npm:^2.2.1"
++    js-cookie: "npm:^3.0.0"
+     nano-css: "npm:^5.6.2"
+     react-universal-interface: "npm:^0.6.2"
+     resize-observer-polyfill: "npm:^1.5.1"
+@@ -34681,7 +34688,7 @@
+   peerDependencies:
+     react: "*"
+     react-dom: "*"
+-  checksum: 10c0/d122199f3edd056bfd866837b0f19a44366e77c7535c6c2c5eb5f400409eae4c9b1fe73c9d35073c8434080eee388ca8fe49a68d09d6f794ccaa35a4ae2112a9
++  checksum: 10c0/8b3babd9f7db14624e172d22c2fb30f091d785e97d0aed84e47e52a3ca8dbdc0c094ab797bbd0e754ff2f92be82357c7a46e08dbc85244edfefa21475f760cdf
    languageName: node
    linkType: hard
  

--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -40,20 +40,20 @@
    languageName: node
    linkType: hard
  
-@@ -10983,13 +10982,6 @@
-   version: 1.0.2
-   resolution: "@protobufjs/float@npm:1.0.2"
-   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
--  languageName: node
--  linkType: hard
--
+@@ -10986,13 +10985,6 @@
+   languageName: node
+   linkType: hard
+ 
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
-   languageName: node
-   linkType: hard
- 
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
 @@ -11007,10 +10999,10 @@
    languageName: node
    linkType: hard
@@ -66,6 +66,21 @@
 +  version: 1.1.2
 +  resolution: "@protobufjs/utf8@npm:1.1.2"
 +  checksum: 10c0/975c6e2c0319bd50c17531d186b537a88cb4d3205e3ca9297cd842b631d341da0ee3ff16be8656cd2660756dc753b29c8a6a14c0ad8ed602c1f91ddf22e7b3f3
+   languageName: node
+   linkType: hard
+ 
+@@ -16995,10 +16987,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"@types/js-cookie@npm:^2.2.6":
+-  version: 2.2.7
+-  resolution: "@types/js-cookie@npm:2.2.7"
+-  checksum: 10c0/29196c6829982b5efa79117122a7d62cf4bc2f6397ce8eac1539319ff5dce3b44b2d86f2ac064f2ed3488fb24439358f24af6914fde5c5c4bab9a85728a13a6f
++"@types/js-cookie@npm:^3.0.0":
++  version: 3.0.6
++  resolution: "@types/js-cookie@npm:3.0.6"
++  checksum: 10c0/173afaf5ea9d86c22395b9d2a00b6adb0006dcfef165d6dcb0395cdc32f5a5dcf9c3c60f97194119963a15849b8f85121e1ae730b03e40bc0c29b84396ba22f9
    languageName: node
    linkType: hard
  
@@ -137,6 +152,21 @@
    languageName: node
    linkType: hard
  
+@@ -28080,10 +28081,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-cookie@npm:^2.2.1":
+-  version: 2.2.1
+-  resolution: "js-cookie@npm:2.2.1"
+-  checksum: 10c0/ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
++"js-cookie@npm:^3.0.0":
++  version: 3.0.8
++  resolution: "js-cookie@npm:3.0.8"
++  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
+   languageName: node
+   linkType: hard
+ 
 @@ -29427,6 +29428,13 @@
    version: 5.2.3
    resolution: "long@npm:5.2.3"
@@ -179,6 +209,35 @@
 -  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
 +    long: "npm:^5.3.2"
 +  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
+   languageName: node
+   linkType: hard
+ 
+@@ -34661,15 +34668,15 @@
+   linkType: hard
+ 
+ "react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0, react-use@npm:^17.5.0":
+-  version: 17.6.0
+-  resolution: "react-use@npm:17.6.0"
++  version: 17.6.1
++  resolution: "react-use@npm:17.6.1"
+   dependencies:
+-    "@types/js-cookie": "npm:^2.2.6"
++    "@types/js-cookie": "npm:^3.0.0"
+     "@xobotyi/scrollbar-width": "npm:^1.9.5"
+     copy-to-clipboard: "npm:^3.3.1"
+     fast-deep-equal: "npm:^3.1.3"
+     fast-shallow-equal: "npm:^1.0.0"
+-    js-cookie: "npm:^2.2.1"
++    js-cookie: "npm:^3.0.0"
+     nano-css: "npm:^5.6.2"
+     react-universal-interface: "npm:^0.6.2"
+     resize-observer-polyfill: "npm:^1.5.1"
+@@ -34681,7 +34688,7 @@
+   peerDependencies:
+     react: "*"
+     react-dom: "*"
+-  checksum: 10c0/d122199f3edd056bfd866837b0f19a44366e77c7535c6c2c5eb5f400409eae4c9b1fe73c9d35073c8434080eee388ca8fe49a68d09d6f794ccaa35a4ae2112a9
++  checksum: 10c0/8b3babd9f7db14624e172d22c2fb30f091d785e97d0aed84e47e52a3ca8dbdc0c094ab797bbd0e754ff2f92be82357c7a46e08dbc85244edfefa21475f760cdf
    languageName: node
    linkType: hard
  

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -27,6 +27,10 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-46625
+    package: js-cookie
+    patch_version: 3.0.8
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5


### PR DESCRIPTION
It fixes js-cookie by upgrading it to 3.0.8 or higher. 
Fixing CVE-2026-46625 
https://redhat.atlassian.net/browse/RHIDP-15065

**dependency status**
```
@internal/orchestrator@1.0.0 /Users/alizardo/Documents/engineering/github/rhdh-plugins/workspaces/orchestrator
├─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-form-react@2.8.5 -> ./plugins/orchestrator-form-react
│ └─┬ @backstage/core-components@0.18.8
│   └─┬ @react-hookz/web@24.0.4
│     └── js-cookie@3.0.8 deduped
└─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-form-widgets@1.10.8 -> ./plugins/orchestrator-form-widgets
  └─┬ react-use@17.6.1
    └── js-cookie@3.0.8
```
