### PR TITLE
chore(deps): [release-1.10][orchestrator] bump js-yaml to 3.15.0, 4.3.0 or higher

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -122,15 +122,6 @@
    languageName: node
    linkType: hard
  
-@@ -13338,7 +13330,7 @@
-     "@types/js-yaml": "npm:^4.0.0"
-     "@types/json-schema": "npm:7.0.15"
-     axios: "npm:^1.15.0"
--    js-yaml: "npm:^4.1.0"
-+    js-yaml: "npm:^4.3.0"
-     js-yaml-cli: "npm:^0.6.0"
-   languageName: unknown
-   linkType: soft
 @@ -14087,11 +14079,11 @@
    languageName: node
    linkType: hard
@@ -377,7 +368,7 @@
 -"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:~4.1.0":
 -  version: 4.1.1
 -  resolution: "js-yaml@npm:4.1.1"
-+"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.0":
++"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0":
 +  version: 4.3.0
 +  resolution: "js-yaml@npm:4.3.0"
    dependencies:

--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -1,5 +1,58 @@
 --- yarn.lock
 +++ yarn.lock
+@@ -9004,30 +9004,30 @@
+   linkType: hard
+ 
+ "@microsoft/api-documenter@npm:^7.28.1":
+-  version: 7.28.8
+-  resolution: "@microsoft/api-documenter@npm:7.28.8"
++  version: 7.30.9
++  resolution: "@microsoft/api-documenter@npm:7.30.9"
+   dependencies:
+-    "@microsoft/api-extractor-model": "npm:7.32.2"
++    "@microsoft/api-extractor-model": "npm:7.33.10"
+     "@microsoft/tsdoc": "npm:~0.16.0"
+-    "@rushstack/node-core-library": "npm:5.19.1"
+-    "@rushstack/terminal": "npm:0.21.0"
+-    "@rushstack/ts-command-line": "npm:5.2.0"
++    "@rushstack/node-core-library": "npm:5.23.3"
++    "@rushstack/terminal": "npm:0.24.2"
++    "@rushstack/ts-command-line": "npm:5.3.12"
+     js-yaml: "npm:~4.1.0"
+     resolve: "npm:~1.22.1"
+   bin:
+     api-documenter: bin/api-documenter
+-  checksum: 10c0/f102ea67f07981aabdd9da4ad4323db10fae20977e9c622c15d2b1e3cda291d91862a3a04f932d9aebb4bfb84fc0221bb574cbb65b9841f3d6388cd364b4df4b
++  checksum: 10c0/8399d628fa95cef8ab35c6ebc24c6b7c785d5b01a5786ad2654060c77a16caa704452a2362b987d89b56003f07ab83eab2f1cbf654c6df203e70c8d064951561
+   languageName: node
+   linkType: hard
+ 
+-"@microsoft/api-extractor-model@npm:7.32.2":
+-  version: 7.32.2
+-  resolution: "@microsoft/api-extractor-model@npm:7.32.2"
++"@microsoft/api-extractor-model@npm:7.33.10":
++  version: 7.33.10
++  resolution: "@microsoft/api-extractor-model@npm:7.33.10"
+   dependencies:
+     "@microsoft/tsdoc": "npm:~0.16.0"
+-    "@microsoft/tsdoc-config": "npm:~0.18.0"
+-    "@rushstack/node-core-library": "npm:5.19.1"
+-  checksum: 10c0/26c7cf56d8b74dbe20270a767ae365a9b93178cd378363c20c15823a68124d55af5c2b4aea5f30dc2b4a93194db3041b4861e39ace79e3d649f06b4b0a6bfb87
++    "@microsoft/tsdoc-config": "npm:~0.18.1"
++    "@rushstack/node-core-library": "npm:5.23.3"
++  checksum: 10c0/d79d6747d6ee7dd5c69d2f63aac43ea0e9e7cf34d31155966c25d60274018a7267a46ee11da279f15a21f66d57914fa2b267dbc50391f685bf58c6f3083af5de
+   languageName: node
+   linkType: hard
+ 
+@@ -9073,7 +9073,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"@microsoft/tsdoc-config@npm:~0.18.0, @microsoft/tsdoc-config@npm:~0.18.1":
++"@microsoft/tsdoc-config@npm:~0.18.1":
+   version: 0.18.1
+   resolution: "@microsoft/tsdoc-config@npm:0.18.1"
+   dependencies:
 @@ -10955,27 +10955,26 @@
    languageName: node
    linkType: hard
@@ -40,20 +93,20 @@
    languageName: node
    linkType: hard
  
-@@ -10983,13 +10982,6 @@
-   version: 1.0.2
-   resolution: "@protobufjs/float@npm:1.0.2"
-   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
--  languageName: node
--  linkType: hard
--
+@@ -10986,13 +10985,6 @@
+   languageName: node
+   linkType: hard
+ 
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
-   languageName: node
-   linkType: hard
- 
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
 @@ -11007,10 +10999,10 @@
    languageName: node
    linkType: hard
@@ -69,7 +122,172 @@
    languageName: node
    linkType: hard
  
-@@ -24337,9 +24329,9 @@
+@@ -13338,7 +13330,7 @@
+     "@types/js-yaml": "npm:^4.0.0"
+     "@types/json-schema": "npm:7.0.15"
+     axios: "npm:^1.15.0"
+-    js-yaml: "npm:^4.1.0"
++    js-yaml: "npm:^4.3.0"
+     js-yaml-cli: "npm:^0.6.0"
+   languageName: unknown
+   linkType: soft
+@@ -14087,11 +14079,11 @@
+   languageName: node
+   linkType: hard
+ 
+-"@rushstack/node-core-library@npm:5.19.1":
+-  version: 5.19.1
+-  resolution: "@rushstack/node-core-library@npm:5.19.1"
++"@rushstack/node-core-library@npm:5.21.0":
++  version: 5.21.0
++  resolution: "@rushstack/node-core-library@npm:5.21.0"
+   dependencies:
+-    ajv: "npm:~8.13.0"
++    ajv: "npm:~8.18.0"
+     ajv-draft-04: "npm:~1.0.0"
+     ajv-formats: "npm:~3.0.1"
+     fs-extra: "npm:~11.3.0"
+@@ -14104,40 +14096,28 @@
+   peerDependenciesMeta:
+     "@types/node":
+       optional: true
+-  checksum: 10c0/1c9174e1d38ce6d1cf5dfff394d800de6a5cb43666da67df7d07b93243a61b0479f5ef04e9c5f8c31759309203a0d7e174157c515c869bab26d23187202bff1c
++  checksum: 10c0/c5968d743101b581f45b73c58d02bd446a918bffd178098b3c660c8661ec7c62ed30229dd46dc5c3e8bf6172a6ece757503bc40a696d940aabb52d26aca40c45
+   languageName: node
+   linkType: hard
+ 
+-"@rushstack/node-core-library@npm:5.21.0":
+-  version: 5.21.0
+-  resolution: "@rushstack/node-core-library@npm:5.21.0"
++"@rushstack/node-core-library@npm:5.23.3":
++  version: 5.23.3
++  resolution: "@rushstack/node-core-library@npm:5.23.3"
+   dependencies:
+-    ajv: "npm:~8.18.0"
++    ajv: "npm:~8.20.0"
+     ajv-draft-04: "npm:~1.0.0"
+     ajv-formats: "npm:~3.0.1"
+     fs-extra: "npm:~11.3.0"
+     import-lazy: "npm:~4.0.0"
+     jju: "npm:~1.4.0"
+     resolve: "npm:~1.22.1"
+-    semver: "npm:~7.5.4"
+-  peerDependencies:
+-    "@types/node": "*"
+-  peerDependenciesMeta:
+-    "@types/node":
+-      optional: true
+-  checksum: 10c0/c5968d743101b581f45b73c58d02bd446a918bffd178098b3c660c8661ec7c62ed30229dd46dc5c3e8bf6172a6ece757503bc40a696d940aabb52d26aca40c45
+-  languageName: node
+-  linkType: hard
+-
+-"@rushstack/problem-matcher@npm:0.1.1":
+-  version: 0.1.1
+-  resolution: "@rushstack/problem-matcher@npm:0.1.1"
++    semver: "npm:~7.7.4"
+   peerDependencies:
+     "@types/node": "*"
+   peerDependenciesMeta:
+     "@types/node":
+       optional: true
+-  checksum: 10c0/c847e721d3536ebb316fdd90b3e4033a7d24ff8c70e38e3eaeaadf167c4d14a7f16377ae4af8097532386bcfa81c15cfec7d2da517542c07882d273d56861d78
++  checksum: 10c0/9a2a6cdf91280a05fdd38dc737c5e925c145165d21f18f76d36f5965c56df27e7418d86e75e991051fb96d6eb82132bf2d672bbf41b41f3f4f96128fb2ff653e
+   languageName: node
+   linkType: hard
+ 
+@@ -14163,27 +14143,27 @@
+   languageName: node
+   linkType: hard
+ 
+-"@rushstack/terminal@npm:0.21.0":
+-  version: 0.21.0
+-  resolution: "@rushstack/terminal@npm:0.21.0"
++"@rushstack/terminal@npm:0.22.4":
++  version: 0.22.4
++  resolution: "@rushstack/terminal@npm:0.22.4"
+   dependencies:
+-    "@rushstack/node-core-library": "npm:5.19.1"
+-    "@rushstack/problem-matcher": "npm:0.1.1"
++    "@rushstack/node-core-library": "npm:5.21.0"
++    "@rushstack/problem-matcher": "npm:0.2.1"
+     supports-color: "npm:~8.1.1"
+   peerDependencies:
+     "@types/node": "*"
+   peerDependenciesMeta:
+     "@types/node":
+       optional: true
+-  checksum: 10c0/47f5688674a10785b65a07760fdb4b010bd9dbad141ea2ae78c8c0c320daecd66363d1c4fad78137e87582cabd6432f2919f7f4eb7557c0f836ce24b58ca45ca
++  checksum: 10c0/952049a620c1f1bff51adab157e2f4c623c76a9935192cc3473bf131aa7a9c91b82a39f8b661768367c062d1d76741c74e9c7294dbd32c7eaa11089116b1b4b7
+   languageName: node
+   linkType: hard
+ 
+-"@rushstack/terminal@npm:0.22.4":
+-  version: 0.22.4
+-  resolution: "@rushstack/terminal@npm:0.22.4"
++"@rushstack/terminal@npm:0.24.2":
++  version: 0.24.2
++  resolution: "@rushstack/terminal@npm:0.24.2"
+   dependencies:
+-    "@rushstack/node-core-library": "npm:5.21.0"
++    "@rushstack/node-core-library": "npm:5.23.3"
+     "@rushstack/problem-matcher": "npm:0.2.1"
+     supports-color: "npm:~8.1.1"
+   peerDependencies:
+@@ -14191,19 +14171,19 @@
+   peerDependenciesMeta:
+     "@types/node":
+       optional: true
+-  checksum: 10c0/952049a620c1f1bff51adab157e2f4c623c76a9935192cc3473bf131aa7a9c91b82a39f8b661768367c062d1d76741c74e9c7294dbd32c7eaa11089116b1b4b7
++  checksum: 10c0/4018249b4dfb17119bcfcf0b5efa5fe7bc54fe9cabff7e8d9ae4cf2188f1bb79c9e746800c2dfd77ba8c456efbc5655c6456c2179a1408263a91d20ecac3a644
+   languageName: node
+   linkType: hard
+ 
+-"@rushstack/ts-command-line@npm:5.2.0":
+-  version: 5.2.0
+-  resolution: "@rushstack/ts-command-line@npm:5.2.0"
++"@rushstack/ts-command-line@npm:5.3.12":
++  version: 5.3.12
++  resolution: "@rushstack/ts-command-line@npm:5.3.12"
+   dependencies:
+-    "@rushstack/terminal": "npm:0.21.0"
++    "@rushstack/terminal": "npm:0.24.2"
+     "@types/argparse": "npm:1.0.38"
+     argparse: "npm:~1.0.9"
+     string-argv: "npm:~0.3.1"
+-  checksum: 10c0/0b8b9ce38ebe0104739e2b67f0b4c75dae6f9bedda3cd95bddc7068c618e7c5945d383baa7b4cc5d88fe2662e6f8402cfd2bef060f0c846b2f37abe6d4bf600a
++  checksum: 10c0/f5e72f3e3870b0d5c8424114f75354276c96fe4c4d14d2e4b9b8826711b848669939000c7099177bd295568e80ce11278b9427a5fd383f5a471821f2c7b36aba
+   languageName: node
+   linkType: hard
+ 
+@@ -18443,7 +18423,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.1.0, ajv@npm:^8.10.0, ajv@npm:^8.11.0, ajv@npm:^8.12.0, ajv@npm:^8.16.0, ajv@npm:^8.17.1, ajv@npm:^8.18.0, ajv@npm:^8.6.0, ajv@npm:^8.6.2, ajv@npm:^8.6.3, ajv@npm:^8.9.0":
++"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.1.0, ajv@npm:^8.10.0, ajv@npm:^8.11.0, ajv@npm:^8.12.0, ajv@npm:^8.16.0, ajv@npm:^8.17.1, ajv@npm:^8.18.0, ajv@npm:^8.6.0, ajv@npm:^8.6.2, ajv@npm:^8.6.3, ajv@npm:^8.9.0, ajv@npm:~8.20.0":
+   version: 8.20.0
+   resolution: "ajv@npm:8.20.0"
+   dependencies:
+@@ -18452,18 +18432,6 @@
+     json-schema-traverse: "npm:^1.0.0"
+     require-from-string: "npm:^2.0.2"
+   checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
+-  languageName: node
+-  linkType: hard
+-
+-"ajv@npm:~8.13.0":
+-  version: 8.13.0
+-  resolution: "ajv@npm:8.13.0"
+-  dependencies:
+-    fast-deep-equal: "npm:^3.1.3"
+-    json-schema-traverse: "npm:^1.0.0"
+-    require-from-string: "npm:^2.0.2"
+-    uri-js: "npm:^4.4.1"
+-  checksum: 10c0/14c6497b6f72843986d7344175a1aa0e2c35b1e7f7475e55bc582cddb765fca7e6bf950f465dc7846f817776d9541b706f4b5b3fbedd8dfdeb5fce6f22864264
+   languageName: node
+   linkType: hard
+ 
+@@ -24337,9 +24305,9 @@
    linkType: hard
  
  "fast-uri@npm:^3.0.1":
@@ -82,7 +300,7 @@
    languageName: node
    linkType: hard
  
-@@ -24775,29 +24767,29 @@
+@@ -24775,29 +24743,29 @@
    linkType: hard
  
  "form-data@npm:^2.5.0":
@@ -121,37 +339,90 @@
    languageName: node
    linkType: hard
  
-@@ -25855,6 +25847,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
-+"hasown@npm:^2.0.4":
+@@ -25849,12 +25817,12 @@
+   languageName: node
+   linkType: hard
+ 
+-"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
+-  version: 2.0.2
+-  resolution: "hasown@npm:2.0.2"
++"hasown@npm:^2.0.0, hasown@npm:^2.0.2, hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
-+  dependencies:
-+    function-bind: "npm:^1.1.2"
+   dependencies:
+     function-bind: "npm:^1.1.2"
+-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
    languageName: node
    linkType: hard
  
-@@ -29427,6 +29428,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
+@@ -28137,25 +28105,25 @@
+   linkType: hard
+ 
+ "js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1, js-yaml@npm:^3.8.3":
+-  version: 3.14.2
+-  resolution: "js-yaml@npm:3.14.2"
++  version: 3.15.0
++  resolution: "js-yaml@npm:3.15.0"
+   dependencies:
+     argparse: "npm:^1.0.7"
+     esprima: "npm:^4.0.0"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
++  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+   languageName: node
+   linkType: hard
+ 
+-"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:~4.1.0":
+-  version: 4.1.1
+-  resolution: "js-yaml@npm:4.1.1"
++"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.0":
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
+   dependencies:
+     argparse: "npm:^2.0.1"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
++  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+   languageName: node
+   linkType: hard
+ 
+@@ -28168,6 +28136,17 @@
+   bin:
+     js-yaml: bin/js-yaml.js
+   checksum: 10c0/3ae3e71d2d462b97c04a2f3f1c621ad749462e3bef7fb83e6d2fbb1e6024035ea3078e853b84a015a083b7ce5806e14e3c7fd0df0fa2e0a844d45cc414ddfae7
 +  languageName: node
 +  linkType: hard
 +
-+"long@npm:^5.3.2":
++"js-yaml@npm:~4.1.0":
++  version: 4.1.1
++  resolution: "js-yaml@npm:4.1.1"
++  dependencies:
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+   languageName: node
+   linkType: hard
+ 
+@@ -29423,10 +29402,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"long@npm:^5.0.0, long@npm:^5.2.1":
+-  version: 5.2.3
+-  resolution: "long@npm:5.2.3"
+-  checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++"long@npm:^5.0.0, long@npm:^5.2.1, long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
    languageName: node
    linkType: hard
  
-@@ -33625,22 +33633,21 @@
+@@ -33625,22 +33604,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
@@ -182,7 +453,16 @@
    languageName: node
    linkType: hard
  
-@@ -38727,9 +38734,9 @@
+@@ -35901,7 +35879,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.7.2":
++"semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.7.2, semver@npm:~7.7.4":
+   version: 7.7.4
+   resolution: "semver@npm:7.7.4"
+   bin:
+@@ -38727,9 +38705,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.2.3, undici@npm:^7.24.0":

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -27,6 +27,27 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-59869
+    package: js-yaml
+    patch_version: 3.0.2, 3.15.0, 4.1.0, 4.1.1, 4.3.0
+    notes: |-
+      [auto] js-yaml@3.0.2 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.6.4
+          └─┬ js-yaml-cli@0.6.0
+            └── js-yaml@3.0.2
+      js-yaml@4.1.0 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ app-legacy@0.0.3
+          └─┬ @backstage/plugin-api-docs@0.13.5
+            └─┬ swagger-ui-react@5.30.0
+              └── js-yaml@4.1.0
+      js-yaml@4.1.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ @backstage/repo-tools@0.17.0
+          └─┬ @microsoft/api-documenter@7.30.9
+            └── js-yaml@4.1.1
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5


### PR DESCRIPTION
It bumps js-yaml to 3.15.0, 4.3.0 or higher

Fixes CVE-2026-59869
https://redhat.atlassian.net/browse/RHIDP-15469