### PR TITLE
chore(deps): [release-1.10][lightspeed] bump js-yaml to 3.15.0, 4.3.0 or higher

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -1,276 +1,43 @@
 --- yarn.lock
 +++ yarn.lock
-@@ -8857,20 +8857,19 @@
+@@ -25214,7 +25214,7 @@
    languageName: node
    linkType: hard
  
--"@protobufjs/eventemitter@npm:^1.1.0":
--  version: 1.1.0
--  resolution: "@protobufjs/eventemitter@npm:1.1.0"
--  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
-+"@protobufjs/eventemitter@npm:^1.1.1":
-+  version: 1.1.1
-+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
-+  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
-   languageName: node
-   linkType: hard
- 
--"@protobufjs/fetch@npm:^1.1.0":
--  version: 1.1.0
--  resolution: "@protobufjs/fetch@npm:1.1.0"
-+"@protobufjs/fetch@npm:^1.1.1":
-+  version: 1.1.1
-+  resolution: "@protobufjs/fetch@npm:1.1.1"
+-"js-yaml@npm:=4.1.1, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:~4.1.0":
++"js-yaml@npm:=4.1.1, js-yaml@npm:~4.1.0":
+   version: 4.1.1
+   resolution: "js-yaml@npm:4.1.1"
    dependencies:
-     "@protobufjs/aspromise": "npm:^1.1.1"
--    "@protobufjs/inquire": "npm:^1.1.0"
--  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
-+  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
-   languageName: node
+@@ -25226,17 +25226,28 @@
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
--"@protobufjs/inquire@npm:1.1.0":
--  version: 1.1.0
--  resolution: "@protobufjs/inquire@npm:1.1.0"
--  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
-@@ -21220,13 +21212,13 @@
-   linkType: hard
- 
- "express-rate-limit@npm:^8.2.2":
--  version: 8.3.1
--  resolution: "express-rate-limit@npm:8.3.1"
-+  version: 8.5.2
-+  resolution: "express-rate-limit@npm:8.5.2"
+ "js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1, js-yaml@npm:^3.8.3":
+-  version: 3.14.1
+-  resolution: "js-yaml@npm:3.14.1"
++  version: 3.15.0
++  resolution: "js-yaml@npm:3.15.0"
    dependencies:
--    ip-address: "npm:10.1.0"
-+    ip-address: "npm:^10.2.0"
-   peerDependencies:
-     express: ">= 4.11"
--  checksum: 10c0/e3229938457cec617460c54ef4e90c8c254facc884729325d20ea35e3838bd273e4c611fc1f4a76f6d14c411e30d31b15e88eb4be87408615ff0aacc142511a2
-+  checksum: 10c0/c98c49b93e94627940cf5e7c2578718b94d77163357161c3343d148e46257136c988933a96d6e1e728a010683133a58f68cad46928b063cf8d99521c8772578d
+     argparse: "npm:^1.0.7"
+     esprima: "npm:^4.0.0"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
++  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
    languageName: node
    linkType: hard
  
-@@ -21408,9 +21400,9 @@
-   linkType: hard
- 
- "fast-uri@npm:^3.0.1":
--  version: 3.0.3
--  resolution: "fast-uri@npm:3.0.3"
--  checksum: 10c0/4b2c5ce681a062425eae4f15cdc8fc151fd310b2f69b1f96680677820a8b49c3cd6e80661a406e19d50f0c40a3f8bffdd458791baf66f4a879d80be28e10a320
-+  version: 3.1.3
-+  resolution: "fast-uri@npm:3.1.3"
-+  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
-   languageName: node
-   linkType: hard
- 
-@@ -21802,29 +21794,29 @@
-   linkType: hard
- 
- "form-data@npm:^2.5.5":
--  version: 2.5.5
--  resolution: "form-data@npm:2.5.5"
-+  version: 2.5.6
-+  resolution: "form-data@npm:2.5.6"
-   dependencies:
-     asynckit: "npm:^0.4.0"
-     combined-stream: "npm:^1.0.8"
-     es-set-tostringtag: "npm:^2.1.0"
--    hasown: "npm:^2.0.2"
-+    hasown: "npm:^2.0.4"
-     mime-types: "npm:^2.1.35"
-     safe-buffer: "npm:^5.2.1"
--  checksum: 10c0/7fb70447849fc9bce4d01fe9a626f6587441f85779a2803b67f803e1ab52b0bd78db0a7acd80d944c665f68ca90936c327f1244b730719b638a0219e98b20488
-+  checksum: 10c0/de6b085a2b0d013299ccc888b677dbdb3d2a54ef8d74982bda9ad7d928f57440abae1bc736a5b85ea01077cfb6c72e9a7752dc786304271c03bd0013ef8f08cb
-   languageName: node
-   linkType: hard
- 
- "form-data@npm:^4.0.0, form-data@npm:^4.0.1, form-data@npm:^4.0.4, form-data@npm:^4.0.5":
--  version: 4.0.5
--  resolution: "form-data@npm:4.0.5"
-+  version: 4.0.6
-+  resolution: "form-data@npm:4.0.6"
-   dependencies:
-     asynckit: "npm:^0.4.0"
-     combined-stream: "npm:^1.0.8"
-     es-set-tostringtag: "npm:^2.1.0"
--    hasown: "npm:^2.0.2"
--    mime-types: "npm:^2.1.12"
--  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
-+    hasown: "npm:^2.0.4"
-+    mime-types: "npm:^2.1.35"
-+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
-   languageName: node
-   linkType: hard
- 
-@@ -22822,6 +22814,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
-+"hasown@npm:^2.0.4":
-+  version: 2.0.4
-+  resolution: "hasown@npm:2.0.4"
++"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
 +  dependencies:
-+    function-bind: "npm:^1.1.2"
-+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
-   languageName: node
-   linkType: hard
- 
-@@ -23818,20 +23819,10 @@
-   languageName: node
-   linkType: hard
- 
--"ip-address@npm:10.1.0":
--  version: 10.1.0
--  resolution: "ip-address@npm:10.1.0"
--  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
--  languageName: node
--  linkType: hard
--
--"ip-address@npm:^9.0.5":
--  version: 9.0.5
--  resolution: "ip-address@npm:9.0.5"
--  dependencies:
--    jsbn: "npm:1.1.0"
--    sprintf-js: "npm:^1.1.3"
--  checksum: 10c0/331cd07fafcb3b24100613e4b53e1a2b4feab11e671e655d46dc09ee233da5011284d09ca40c4ecbdfe1d0004f462958675c224a804259f2f78d2465a87824bc
-+"ip-address@npm:^10.1.1, ip-address@npm:^10.2.0":
-+  version: 10.2.0
-+  resolution: "ip-address@npm:10.2.0"
-+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
-   languageName: node
-   linkType: hard
- 
-@@ -25246,7 +25237,7 @@
-   languageName: node
-   linkType: hard
- 
--"jsbn@npm:1.1.0, jsbn@npm:^1.1.0":
-+"jsbn@npm:^1.1.0":
-   version: 1.1.0
-   resolution: "jsbn@npm:1.1.0"
-   checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
-@@ -26426,6 +26417,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
 +  languageName: node
 +  linkType: hard
 +
-+"long@npm:^5.3.2":
-+  version: 5.3.2
-+  resolution: "long@npm:5.3.2"
-+  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
-   languageName: node
-   linkType: hard
- 
-@@ -27950,7 +27948,7 @@
-   languageName: node
-   linkType: hard
- 
--"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35, mime-types@npm:~2.1.17, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
-+"mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35, mime-types@npm:~2.1.17, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
-   version: 2.1.35
-   resolution: "mime-types@npm:2.1.35"
-   dependencies:
-@@ -31078,22 +31076,21 @@
-   linkType: hard
- 
- "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
--  version: 7.5.6
--  resolution: "protobufjs@npm:7.5.6"
-+  version: 7.6.5
-+  resolution: "protobufjs@npm:7.6.5"
-   dependencies:
-     "@protobufjs/aspromise": "npm:^1.1.2"
-     "@protobufjs/base64": "npm:^1.1.2"
-     "@protobufjs/codegen": "npm:^2.0.5"
--    "@protobufjs/eventemitter": "npm:^1.1.0"
--    "@protobufjs/fetch": "npm:^1.1.0"
-+    "@protobufjs/eventemitter": "npm:^1.1.1"
-+    "@protobufjs/fetch": "npm:^1.1.1"
-     "@protobufjs/float": "npm:^1.0.2"
--    "@protobufjs/inquire": "npm:^1.1.1"
-     "@protobufjs/path": "npm:^1.1.2"
-     "@protobufjs/pool": "npm:^1.1.0"
-     "@protobufjs/utf8": "npm:^1.1.1"
-     "@types/node": "npm:>=13.7.0"
--    long: "npm:^5.0.0"
--  checksum: 10c0/220df6c3cf6d2346748639a9b0b688fecc994bff9fee7018a93167e8cd45ab0ee3b4270d9eaa6be33a11adb46514ef9dce7e8217fd578c36726a9e70b96327cd
-+    long: "npm:^5.3.2"
-+  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
-   languageName: node
-   linkType: hard
- 
-@@ -33789,12 +33786,12 @@
-   linkType: hard
- 
- "socks@npm:^2.6.2, socks@npm:^2.8.3":
--  version: 2.8.3
--  resolution: "socks@npm:2.8.3"
-+  version: 2.8.9
-+  resolution: "socks@npm:2.8.9"
-   dependencies:
--    ip-address: "npm:^9.0.5"
-+    ip-address: "npm:^10.1.1"
-     smart-buffer: "npm:^4.2.0"
--  checksum: 10c0/d54a52bf9325165770b674a67241143a3d8b4e4c8884560c4e0e078aace2a728dffc7f70150660f51b85797c4e1a3b82f9b7aa25e0a0ceae1a243365da5c51a7
-+  checksum: 10c0/2d4350c31142b0931eb1758825b426bcbf4bfb5eed682ca48bc46dc9e7d1930ec366ea574ad49fc6c1fd9e9e17ce243be0ef13e31fc4b0319d9093f1fb19743c
-   languageName: node
-   linkType: hard
- 
-@@ -33958,7 +33955,7 @@
-   languageName: node
-   linkType: hard
- 
--"sprintf-js@npm:^1.1.2, sprintf-js@npm:^1.1.3":
-+"sprintf-js@npm:^1.1.2":
-   version: 1.1.3
-   resolution: "sprintf-js@npm:1.1.3"
-   checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-@@ -35999,9 +35996,9 @@
-   linkType: hard
- 
- "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.24.5":
--  version: 7.25.0
--  resolution: "undici@npm:7.25.0"
--  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
-+  version: 7.28.0
-+  resolution: "undici@npm:7.28.0"
-+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
-   languageName: node
-   linkType: hard
- 
-@@ -37294,8 +37291,8 @@
-   linkType: hard
- 
- "ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
--  version: 8.20.0
--  resolution: "ws@npm:8.20.0"
-+  version: 8.21.0
-+  resolution: "ws@npm:8.21.0"
-   peerDependencies:
-     bufferutil: ^4.0.1
-     utf-8-validate: ">=5.0.2"
-@@ -37304,7 +37301,7 @@
-       optional: true
-     utf-8-validate:
-       optional: true
--  checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
-+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
-   languageName: node
-   linkType: hard
- 
+ "js2xmlparser@npm:^4.0.2":
+   version: 4.0.2
+   resolution: "js2xmlparser@npm:4.0.2"

--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,20 +29,29 @@
    languageName: node
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
+   languageName: node
+   linkType: hard
+ 
+@@ -11198,7 +11190,7 @@
+     form-data: "npm:^4.0.5"
+     htmlparser2: "npm:^9.1.0"
+     http-proxy-middleware: "npm:^3.0.2"
+-    js-yaml: "npm:^4.1.1"
++    js-yaml: "npm:4.3.0"
+     knex: "npm:^3.1.0"
+     llama-stack-client: "npm:^0.5.0"
+     msw: "npm:2.12.10"
 @@ -21220,13 +21212,13 @@
    linkType: hard
  
@@ -113,22 +122,22 @@
    languageName: node
    linkType: hard
  
-@@ -22822,6 +22814,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
+@@ -22825,6 +22817,15 @@
+   languageName: node
+   linkType: hard
+ 
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: "npm:^1.1.2"
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
-   languageName: node
-   linkType: hard
- 
++  languageName: node
++  linkType: hard
++
+ "hast-util-from-parse5@npm:^7.0.0":
+   version: 7.1.2
+   resolution: "hast-util-from-parse5@npm:7.1.2"
 @@ -23818,20 +23819,10 @@
    languageName: node
    linkType: hard
@@ -154,7 +163,45 @@
    languageName: node
    linkType: hard
  
-@@ -25246,7 +25237,7 @@
+@@ -25214,7 +25205,18 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-yaml@npm:=4.1.1, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:~4.1.0":
++"js-yaml@npm:4.3.0, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0":
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
++  dependencies:
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
++  languageName: node
++  linkType: hard
++
++"js-yaml@npm:=4.1.1, js-yaml@npm:~4.1.0":
+   version: 4.1.1
+   resolution: "js-yaml@npm:4.1.1"
+   dependencies:
+@@ -25226,14 +25228,14 @@
+   linkType: hard
+ 
+ "js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1, js-yaml@npm:^3.8.3":
+-  version: 3.14.1
+-  resolution: "js-yaml@npm:3.14.1"
++  version: 3.15.0
++  resolution: "js-yaml@npm:3.15.0"
+   dependencies:
+     argparse: "npm:^1.0.7"
+     esprima: "npm:^4.0.0"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
++  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+   languageName: node
+   linkType: hard
+ 
+@@ -25246,7 +25248,7 @@
    languageName: node
    linkType: hard
  
@@ -163,7 +210,7 @@
    version: 1.1.0
    resolution: "jsbn@npm:1.1.0"
    checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
-@@ -26426,6 +26417,13 @@
+@@ -26426,6 +26428,13 @@
    version: 5.2.3
    resolution: "long@npm:5.2.3"
    checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
@@ -177,7 +224,7 @@
    languageName: node
    linkType: hard
  
-@@ -27950,7 +27948,7 @@
+@@ -27950,7 +27959,7 @@
    languageName: node
    linkType: hard
  
@@ -186,7 +233,7 @@
    version: 2.1.35
    resolution: "mime-types@npm:2.1.35"
    dependencies:
-@@ -31078,22 +31076,21 @@
+@@ -31078,22 +31087,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
@@ -215,7 +262,7 @@
    languageName: node
    linkType: hard
  
-@@ -33789,12 +33786,12 @@
+@@ -33789,12 +33797,12 @@
    linkType: hard
  
  "socks@npm:^2.6.2, socks@npm:^2.8.3":
@@ -232,7 +279,7 @@
    languageName: node
    linkType: hard
  
-@@ -33958,7 +33955,7 @@
+@@ -33958,7 +33966,7 @@
    languageName: node
    linkType: hard
  
@@ -241,7 +288,7 @@
    version: 1.1.3
    resolution: "sprintf-js@npm:1.1.3"
    checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-@@ -35999,9 +35996,9 @@
+@@ -35999,9 +36007,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.24.5":
@@ -254,7 +301,7 @@
    languageName: node
    linkType: hard
  
-@@ -37294,8 +37291,8 @@
+@@ -37294,8 +37302,8 @@
    linkType: hard
  
  "ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
@@ -265,7 +312,7 @@
    peerDependencies:
      bufferutil: ^4.0.1
      utf-8-validate: ">=5.0.2"
-@@ -37304,7 +37301,7 @@
+@@ -37304,7 +37312,7 @@
        optional: true
      utf-8-validate:
        optional: true

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -18,6 +18,16 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-59869
+    package: js-yaml
+    patch_version: 3.15.0, 4.1.1, 4.3.0
+    notes: |-
+      [auto] js-yaml@4.1.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ @backstage/repo-tools@0.17.0
+          └─┬ @microsoft/api-documenter@7.28.6
+            └── js-yaml@4.1.1
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -18,6 +18,22 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-59869
+    package: js-yaml
+    patch_version: 3.15.0, 4.1.1, 4.3.0
+    notes: |-
+      [auto] js-yaml@4.1.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ @backstage/repo-tools@0.17.0
+          └─┬ @microsoft/api-documenter@7.28.6
+            └── js-yaml@4.1.1
+
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ app-legacy@0.0.27
+          └─┬ @backstage/plugin-api-docs@0.13.5
+            └─┬ swagger-ui-react@5.30.3
+              └── js-yaml@4.1.1
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5
@@ -41,3 +57,10 @@ backports:
               └─┬ @module-federation/dts-plugin@0.21.6
                 └─┬ isomorphic-ws@5.0.0
                   └── ws@8.18.0
+
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ @backstage/cli-defaults@0.1.0
+          └─┬ @backstage/cli-module-build@0.1.2
+            └─┬ @module-federation/enhanced@0.21.6
+              └─┬ @module-federation/dts-plugin@0.21.6
+                └── ws@8.18.0


### PR DESCRIPTION
It partially bumps js-yaml to 3.15.0, 4.3.0 or higher

Fixes CVE-2026-59869
https://redhat.atlassian.net/browse/RHIDP-15469