### PR TITLE
chore(deps): [release-1.10][lightspeed] bump tar to 7.5.20

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,20 +29,20 @@
    languageName: node
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
+   languageName: node
+   linkType: hard
+ 
 @@ -21220,13 +21212,13 @@
    linkType: hard
  
@@ -113,23 +113,24 @@
    languageName: node
    linkType: hard
  
-@@ -22822,6 +22814,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
-+"hasown@npm:^2.0.4":
+@@ -22816,12 +22808,12 @@
+   languageName: node
+   linkType: hard
+ 
+-"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
+-  version: 2.0.2
+-  resolution: "hasown@npm:2.0.2"
++"hasown@npm:^2.0.0, hasown@npm:^2.0.2, hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
-+  dependencies:
-+    function-bind: "npm:^1.1.2"
+   dependencies:
+     function-bind: "npm:^1.1.2"
+-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
    languageName: node
    linkType: hard
  
-@@ -23818,20 +23819,10 @@
+@@ -23818,20 +23810,10 @@
    languageName: node
    linkType: hard
  
@@ -154,7 +155,7 @@
    languageName: node
    linkType: hard
  
-@@ -25246,7 +25237,7 @@
+@@ -25246,7 +25228,7 @@
    languageName: node
    linkType: hard
  
@@ -163,21 +164,22 @@
    version: 1.1.0
    resolution: "jsbn@npm:1.1.0"
    checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
-@@ -26426,6 +26417,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
-+  languageName: node
-+  linkType: hard
-+
-+"long@npm:^5.3.2":
+@@ -26422,10 +26404,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"long@npm:^5.0.0, long@npm:^5.2.1":
+-  version: 5.2.3
+-  resolution: "long@npm:5.2.3"
+-  checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++"long@npm:^5.0.0, long@npm:^5.2.1, long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
    languageName: node
    linkType: hard
  
-@@ -27950,7 +27948,7 @@
+@@ -27950,7 +27932,7 @@
    languageName: node
    linkType: hard
  
@@ -186,7 +188,7 @@
    version: 2.1.35
    resolution: "mime-types@npm:2.1.35"
    dependencies:
-@@ -31078,22 +31076,21 @@
+@@ -31078,22 +31060,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
@@ -215,7 +217,7 @@
    languageName: node
    linkType: hard
  
-@@ -33789,12 +33786,12 @@
+@@ -33789,12 +33770,12 @@
    linkType: hard
  
  "socks@npm:^2.6.2, socks@npm:^2.8.3":
@@ -232,7 +234,7 @@
    languageName: node
    linkType: hard
  
-@@ -33958,7 +33955,7 @@
+@@ -33958,7 +33939,7 @@
    languageName: node
    linkType: hard
  
@@ -241,7 +243,26 @@
    version: 1.1.3
    resolution: "sprintf-js@npm:1.1.3"
    checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-@@ -35999,9 +35996,9 @@
+@@ -34883,15 +34864,15 @@
+   linkType: hard
+ 
+ "tar@npm:^7.5.6":
+-  version: 7.5.13
+-  resolution: "tar@npm:7.5.13"
++  version: 7.5.20
++  resolution: "tar@npm:7.5.20"
+   dependencies:
+     "@isaacs/fs-minipass": "npm:^4.0.0"
+     chownr: "npm:^3.0.0"
+     minipass: "npm:^7.1.2"
+     minizlib: "npm:^3.1.0"
+     yallist: "npm:^5.0.0"
+-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
++  checksum: 10c0/4df4335c6d958b76adf1eaced55889dec3ca1c51f450658a074af80694bb0d9c154a8e93fdf4da617372d1575b121295379993961bbe4cd4b0867c0e5689846a
+   languageName: node
+   linkType: hard
+ 
+@@ -35999,9 +35980,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.24.5":
@@ -254,7 +275,7 @@
    languageName: node
    linkType: hard
  
-@@ -37294,8 +37291,8 @@
+@@ -37294,8 +37275,8 @@
    linkType: hard
  
  "ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
@@ -265,7 +286,7 @@
    peerDependencies:
      bufferutil: ^4.0.1
      utf-8-validate: ">=5.0.2"
-@@ -37304,7 +37301,7 @@
+@@ -37304,7 +37285,7 @@
        optional: true
      utf-8-validate:
        optional: true

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -22,6 +22,18 @@ backports:
     package: protobufjs
     patch_version: 7.6.5
   - cve_ids:
+      - CVE-2026-59874
+    package: tar
+    patch_version: 6.2.1, 7.5.20
+    notes: |-
+      [auto] tar@6.2.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ @backstage/cli-defaults@0.1.0
+          └─┬ @backstage/cli-module-auth@0.1.0
+            └─┬ keytar@7.9.0
+              └─┬ node-gyp@10.2.0
+                └── tar@6.2.1
+  - cve_ids:
       - CVE-2026-12151
       - CVE-2026-6734
       - CVE-2026-9697


### PR DESCRIPTION
It bumps tar to 7.5.20 to fix CVE-2026-59874 and CVE-2026-59873
https://redhat.atlassian.net/browse/RHIDP-15401