### PR TITLE
chore(deps): [release-1.10][orchestrator] bump dompurify to 3.4.7 or higher

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -1,5 +1,20 @@
 --- yarn.lock
 +++ yarn.lock
+@@ -2664,10 +2664,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+-  version: 7.28.4
+-  resolution: "@babel/runtime@npm:7.28.4"
+-  checksum: 10c0/792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
++"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
++  version: 7.29.7
++  resolution: "@babel/runtime@npm:7.29.7"
++  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
+   languageName: node
+   linkType: hard
+ 
 @@ -10955,27 +10955,26 @@
    languageName: node
    linkType: hard
@@ -40,20 +55,20 @@
    languageName: node
    linkType: hard
  
-@@ -10983,13 +10982,6 @@
-   version: 1.0.2
-   resolution: "@protobufjs/float@npm:1.0.2"
-   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
--  languageName: node
--  linkType: hard
--
+@@ -10986,13 +10985,6 @@
+   languageName: node
+   linkType: hard
+ 
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
-   languageName: node
-   linkType: hard
- 
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
 @@ -11007,10 +10999,10 @@
    languageName: node
    linkType: hard
@@ -69,7 +84,975 @@
    languageName: node
    linkType: hard
  
-@@ -24337,9 +24329,9 @@
+@@ -15674,482 +15666,579 @@
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ast@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ast@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ast@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ast@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     unraw: "npm:^3.0.0"
+-  checksum: 10c0/a1ebc294f389d73744dd04af6e7f41815478c63a2fda14ae73e355a4c77a3d6d85f94772a11f1893e4d724138d5b6bc3c42354c6bc9e813927e74c737a0fe6f9
++  checksum: 10c0/e2595f82f8748108e95b09663b89aff6a35d15d3b57bb241b31a0cc0921dd13f1e313605d29471039ae9203d521c7a560e794bcb3bb866b78a656bf62af663b8
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-core@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-core@npm:1.0.0-rc.1"
++"@swagger-api/apidom-core@npm:^1.11.0, @swagger-api/apidom-core@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-core@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     minim: "npm:~0.23.8"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     short-unique-id: "npm:^5.3.2"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/a3ab3f981c77bcc359f5dfdd911c506c5636007a09ed8f1418c8dcd98bb45b6e536d4b2d42d78d89fc2b577c4e06559b3614bf5d20674bfce2c631cb7ace7c41
++  checksum: 10c0/397483645435b7d91660bc56300f0c1f8e974cc46494983b507a752af224b9185eea8eb692d7b39c6f1b96f0056fff74203559815a7bf0636131f867ed6a6325
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-error@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-error@npm:1.0.0-rc.1"
++"@swagger-api/apidom-error@npm:^1.11.0, @swagger-api/apidom-error@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-error@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.20.7"
+-  checksum: 10c0/a885e56b95c22c3358e144bc4f8ce81f08a5a8bd7a4f6770f0907338cff8daa175be2309dfb7b55746c0e52ee552cd21e866d5cfc3de85736b6d302ef39b7cb5
++  checksum: 10c0/0c5d089d3c58ff46ae91fbd60e4ff328d0a334a6764f65f3d88a00b7a8622010aeaff5c705fdcab42bb51f95c6a053d843383aff9e40e059e86e50786289985c
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-json-pointer@npm:^1.0.0-rc.0, @swagger-api/apidom-json-pointer@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-json-pointer@npm:1.0.0-rc.1"
++"@swagger-api/apidom-json-pointer@npm:^1.11.0, @swagger-api/apidom-json-pointer@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-json-pointer@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@swaggerexpert/json-pointer": "npm:^2.10.1"
+-  checksum: 10c0/8673c54ffa68d96462bfa22f7f4435039910e31acf639d06e77e5bbba921f3c0ceadf5af17987fb7fb9c348468b6eb285e7710f6d0d14331a3cebd871b131070
++  checksum: 10c0/39cf5e9a1df5ae654ed8851f1f9540899c57e01b027cb2bcd783f2f2cacbb48744f852f83b52d345423ddff413581e05f0e002e22113b132d1105cb9ca80819a
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-api-design-systems@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-api-design-systems@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/69e4251c662d9964efc64c3f75fb682d96bf96033c43966f2a5af5147dfaf39119b78d74f3965c7cbcd8d8c0a5a2446c00b064734dd091ffe28906afbc75dce9
++  checksum: 10c0/7554e3e0208e22596ace36660e3f46bc0e4f4b270a5b6be313b0d5cf774ac8500b3bde076cc35bb00f081df9de2ea8091ef5885f42b59115006ee405e30d7511
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-arazzo-1@npm:^1.0.0-rc.0, @swagger-api/apidom-ns-arazzo-1@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-arazzo-1@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-arazzo-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-arazzo-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/e999a587543e0483ba157a86e53ce1fde298995324890cf599d4cb08a75da460e10aa2f58cd0640d8202c5490198f498c9dab5768f01314f45b48c8c01575ea6
++  checksum: 10c0/34d4cc020fab5ee5ccfd7d32bad77109b20d13ea9ddaf44e957813850123b7010c80f167402fab6c7070d2fab5274f504eebda2017b85f54697a41b24b158076
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-asyncapi-2@npm:^1.0.0-rc.0, @swagger-api/apidom-ns-asyncapi-2@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-asyncapi-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++    ts-mixer: "npm:^6.0.3"
++  checksum: 10c0/af775a11bceba7c41fcce50f13ec7baa64194aa6f781842c05b9b7de3ed456831aa6dcfe49323d3ff93eda680014aaacb2bb50478a9956ea4cb49c099cf8bae9
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-ns-asyncapi-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-asyncapi-3@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/23075e216b3a757103d39dc6e63606e8f7a879f22755b737313ccf0f07fcdad8e07f504066c2e5c2e345134cc9108c47edab67d5e07a2c79541e7ea2cd2c0bbf
++  checksum: 10c0/01c7ece4fa8a4e1f81913e9ed018b5439b926874e00882dc79e24556ccbad329cd149184e19f15a4f42f00eba6c4f3b69773b314191760c8000422ddd06a3e79
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-2019-09@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-json-schema-2019-09@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-json-schema-2019-09@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-2019-09@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/5479dbc6efb7f92053d8b9154d6907e7c5cdbe9e97ccb911c8fe8924952bb58e89cccbbf513ea60e18d8ee68730fa29876c18f462202b08e8e4ce964d9cae046
++  checksum: 10c0/7c4078e81b5fcd869869a576d211ed9bc0186461b7467881c62a82975e2f5945130385a372e7b7e80eb874f43912a4876f6a3352dac7d7491edd702942676a62
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-2020-12@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-json-schema-2020-12@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-json-schema-2020-12@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-2020-12@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-2019-09": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2019-09": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/ceb4f717e394c502ccb03e6657f85442aa164c6006f627983fd5003458f98dbef97ca66e463690b531dc1c777677c116b8506bbd535e3f68677635852daef2cb
++  checksum: 10c0/7dcb997bdcaa6c3f1f5ca0a68eaae13988af8b20aeea1fdce8fc11e874312100369e8ea5b942a55a82e380a22cf0c912d40fcfd316dc2bbbfff2096eadaa6686
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-4@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-json-schema-draft-4@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/327520734c4fb98cc9130ba4807e996cc82c75486085002e526432ec28d449213bd385df8ed14b99af32f231bdabb16c6141702a2fc0dc63f15dbe33a4eebefd
++  checksum: 10c0/1f0269f0ae1951edca13b6922028bd8e294a8931847e1a4ac1e9f38c4db78e6960714dcc6e691adc091e3f241808fd6af8884615d5fe1c4f800cf38006efca54
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-6@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-json-schema-draft-6@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/a99f579a3a5c5eca58e7dd278db20833f1c20981e42c4e5104a304480dc46fdc44bea0cc1782f7f66fa8f2d192906b64bb81494f90ee522fd4c3b0f0b5eb6422
++  checksum: 10c0/b431973c16b5570b19b555366ace9ca9563705912fa730aadc434272af68117c288863663375723c48ef17bede088a4dbedac85947ec17af413a9bb6dd8b429a
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-7@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-json-schema-draft-7@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/6aa4366d54fb948050de7eff98a34cac23531f56c3c0d1645174d70884c16fc956a010214c35edcefd46dc2137c34bb672a1101e21970d379fa10201ac5ea35c
++  checksum: 10c0/09035f8e569f2073009051876abdc80708e304ecb11b04c9dfe0288fd87084fa99c61c8df134a6cabd9bd3ef2b76cff08156c813dc8087cd3ce8e5809d394d65
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-2@npm:^1.0.0-rc.0, @swagger-api/apidom-ns-openapi-2@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-openapi-2@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-openapi-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/157653ff0d9ce4aab77605a2558f83bec679b5d289b5fe9e743a175b06931896cf94d49add77cd8be4baee057941cf387755f82cc5669455665043ee27842785
++  checksum: 10c0/95ad6eb1026dcd4eaf00ec1fe98461f2ba3a4c2793394fda42bc4d97ef9e0a33e8f94add116f9ba9c02f5feb3ccfc7b8e3b2b430b5b60d299e9f7f92d651c36b
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-3-0@npm:^1.0.0-rc.0, @swagger-api/apidom-ns-openapi-3-0@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-openapi-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/ee6e467e748b96230b703722dff9e120f31817e7616294a03cb808c19c61b6fadbb159aab194ad683a199a64689c15c0d29f414db72dc46083f25df327ef2013
++  checksum: 10c0/227f4744c36ad40a0779847a356c33554b0a9ac6f61742a446fec0ba85314c375bea5cfbcbc683d4b2aa0278f5399d84e6fb85c926148397faacd6c0207f1103
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-3-1@npm:^1.0.0-rc.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-openapi-3-1@npm:^1.11.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/a9aa40249be639a238250ab8c7ee94b9ef7d26376aaf5a8c137ad8854fd920f91a3cd8e616b4edfafa92b559911a96a500787bb91ffcdf5d6f8e95e795bf53b9
++  checksum: 10c0/9953cc31b75a9632afaacb4690ac1f80f880311b7c7beafc5aaaf357fbb8b68f6a5dc2cbbe5659d43d118687f93641898c7814b8fa25ba2911dbda4f7fccb516
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:1.0.0-rc.1"
++"@swagger-api/apidom-ns-openapi-3-2@npm:^1.11.0, @swagger-api/apidom-ns-openapi-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/be3c64f4b0af0882fb1185555daf4a753bf98949c300f13484d4dd6cc530387e6f90d7a0cd9ba4753ce9f39afd1e7f4da56f8c07885289d6e50684781980f0f7
++    ts-mixer: "npm:^6.0.3"
++  checksum: 10c0/6bd09f33369e50d4681bc5e132073302e5f73bbcaf8c29086e1d5a807ac4f4a4d95871852e980e7446da359cad04edc3f80c6da82f0406ed8bfb3abc67ee2a66
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/35ef280851edc5569f4166dffc9966381fd3706026d756862bd1f90a28402fee314c52ac8da5ef833b30477101eb0b958c9a287a50316a38ebaf1e40f28d7da4
++  checksum: 10c0/a4fe017c2d80daf95b2c4d6a8d52efb9883ae9b9bc5c1e3e4bc885168a1202de5fe43a007139245c6aed8e89078c98ca4ef5a878f5168f125b1a4dbf9ad43802
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/f2351f316c9fd068a756f419243b34e6c88221a49294c06deb6e8c27e3af216843fe51b45ded74e912edd71ccb6a1d265641feb04fe42450eb4822fcee472051
++  checksum: 10c0/fade65dd190174e092e8024519d58a4e863a048968b711fc5edc54aedf06ec418b2586bceaa22155f4f822c2d8ce4b61c2f78f22a7c6e220930e6f18aec93bec
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/0570e5723dc8eee6b7c200fb3d3e34cb4d9f7981b07854c03537f68be1d40e487823ea018c9ff9d6e158effaa3e7448f0e488b5215288d38fdc4a5aed415c332
++  checksum: 10c0/7ae294ba91238552b0c26727fb6625b1191f6e224bcc47a8a57572935634cb5e892a5c257ff45530ec0fb38dc1a8900a1946c844d29c36fe68480e42f69a1304
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/04760205c058d7c08d3aab697079a8dfcc4d18ea0c556925d7de2a1e372071e34492d85a2949653dbc9f441e671417fa0111f8888033a9de2eaeafbbb90175a7
++  checksum: 10c0/9324eec2942c8241d25c814b1fa68649fcd582bc768ab98c34e20265c57d8e28778a50c76e8351d9a0da0f8894c4e113f88bfc44fcae419c323f94d5a785f9cc
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/513c809c3ab6aaed29edbd753ad94b65d7546801bd3fb609bb71ada1564ec696d1a24204c42cd78e8c63d230adef9e1b4f59fe3cc6be1ef6828fccba877f5602
++  checksum: 10c0/eae58e52cd21d4ffe3630073d72b8c41caa84a26f7140e46c0f5caf9879cf811b40fbdff0f109b3922f5f272930d7b5adc83e47f8974688c006ad74c12485f72
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-json@npm:^1.0.0-rc.0, @swagger-api/apidom-parser-adapter-json@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-json@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/c7f4c50a124b1738510e53f55cf75a4b9b622aaf37f09fcaf0a74a8bdeef184aa16cd12fcde6a266bad6492879f9db18037d06392e55912a4a5a515ca79c9cb7
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/3298e3a8e91351533ca1e28ad971e24daae79d44e1b5a4ee12c420c43bef842ca7b4ddeeaa007f8d34f62a6ae27bde9c9e829155d38db40a973feb9285ead897
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/9e091160a28fa45e3bf3d7a4d3548b42dc58f5c1f3ddd72efd8420350d6819696966213181ece1c142b2c15f9e1ec735c8d9c2c20ce48175d4ef23306a611a0f
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-json@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-json@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
+     node-gyp: "npm:latest"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     tree-sitter: "npm:=0.21.1"
+     tree-sitter-json: "npm:=0.24.8"
+     web-tree-sitter: "npm:=0.24.5"
+-  checksum: 10c0/125aeae8b68f2b346d4168a1d02f20c6c57c8fef8e75a4037219c757e230665f5c0d51c28f62ee79559942063bab2238de23e636b5d4f3afdbb9ffa67429a7b9
++  checksum: 10c0/fca5de8a4c924b72fdfd0c8a3c647688c0c575cfacbbe5a43d8a3d87a4a4ce3a2014893cba76ec5e0ce0327ee3c0e36b83ec1047efb0ca59f7d6b1206706938e
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/5965e1d8f061b22622c7af41b4226a70179c8d2a488196bc632b905d38e6ec0c118d2de237ae8d0ff49e66f6a68398ce8b24cfaff8c663748472bb7cd542f534
++  checksum: 10c0/7946783cd11265f45d56acf3406d2173150adeab6ca6cfe41bfe7a8b5f4eed0b9323216cda8f4c47f96794c0fdff30168fb672574f3619655e7491d46729a62c
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/3cb02685e1d2f1ab56aabab89082025271f8988f3957901757fc41f8029e7ccd884bfaec46934a44b0f953cbf83dcdb2784aad6e929117a6d508b5d844790bb0
++  checksum: 10c0/256030920f5c1c524cc820f2e7a4c340a4cd644cbc9c34232ed1f705fb6f526f91aee1220ffe0b9fa92e3ee5bb83b05030acf863c5be7a21147f0f1b52c05193
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/0626f6362422195e1195aeb5c1cb6cd7b3dfcab2846de6951abf4d953ef7e1b0683748e9b3da39760bb08b7122b0f78d4e9cec19a6ee368d4f6e92862b6d49c7
++  checksum: 10c0/0f765a75f174211bf09abc6ed4b556a539d738a6d53fbdf103c686b5fc61238e515ea8610942c1c74331c6fbe4b6984d840711dc1cac617505e58b4b0e1776e1
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/a041afb41d10964ff849dd202f79e0692ac332ed280afbc88b565cbc04f89dfbd54808cdf6f616795e96b908e5b21f538951b5a0540d270d49ba54fb912e847a
++  checksum: 10c0/5269c95948aa882f5f54ba0ae758d3d56732ff511f37760dd1bf4889805273e3674aeeb7faaade8996b7de00a49f6494701ee52b52f5a6442467102272d9ac8d
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/d2f7e6f8486eefbcdf6495c7f0adad4a57827d5eff7feb87c969332a9b85df3cea6352e50ee0f8d939e5387e86d5dd5f23883d2c2457b9b853f3dfcbd7e46a80
++  checksum: 10c0/056d2c841c0928c0438e23a972f494c96962eda049dc1f677c198ec76da10b5eb244addd2da452a634f3fd0689ae7332ef01c232b667f02644d3402206f42f11
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/f2fa17ab28e012aa355aec4785fec3a926d01a996b5330337cf8c2a53341263ef3ea6ed519aec78179d20667812ffec5068e1a8243a9e6806ced8dea64926d20
++  checksum: 10c0/9d0a6e51f854e1f4bbb8bc6079c47aad0665e134af0a76b748662f52587e27f07b5657d1f1fc98c5a22ed055f4cc340353ca8acb7980855b921bfd7f6663dc05
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.0.0-rc.0, @swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:1.0.0-rc.1"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/ab23c1404b7e764c3eaec92f9cc04a6c9ccee9d0978581f223a942c0364db39055d5b93cabd3fda05245fb3218877d4173464e86def1cbca7fb140918c751596
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/810cb0e1384d0da50d096d73a35815658183d7217b2055552838f251ea274417e1614c97b9479b31f32ce9e865157c0063176907b12d86a9e282c977c638e7f0
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@tree-sitter-grammars/tree-sitter-yaml": "npm:=0.7.1"
+     "@types/ramda": "npm:~0.30.0"
+-    node-gyp: "npm:latest"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     tree-sitter: "npm:=0.22.4"
+     web-tree-sitter: "npm:=0.24.5"
+-  checksum: 10c0/11e675203fcadd1952141c3cd9456529fa26513a5babe735053f646e3d20df3354d5d1941eb78212a1a3ef1ed6569d69b738971901848ef2c442b3f7beb86f73
++  checksum: 10c0/bc05319a86f1e446738fb2f615d0818dbb9393740eb13c8002501e6f1f701ea1540d7d4f879a5d189496e20f7260920b7783b67cf44b94b027160275e451aaa8
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-reference@npm:^1.0.0-rc.1":
+-  version: 1.0.0-rc.1
+-  resolution: "@swagger-api/apidom-reference@npm:1.0.0-rc.1"
++"@swagger-api/apidom-reference@npm:^1.11.0":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-reference@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+-    axios: "npm:^1.12.2"
+-    minimatch: "npm:^7.4.3"
+-    process: "npm:^0.11.10"
++    axios: "npm:^1.16.0"
++    minimatch: "npm:^10.2.1"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+   dependenciesMeta:
+@@ -16165,6 +16254,8 @@
+       optional: true
+     "@swagger-api/apidom-ns-openapi-3-1":
+       optional: true
++    "@swagger-api/apidom-ns-openapi-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-api-design-systems-json":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-api-design-systems-yaml":
+@@ -16175,7 +16266,11 @@
+       optional: true
+     "@swagger-api/apidom-parser-adapter-asyncapi-json-2":
+       optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-json":
+       optional: true
+@@ -16185,15 +16280,19 @@
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-json-3-1":
+       optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-2":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1":
+       optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-yaml-1-2":
+       optional: true
+-  checksum: 10c0/d4b748539dafbfdc2f386a01bba53f453887dd22b8069aebcbbcc6ac30958dd05b5d3510cd7c911f34b3a1783a1ad210cb88dcdf1025dcf62c1006dc3eab4f3d
++  checksum: 10c0/aa0536e5461b4b63f0541e2cf547ed9a85059f588e8e35830d3cfc15f4fb72caeed1d90407349bc6df84b65aedbc37e70523ac22e638376c51cc299a0441c068
+   languageName: node
+   linkType: hard
+ 
+@@ -16927,6 +17026,15 @@
+   languageName: node
+   linkType: hard
+ 
++"@types/hast@npm:^3.0.0":
++  version: 3.0.5
++  resolution: "@types/hast@npm:3.0.5"
++  dependencies:
++    "@types/unist": "npm:*"
++  checksum: 10c0/f3af8594a6903a507ed191eda944af18099198d6708c29102ae17118c3e20779f6929e91ed37e033541fd28d58055d8a5910a4366dbdf976cf81b13a464741fb
++  languageName: node
++  linkType: hard
++
+ "@types/hoist-non-react-statics@npm:^3.3.0, @types/hoist-non-react-statics@npm:^3.3.1":
+   version: 3.3.6
+   resolution: "@types/hoist-non-react-statics@npm:3.3.6"
+@@ -17266,6 +17374,13 @@
+   languageName: node
+   linkType: hard
+ 
++"@types/prismjs@npm:^1.0.0":
++  version: 1.26.6
++  resolution: "@types/prismjs@npm:1.26.6"
++  checksum: 10c0/152a27500cb32b114edfb77f9d0dccd03bebc84828d1e92abacaf212b22d3ccdde041ce421dd58b6ec8461bbec7cd76ed5ee773cae4be7ca36a6dd4ddcf0f9e7
++  languageName: node
++  linkType: hard
++
+ "@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0, @types/prop-types@npm:^15.7.12, @types/prop-types@npm:^15.7.13, @types/prop-types@npm:^15.7.3":
+   version: 15.7.14
+   resolution: "@types/prop-types@npm:15.7.14"
+@@ -17523,6 +17638,13 @@
+   languageName: node
+   linkType: hard
+ 
++"@types/unist@npm:*":
++  version: 3.0.3
++  resolution: "@types/unist@npm:3.0.3"
++  checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
++  languageName: node
++  linkType: hard
++
+ "@types/unist@npm:^2, @types/unist@npm:^2.0.0":
+   version: 2.0.11
+   resolution: "@types/unist@npm:2.0.11"
+@@ -19218,7 +19340,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"axios@npm:^1.0.0, axios@npm:^1.12.0, axios@npm:^1.12.2, axios@npm:^1.13.6, axios@npm:^1.15.0":
++"axios@npm:^1.0.0, axios@npm:^1.12.0, axios@npm:^1.13.6, axios@npm:^1.15.0, axios@npm:^1.16.0":
+   version: 1.18.1
+   resolution: "axios@npm:1.18.1"
+   dependencies:
+@@ -20353,6 +20475,13 @@
+   languageName: node
+   linkType: hard
+ 
++"character-entities-legacy@npm:^3.0.0":
++  version: 3.0.0
++  resolution: "character-entities-legacy@npm:3.0.0"
++  checksum: 10c0/ec4b430af873661aa754a896a2b55af089b4e938d3d010fad5219299a6b6d32ab175142699ee250640678cd64bdecd6db3c9af0b8759ab7b155d970d84c4c7d1
++  languageName: node
++  linkType: hard
++
+ "character-entities@npm:^1.0.0":
+   version: 1.2.4
+   resolution: "character-entities@npm:1.2.4"
+@@ -20374,6 +20503,13 @@
+   languageName: node
+   linkType: hard
+ 
++"character-reference-invalid@npm:^2.0.0":
++  version: 2.0.1
++  resolution: "character-reference-invalid@npm:2.0.1"
++  checksum: 10c0/2ae0dec770cd8659d7e8b0ce24392d83b4c2f0eb4a3395c955dce5528edd4cc030a794cfa06600fcdd700b3f2de2f9b8e40e309c0011c4180e3be64a0b42e6a1
++  languageName: node
++  linkType: hard
++
+ "chardet@npm:^0.7.0":
+   version: 0.7.0
+   resolution: "chardet@npm:0.7.0"
+@@ -21247,7 +21383,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"copy-to-clipboard@npm:^3.2.0, copy-to-clipboard@npm:^3.3.1":
++"copy-to-clipboard@npm:^3.2.0, copy-to-clipboard@npm:^3.3.1, copy-to-clipboard@npm:^3.3.3":
+   version: 3.3.3
+   resolution: "copy-to-clipboard@npm:3.3.3"
+   dependencies:
+@@ -22626,27 +22762,15 @@
+   languageName: node
+   linkType: hard
+ 
+-"dompurify@npm:=3.2.6":
+-  version: 3.2.6
+-  resolution: "dompurify@npm:3.2.6"
+-  dependencies:
+-    "@types/trusted-types": "npm:^2.0.7"
+-  dependenciesMeta:
+-    "@types/trusted-types":
+-      optional: true
+-  checksum: 10c0/c8f8e5b0879a0d93c84a2e5e78649a47d0c057ed0f7850ca3d573d2cca64b84fb1ff85bd4b20980ade69c4e5b80ae73011340f1c2ff375c7ef98bb8268e1d13a
+-  languageName: node
+-  linkType: hard
+-
+-"dompurify@npm:^3.2.3, dompurify@npm:^3.3.2":
+-  version: 3.3.3
+-  resolution: "dompurify@npm:3.3.3"
++"dompurify@npm:^3.2.3, dompurify@npm:^3.3.2, dompurify@npm:^3.4.11":
++  version: 3.4.12
++  resolution: "dompurify@npm:3.4.12"
+   dependencies:
+     "@types/trusted-types": "npm:^2.0.7"
+   dependenciesMeta:
+     "@types/trusted-types":
+       optional: true
+-  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
++  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+   languageName: node
+   linkType: hard
+ 
+@@ -24337,9 +24461,9 @@
    linkType: hard
  
  "fast-uri@npm:^3.0.1":
@@ -82,7 +1065,7 @@
    languageName: node
    linkType: hard
  
-@@ -24775,29 +24767,29 @@
+@@ -24775,29 +24899,29 @@
    linkType: hard
  
  "form-data@npm:^2.5.0":
@@ -121,37 +1104,259 @@
    languageName: node
    linkType: hard
  
-@@ -25855,6 +25847,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
-+"hasown@npm:^2.0.4":
+@@ -25849,12 +25973,12 @@
+   languageName: node
+   linkType: hard
+ 
+-"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
+-  version: 2.0.2
+-  resolution: "hasown@npm:2.0.2"
++"hasown@npm:^2.0.0, hasown@npm:^2.0.2, hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
-+  dependencies:
-+    function-bind: "npm:^1.1.2"
+   dependencies:
+     function-bind: "npm:^1.1.2"
+-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
    languageName: node
    linkType: hard
  
-@@ -29427,6 +29428,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
+@@ -25889,6 +26013,15 @@
+   languageName: node
+   linkType: hard
+ 
++"hast-util-parse-selector@npm:^4.0.0":
++  version: 4.0.0
++  resolution: "hast-util-parse-selector@npm:4.0.0"
++  dependencies:
++    "@types/hast": "npm:^3.0.0"
++  checksum: 10c0/5e98168cb44470dc274aabf1a28317e4feb09b1eaf7a48bbaa8c1de1b43a89cd195cb1284e535698e658e3ec26ad91bc5e52c9563c36feb75abbc68aaf68fb9f
 +  languageName: node
 +  linkType: hard
 +
-+"long@npm:^5.3.2":
+ "hast-util-raw@npm:^7.2.0":
+   version: 7.2.3
+   resolution: "hast-util-raw@npm:7.2.3"
+@@ -25964,6 +26097,19 @@
+   languageName: node
+   linkType: hard
+ 
++"hastscript@npm:^9.0.0":
++  version: 9.0.1
++  resolution: "hastscript@npm:9.0.1"
++  dependencies:
++    "@types/hast": "npm:^3.0.0"
++    comma-separated-tokens: "npm:^2.0.0"
++    hast-util-parse-selector: "npm:^4.0.0"
++    property-information: "npm:^7.0.0"
++    space-separated-tokens: "npm:^2.0.0"
++  checksum: 10c0/18dc8064e5c3a7a2ae862978e626b97a254e1c8a67ee9d0c9f06d373bba155ed805fc5b5ce21b990fb7bc174624889e5e1ce1cade264f1b1d58b48f994bc85ce
++  languageName: node
++  linkType: hard
++
+ "he@npm:^1.2.0":
+   version: 1.2.0
+   resolution: "he@npm:1.2.0"
+@@ -26744,6 +26890,13 @@
+   version: 1.0.4
+   resolution: "is-alphabetical@npm:1.0.4"
+   checksum: 10c0/1505b1de5a1fd74022c05fb21b0e683a8f5229366bac8dc4d34cf6935bcfd104d1125a5e6b083fb778847629f76e5bdac538de5367bdf2b927a1356164e23985
++  languageName: node
++  linkType: hard
++
++"is-alphabetical@npm:^2.0.0":
++  version: 2.0.1
++  resolution: "is-alphabetical@npm:2.0.1"
++  checksum: 10c0/932367456f17237533fd1fc9fe179df77957271020b83ea31da50e5cc472d35ef6b5fb8147453274ffd251134472ce24eb6f8d8398d96dee98237cdb81a6c9a7
+   languageName: node
+   linkType: hard
+ 
+@@ -26757,6 +26910,16 @@
+   languageName: node
+   linkType: hard
+ 
++"is-alphanumerical@npm:^2.0.0":
++  version: 2.0.1
++  resolution: "is-alphanumerical@npm:2.0.1"
++  dependencies:
++    is-alphabetical: "npm:^2.0.0"
++    is-decimal: "npm:^2.0.0"
++  checksum: 10c0/4b35c42b18e40d41378293f82a3ecd9de77049b476f748db5697c297f686e1e05b072a6aaae2d16f54d2a57f85b00cbbe755c75f6d583d1c77d6657bd0feb5a2
++  languageName: node
++  linkType: hard
++
+ "is-arguments@npm:^1.0.4, is-arguments@npm:^1.1.1":
+   version: 1.1.1
+   resolution: "is-arguments@npm:1.1.1"
+@@ -26886,6 +27049,13 @@
+   version: 1.0.4
+   resolution: "is-decimal@npm:1.0.4"
+   checksum: 10c0/a4ad53c4c5c4f5a12214e7053b10326711f6a71f0c63ba1314a77bd71df566b778e4ebd29f9fb6815f07a4dc50c3767fb19bd6fc9fa05e601410f1d64ffeac48
++  languageName: node
++  linkType: hard
++
++"is-decimal@npm:^2.0.0":
++  version: 2.0.1
++  resolution: "is-decimal@npm:2.0.1"
++  checksum: 10c0/8085dd66f7d82f9de818fba48b9e9c0429cb4291824e6c5f2622e96b9680b54a07a624cfc663b24148b8e853c62a1c987cfe8b0b5a13f5156991afaf6736e334
+   languageName: node
+   linkType: hard
+ 
+@@ -26966,6 +27136,13 @@
+   version: 1.0.4
+   resolution: "is-hexadecimal@npm:1.0.4"
+   checksum: 10c0/ec4c64e5624c0f240922324bc697e166554f09d3ddc7633fc526084502626445d0a871fbd8cae52a9844e83bd0bb414193cc5a66806d7b2867907003fc70c5ea
++  languageName: node
++  linkType: hard
++
++"is-hexadecimal@npm:^2.0.0":
++  version: 2.0.1
++  resolution: "is-hexadecimal@npm:2.0.1"
++  checksum: 10c0/3eb60fe2f1e2bbc760b927dcad4d51eaa0c60138cf7fc671803f66353ad90c301605b502c7ea4c6bb0548e1c7e79dfd37b73b632652e3b76030bba603a7e9626
+   languageName: node
+   linkType: hard
+ 
+@@ -28125,14 +28302,14 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-yaml@npm:=4.1.0":
+-  version: 4.1.0
+-  resolution: "js-yaml@npm:4.1.0"
++"js-yaml@npm:=4.2.0":
++  version: 4.2.0
++  resolution: "js-yaml@npm:4.2.0"
+   dependencies:
+     argparse: "npm:^2.0.1"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
++  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+   languageName: node
+   linkType: hard
+ 
+@@ -28148,14 +28325,14 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:~4.1.0":
+-  version: 4.1.1
+-  resolution: "js-yaml@npm:4.1.1"
++"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.2.0":
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
+   dependencies:
+     argparse: "npm:^2.0.1"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
++  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+   languageName: node
+   linkType: hard
+ 
+@@ -28171,6 +28348,17 @@
+   languageName: node
+   linkType: hard
+ 
++"js-yaml@npm:~4.1.0":
++  version: 4.1.1
++  resolution: "js-yaml@npm:4.1.1"
++  dependencies:
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
++  languageName: node
++  linkType: hard
++
+ "js2xmlparser@npm:^4.0.2":
+   version: 4.0.2
+   resolution: "js2xmlparser@npm:4.0.2"
+@@ -29423,10 +29611,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"long@npm:^5.0.0, long@npm:^5.2.1":
+-  version: 5.2.3
+-  resolution: "long@npm:5.2.3"
+-  checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++"long@npm:^5.0.0, long@npm:^5.2.1, long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
    languageName: node
    linkType: hard
  
-@@ -33625,22 +33633,21 @@
+@@ -30589,7 +30777,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"minimatch@npm:^7.4.2, minimatch@npm:^7.4.3":
++"minimatch@npm:^7.4.2":
+   version: 7.4.9
+   resolution: "minimatch@npm:7.4.9"
+   dependencies:
+@@ -31237,23 +31425,6 @@
+   languageName: node
+   linkType: hard
+ 
+-"node-domexception@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "node-domexception@npm:1.0.0"
+-  checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+-  languageName: node
+-  linkType: hard
+-
+-"node-fetch-commonjs@npm:^3.3.2":
+-  version: 3.3.2
+-  resolution: "node-fetch-commonjs@npm:3.3.2"
+-  dependencies:
+-    node-domexception: "npm:^1.0.0"
+-    web-streams-polyfill: "npm:^3.0.3"
+-  checksum: 10c0/87d36ed3e6dcb9dea96783700bc0becf0fdbcdc26c975e16b01a0d3a6e2f420c7e589e765bbfad461ae5377d4c5bd5f6937969a9dd34a0d736a81ac898f5c26a
+-  languageName: node
+-  linkType: hard
+-
+ "node-fetch@npm:2.6.7":
+   version: 2.6.7
+   resolution: "node-fetch@npm:2.6.7"
+@@ -32311,6 +32482,21 @@
+   languageName: node
+   linkType: hard
+ 
++"parse-entities@npm:^4.0.0":
++  version: 4.0.2
++  resolution: "parse-entities@npm:4.0.2"
++  dependencies:
++    "@types/unist": "npm:^2.0.0"
++    character-entities-legacy: "npm:^3.0.0"
++    character-reference-invalid: "npm:^2.0.0"
++    decode-named-character-reference: "npm:^1.0.0"
++    is-alphanumerical: "npm:^2.0.0"
++    is-decimal: "npm:^2.0.0"
++    is-hexadecimal: "npm:^2.0.0"
++  checksum: 10c0/a13906b1151750b78ed83d386294066daf5fb559e08c5af9591b2d98cc209123103016a01df776f65f8219ad26652d6d6b210d0974d452049cddfc53a8916c34
++  languageName: node
++  linkType: hard
++
+ "parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
+   version: 5.2.0
+   resolution: "parse-json@npm:5.2.0"
+@@ -33615,6 +33801,13 @@
+   languageName: node
+   linkType: hard
+ 
++"property-information@npm:^7.0.0":
++  version: 7.2.0
++  resolution: "property-information@npm:7.2.0"
++  checksum: 10c0/03662c8f9e1544510914c5e594ae72963f67d261027a5fdc06c4134742584fe40dd49b959470d30e757e9fb70b297d8546ab1362a040364144029926ad4e07c4
++  languageName: node
++  linkType: hard
++
+ "proto3-json-serializer@npm:^2.0.2":
+   version: 2.0.2
+   resolution: "proto3-json-serializer@npm:2.0.2"
+@@ -33625,22 +33818,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
@@ -182,7 +1387,238 @@
    languageName: node
    linkType: hard
  
-@@ -38727,9 +38734,9 @@
+@@ -34150,15 +34342,15 @@
+   languageName: node
+   linkType: hard
+ 
+-"react-copy-to-clipboard@npm:5.1.0":
+-  version: 5.1.0
+-  resolution: "react-copy-to-clipboard@npm:5.1.0"
++"react-copy-to-clipboard@npm:5.1.1":
++  version: 5.1.1
++  resolution: "react-copy-to-clipboard@npm:5.1.1"
+   dependencies:
+-    copy-to-clipboard: "npm:^3.3.1"
++    copy-to-clipboard: "npm:^3.3.3"
+     prop-types: "npm:^15.8.1"
+   peerDependencies:
+-    react: ^15.3.0 || 16 || 17 || 18
+-  checksum: 10c0/de70d9f9c2d17cee207888ed791d4a042c300e5ca732503434d49e6745cff56c0d5ebcc82ab86237e9c2248e636d1d031b9f9cf9913ecec61d82a0e5ebc93881
++    react: ">=15.3.0"
++  checksum: 10c0/a46adefbb47508259af135c6de3b29de14a68b3874d94f76d20f079e0b3b399e1038f06a9116216805dce64d90d9d96cdab10af06969dd4b941c4b5d546b6158
+   languageName: node
+   linkType: hard
+ 
+@@ -34619,7 +34811,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"react-syntax-highlighter@npm:^15.4.5, react-syntax-highlighter@npm:^15.6.1":
++"react-syntax-highlighter@npm:^15.4.5":
+   version: 15.6.6
+   resolution: "react-syntax-highlighter@npm:15.6.6"
+   dependencies:
+@@ -34635,6 +34827,22 @@
+   languageName: node
+   linkType: hard
+ 
++"react-syntax-highlighter@npm:^16.0.0":
++  version: 16.1.1
++  resolution: "react-syntax-highlighter@npm:16.1.1"
++  dependencies:
++    "@babel/runtime": "npm:^7.28.4"
++    highlight.js: "npm:^10.4.1"
++    highlightjs-vue: "npm:^1.0.0"
++    lowlight: "npm:^1.17.0"
++    prismjs: "npm:^1.30.0"
++    refractor: "npm:^5.0.0"
++  peerDependencies:
++    react: ">= 0.14.0"
++  checksum: 10c0/5f3d7361f3db68dc1ec38aaf2b347d4fe15398b21aa3b4c69593d4d146ee1db15289c8c3bcd491e6bf73a656afd490d3cd8a6189c7dd180a8aae81ec035bffa4
++  languageName: node
++  linkType: hard
++
+ "react-transition-group@npm:^4.0.0, react-transition-group@npm:^4.4.0, react-transition-group@npm:^4.4.5":
+   version: 4.4.5
+   resolution: "react-transition-group@npm:4.4.5"
+@@ -34951,6 +35159,18 @@
+     parse-entities: "npm:^2.0.0"
+     prismjs: "npm:~1.27.0"
+   checksum: 10c0/63ab62393c8c2fd7108c2ea1eff721c0ad2a1a6eee60fdd1b47f4bb25cf298667dc97d041405b3e718b0817da12b37a86ed07ebee5bd2ca6405611f1bae456db
++  languageName: node
++  linkType: hard
++
++"refractor@npm:^5.0.0":
++  version: 5.0.0
++  resolution: "refractor@npm:5.0.0"
++  dependencies:
++    "@types/hast": "npm:^3.0.0"
++    "@types/prismjs": "npm:^1.0.0"
++    hastscript: "npm:^9.0.0"
++    parse-entities: "npm:^4.0.0"
++  checksum: 10c0/7b69a3b525f88de4adae3467f30ff7e80513fa53e65d85656f169ded16e314f471dfa936ccc545ae604e178ee7a108cbd94e6144a5bd541ed8d20626cc75e7b8
+   languageName: node
+   linkType: hard
+ 
+@@ -37247,35 +37467,99 @@
+   languageName: node
+   linkType: hard
+ 
+-"swagger-client@npm:^3.36.0":
+-  version: 3.36.0
+-  resolution: "swagger-client@npm:3.36.0"
++"swagger-client@npm:^3.37.4":
++  version: 3.37.6
++  resolution: "swagger-client@npm:3.37.6"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.22.15"
+     "@scarf/scarf": "npm:=1.4.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-reference": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.0"
++    "@swagger-api/apidom-error": "npm:^1.11.0"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.0"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.0"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.0"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@swagger-api/apidom-reference": "npm:^1.11.0"
+     "@swaggerexpert/cookie": "npm:^2.0.2"
+     deepmerge: "npm:~4.3.0"
+     fast-json-patch: "npm:^3.0.0-1"
+-    js-yaml: "npm:^4.1.0"
++    js-yaml: "npm:^4.2.0"
+     neotraverse: "npm:=0.6.18"
+     node-abort-controller: "npm:^3.1.1"
+-    node-fetch-commonjs: "npm:^3.3.2"
+     openapi-path-templating: "npm:^2.2.1"
+     openapi-server-url-templating: "npm:^1.3.0"
+     ramda: "npm:^0.30.1"
+     ramda-adjunct: "npm:^5.1.0"
+-  checksum: 10c0/a774886ea2f4a0f98733c784a8d0db8ab73a6e43856c411e8562846cd7eee5669772fa509f33a2e8d7fd67ed9073ec7c74d0a937a28534856c496d2423c812b1
++  dependenciesMeta:
++    "@swagger-api/apidom-ns-asyncapi-2":
++      optional: true
++    "@swagger-api/apidom-ns-asyncapi-3":
++      optional: true
++    "@swagger-api/apidom-ns-openapi-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-json":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-yaml-1-2":
++      optional: true
++  checksum: 10c0/78f6734db5d9c154a809e6878cb0056d63ffbdca98060cee045a120eed29d6de44c90e13eee626ba6b7bc6d2ef5012e000a7f9de5a3e5ef53b0f18a4e166530a
+   languageName: node
+   linkType: hard
+ 
+ "swagger-ui-react@npm:^5.27.1":
+-  version: 5.30.0
+-  resolution: "swagger-ui-react@npm:5.30.0"
++  version: 5.32.9
++  resolution: "swagger-ui-react@npm:5.32.9"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.27.1"
+     "@scarf/scarf": "npm:=1.4.0"
+@@ -37284,29 +37568,29 @@
+     classnames: "npm:^2.5.1"
+     css.escape: "npm:1.5.1"
+     deep-extend: "npm:0.6.0"
+-    dompurify: "npm:=3.2.6"
++    dompurify: "npm:^3.4.11"
+     ieee754: "npm:^1.2.1"
+     immutable: "npm:^3.x.x"
+     js-file-download: "npm:^0.4.12"
+-    js-yaml: "npm:=4.1.0"
+-    lodash: "npm:^4.17.21"
++    js-yaml: "npm:=4.2.0"
++    lodash: "npm:^4.18.1"
+     prop-types: "npm:^15.8.1"
+     randexp: "npm:^0.5.3"
+     randombytes: "npm:^2.1.0"
+-    react-copy-to-clipboard: "npm:5.1.0"
++    react-copy-to-clipboard: "npm:5.1.1"
+     react-debounce-input: "npm:=3.3.0"
+     react-immutable-proptypes: "npm:2.2.0"
+     react-immutable-pure-component: "npm:^2.2.0"
+     react-inspector: "npm:^6.0.1"
+     react-redux: "npm:^9.2.0"
+-    react-syntax-highlighter: "npm:^15.6.1"
++    react-syntax-highlighter: "npm:^16.0.0"
+     redux: "npm:^5.0.1"
+     redux-immutable: "npm:^4.0.0"
+     remarkable: "npm:^2.0.1"
+     reselect: "npm:^5.1.1"
+     serialize-error: "npm:^8.1.0"
+     sha.js: "npm:^2.4.12"
+-    swagger-client: "npm:^3.36.0"
++    swagger-client: "npm:^3.37.4"
+     url-parse: "npm:^1.5.10"
+     xml: "npm:=1.0.1"
+     xml-but-prettier: "npm:^1.0.1"
+@@ -37314,7 +37598,7 @@
+   peerDependencies:
+     react: ">=16.8.0 <20"
+     react-dom: ">=16.8.0 <20"
+-  checksum: 10c0/5d6e50df7b7cc646297e0893cb4b53c3bbf59a05a360b7062342dfd2dd6391ca9924a0675df4c0e9e5516f7f00049dc8e0f5ceeb7ae9d8b3b5e1bb90778d9cfd
++  checksum: 10c0/3987fb028eec6faf05cf9cbb80da7cf25b4d12f14368df90a9df0ef014ea73fe8e89408e6ea3653e8825605dbd82dfa99508fb24a4774f21c86dd7e2628960bf
+   languageName: node
+   linkType: hard
+ 
+@@ -38727,9 +39011,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.2.3, undici@npm:^7.24.0":
@@ -195,3 +1631,17 @@
    languageName: node
    linkType: hard
  
+@@ -39496,13 +39780,6 @@
+   languageName: node
+   linkType: hard
+ 
+-"web-streams-polyfill@npm:^3.0.3":
+-  version: 3.3.3
+-  resolution: "web-streams-polyfill@npm:3.3.3"
+-  checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+-  languageName: node
+-  linkType: hard
+-
+ "web-tree-sitter@npm:=0.24.5":
+   version: 0.24.5
+   resolution: "web-tree-sitter@npm:0.24.5"

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -6,6 +6,10 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: eb6cce6110fc8bd532e717e9d995764481b36f1b
 backports:
   - cve_ids:
+      - CVE-2026-49978
+    package: dompurify
+    patch_version: 3.4.12
+  - cve_ids:
       - CVE-2026-13676
     package: fast-uri
     patch_version: 3.1.3


### PR DESCRIPTION
It bumps dompurify to 3.4.7 or higher to fix CVE-2026-49978
https://redhat.atlassian.net/browse/RHIDP-15535