### PR TITLE
chore(deps): [release-1.10][lightspeed] bump dompurify to 3.4.7 or higher

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,21 +29,961 @@
    languageName: node
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+   languageName: node
+   linkType: hard
+ 
+@@ -13215,528 +13207,579 @@
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ast@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ast@npm:1.0.0"
++"@swagger-api/apidom-ast@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ast@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     unraw: "npm:^3.0.0"
+-  checksum: 10c0/8ef48b93a4fcacb0a114fe8b1bfd8b69997c908014d9fe2dc0287e427313b13478bebb1ac410f569b3492d3724c52e1e7742aeffedb0631f7be37a2598a00f1a
++  checksum: 10c0/e2595f82f8748108e95b09663b89aff6a35d15d3b57bb241b31a0cc0921dd13f1e313605d29471039ae9203d521c7a560e794bcb3bb866b78a656bf62af663b8
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-core@npm:^1.0.0, @swagger-api/apidom-core@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-core@npm:1.0.0"
++"@swagger-api/apidom-core@npm:^1.11.0, @swagger-api/apidom-core@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-core@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     minim: "npm:~0.23.8"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     short-unique-id: "npm:^5.3.2"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/52bcbc47a1d01a22927363ac62dbf31a58709debd7450edf3021f2b07c39019f669ac111c231931159e9e15348e61e17045e300a40b6bd32bfe9a9dec38cc5db
++  checksum: 10c0/397483645435b7d91660bc56300f0c1f8e974cc46494983b507a752af224b9185eea8eb692d7b39c6f1b96f0056fff74203559815a7bf0636131f867ed6a6325
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-error@npm:^1.0.0, @swagger-api/apidom-error@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-error@npm:1.0.0"
++"@swagger-api/apidom-error@npm:^1.11.0, @swagger-api/apidom-error@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-error@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.20.7"
+-  checksum: 10c0/7596bf4fae932e1ae86fd336df9f7c55bf067d33643599c116d89daa3b303e35f5253564020548bdc4efe3bf56d4c5981a76f199c5206e9170d1fad20f1b868e
++  checksum: 10c0/0c5d089d3c58ff46ae91fbd60e4ff328d0a334a6764f65f3d88a00b7a8622010aeaff5c705fdcab42bb51f95c6a053d843383aff9e40e059e86e50786289985c
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-json-pointer@npm:^1.0.0, @swagger-api/apidom-json-pointer@npm:^1.0.0-rc.0, @swagger-api/apidom-json-pointer@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-json-pointer@npm:1.0.0"
++"@swagger-api/apidom-json-pointer@npm:^1.11.0, @swagger-api/apidom-json-pointer@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-json-pointer@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@swaggerexpert/json-pointer": "npm:^2.10.1"
+-  checksum: 10c0/2a8c0fe5556d517e6d0b0db6436a124b680acb4b6a4c619d4782d38d6f41bac50df33ac86ef5be17b9a1d7432b22272bc89ab6170d17d90ef6710ee1b895bd69
++  checksum: 10c0/39cf5e9a1df5ae654ed8851f1f9540899c57e01b027cb2bcd783f2f2cacbb48744f852f83b52d345423ddff413581e05f0e002e22113b132d1105cb9ca80819a
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-api-design-systems@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:1.0.0"
++"@swagger-api/apidom-ns-api-design-systems@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/08ed193d8f3d0e1e94f570df16dc8a3c4e5bc50e9cf80b1a0bccafa0c3c78508d76c473e09f62303f986a923750c88de3c37796356a2bb2e1f2edd0ae226001d
++  checksum: 10c0/7554e3e0208e22596ace36660e3f46bc0e4f4b270a5b6be313b0d5cf774ac8500b3bde076cc35bb00f081df9de2ea8091ef5885f42b59115006ee405e30d7511
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-arazzo-1@npm:^1.0.0, @swagger-api/apidom-ns-arazzo-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-arazzo-1@npm:1.0.0"
++"@swagger-api/apidom-ns-arazzo-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-arazzo-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/1cf83a59d786ea41391b85fd233bc1043703f57166b75c952a13d660593e7c30424e561ea0e0110861e351494971ec9c787ba350389ecf034fc8a60584804468
++  checksum: 10c0/34d4cc020fab5ee5ccfd7d32bad77109b20d13ea9ddaf44e957813850123b7010c80f167402fab6c7070d2fab5274f504eebda2017b85f54697a41b24b158076
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-asyncapi-2@npm:^1.0.0, @swagger-api/apidom-ns-asyncapi-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:1.0.0"
++"@swagger-api/apidom-ns-asyncapi-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/0eadc5fa28ce516fe1308f0380a0663872be89beab68a282ea97bff9ee82373dc89e9e526fc10c4fb8cc486521861a5a61a864d9691ef5e889f129f6c594c56a
++  checksum: 10c0/af775a11bceba7c41fcce50f13ec7baa64194aa6f781842c05b9b7de3ed456831aa6dcfe49323d3ff93eda680014aaacb2bb50478a9956ea4cb49c099cf8bae9
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-asyncapi-3@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-asyncapi-3@npm:1.0.0"
++"@swagger-api/apidom-ns-asyncapi-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-asyncapi-3@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/d3ecece78fe2bd0063f8d58816f3783902a14620a0998ed84a611c47d65b7311bed237dd2cba86b70fa1eee1212dade0c628d53d346543aee22c6f480d17dedc
++  checksum: 10c0/01c7ece4fa8a4e1f81913e9ed018b5439b926874e00882dc79e24556ccbad329cd149184e19f15a4f42f00eba6c4f3b69773b314191760c8000422ddd06a3e79
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-2019-09@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-2019-09@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-2019-09@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-2019-09@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/3710e8add1ef87c280a0527b0b619c6a7d0d4f11864fc87cd42c978575245f5007102ce9be8950aff1d24fa6c61a1b4e3fa94fd602824990b14ef359c0013d20
++  checksum: 10c0/7c4078e81b5fcd869869a576d211ed9bc0186461b7467881c62a82975e2f5945130385a372e7b7e80eb874f43912a4876f6a3352dac7d7491edd702942676a62
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-2020-12@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-2020-12@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-2020-12@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-2020-12@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-2019-09": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2019-09": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/c913a0428d2c719465f3cf8b48df9fa4b55cf07c97a59bd66aa1758c6b784eefaab1f8095d1dd8c71b6bb7853c38a248a0c39329700c0f1c8e0f33eca8102475
++  checksum: 10c0/7dcb997bdcaa6c3f1f5ca0a68eaae13988af8b20aeea1fdce8fc11e874312100369e8ea5b942a55a82e380a22cf0c912d40fcfd316dc2bbbfff2096eadaa6686
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-4@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-draft-4@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/d59644f68069aa83801cf96493876888b3844de04cf5297777adf9d11f5d322acd5774942b6a1398cf6cdf63517b927457db59c2f17fd7e686da420a25dd410b
++  checksum: 10c0/1f0269f0ae1951edca13b6922028bd8e294a8931847e1a4ac1e9f38c4db78e6960714dcc6e691adc091e3f241808fd6af8884615d5fe1c4f800cf38006efca54
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-6@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-draft-6@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/a52f3d1ee0b53ebddcf9e8cc47046b7ccf8c7e1db1d80fd046b53c6453f1ce0f522bcbc723235e60afce29678ea5a846c96407ef9d4e94600baf3f5b38ab6fd1
++  checksum: 10c0/b431973c16b5570b19b555366ace9ca9563705912fa730aadc434272af68117c288863663375723c48ef17bede088a4dbedac85947ec17af413a9bb6dd8b429a
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-7@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-draft-7@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/79132c7bb642ac8648243722e60c1165cf1c833f7c7eff46e4e722ff522c6e99c2683603a89d40b70ae22674c30996125119634b7836a67ee857fef870e60359
++  checksum: 10c0/09035f8e569f2073009051876abdc80708e304ecb11b04c9dfe0288fd87084fa99c61c8df134a6cabd9bd3ef2b76cff08156c813dc8087cd3ce8e5809d394d65
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-2@npm:^1.0.0, @swagger-api/apidom-ns-openapi-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-openapi-2@npm:1.0.0"
++"@swagger-api/apidom-ns-openapi-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/55c1b057b40780edd930463506907b84cea49b99b788bc4526249867707fed9d5cb2c1d4a2d52b3782be749901dcba32c1402c3af6bf29caf6b4f49cf0083bf0
++  checksum: 10c0/95ad6eb1026dcd4eaf00ec1fe98461f2ba3a4c2793394fda42bc4d97ef9e0a33e8f94add116f9ba9c02f5feb3ccfc7b8e3b2b430b5b60d299e9f7f92d651c36b
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-3-0@npm:^1.0.0, @swagger-api/apidom-ns-openapi-3-0@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:1.0.0"
++"@swagger-api/apidom-ns-openapi-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/e26ca00cc48ecdd8b135faaa51b59b0e5cfe2cb3eda99c3890b233c85bdef226e197617e7f6206565baece7f2f1922265ffaad569a99af49a15c56e88bdda1d9
++  checksum: 10c0/227f4744c36ad40a0779847a356c33554b0a9ac6f61742a446fec0ba85314c375bea5cfbcbc683d4b2aa0278f5399d84e6fb85c926148397faacd6c0207f1103
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-3-1@npm:^1.0.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.0.0-rc.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:1.0.0"
++"@swagger-api/apidom-ns-openapi-3-1@npm:^1.11.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/1a41940f999447ef7b95d8b717934728340dd2fdf87bae067743d7fea59472d1c95d40ec8ab47ab25a4132abe1e560313e895a4a461022ff781e6a784140ebdb
++  checksum: 10c0/9953cc31b75a9632afaacb4690ac1f80f880311b7c7beafc5aaaf357fbb8b68f6a5dc2cbbe5659d43d118687f93641898c7814b8fa25ba2911dbda4f7fccb516
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:1.0.0"
++"@swagger-api/apidom-ns-openapi-3-2@npm:^1.11.0, @swagger-api/apidom-ns-openapi-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/22c989382325d2a4174cefd0e73ebb5db13cdb28ceb22a00c9dc64a1c59eaf53a6905cbd2d9fc510c590eef75b9dfb50a92a71a03b9dd453503086531d7c8b24
++    ts-mixer: "npm:^6.0.3"
++  checksum: 10c0/6bd09f33369e50d4681bc5e132073302e5f73bbcaf8c29086e1d5a807ac4f4a4d95871852e980e7446da359cad04edc3f80c6da82f0406ed8bfb3abc67ee2a66
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/9d58a7185d533e940e141ed0b8a54310c944bf60db16a55c2cc313c75c58825433e7982019207c1bb9d6eaa529882220a0b5b65e54ab489111700bf8c3753866
++  checksum: 10c0/a4fe017c2d80daf95b2c4d6a8d52efb9883ae9b9bc5c1e3e4bc885168a1202de5fe43a007139245c6aed8e89078c98ca4ef5a878f5168f125b1a4dbf9ad43802
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/a1c055c98dff15b82affc11f30804f3940072ce3bb38c082f18a858ea002f3cd2a50fb6a350ed58235d38a87a377c26cdb0fb5ee595684b86f7a522e8403d025
++  checksum: 10c0/fade65dd190174e092e8024519d58a4e863a048968b711fc5edc54aedf06ec418b2586bceaa22155f4f822c2d8ce4b61c2f78f22a7c6e220930e6f18aec93bec
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/64522bba83a3c02b6deb8fd756605b013a672ac0faf7ed7f4e817ea8f52385b0ae68150f07fa6e6e4bdee7195cdda21a9a4f78e840188d20bc1af0cc10a20925
++  checksum: 10c0/7ae294ba91238552b0c26727fb6625b1191f6e224bcc47a8a57572935634cb5e892a5c257ff45530ec0fb38dc1a8900a1946c844d29c36fe68480e42f69a1304
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/e44d9e5a80afaf59caf94057555c0bf553650d1ea231c49e4bb041384a9feccd111f0d69f338fd4e9de0f1e18d7072a46f8a30ffc8e2b3d36a817e8444f1c51b
++  checksum: 10c0/9324eec2942c8241d25c814b1fa68649fcd582bc768ab98c34e20265c57d8e28778a50c76e8351d9a0da0f8894c4e113f88bfc44fcae419c323f94d5a785f9cc
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/0eec71a07f486e271c1d7c8972e935d68971c730192737b010780e3b8a5ff325e2d1347533aa5388419f60b274c3e57c5c22c2c4550432fe8aacf43f82f9d322
++  checksum: 10c0/eae58e52cd21d4ffe3630073d72b8c41caa84a26f7140e46c0f5caf9879cf811b40fbdff0f109b3922f5f272930d7b5adc83e47f8974688c006ad74c12485f72
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/dd2a75b3c17e8fa5fa3ecb6ec53529c68129c6dc89053f3d9cfa33df67d20d48804d6d0abafbcb3882b8048ec7422c2ecb26802ed42ddba6eb2f08feb3ff1f1a
++  checksum: 10c0/c7f4c50a124b1738510e53f55cf75a4b9b622aaf37f09fcaf0a74a8bdeef184aa16cd12fcde6a266bad6492879f9db18037d06392e55912a4a5a515ca79c9cb7
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/74582ea8af30be8bfba70ff54b458d72376b321f96a749ddf22317aaa0faf5f7f459c5484db4157ebb4b3dd7683258290251490c523001810223a7cf6ab4fac5
++  checksum: 10c0/3298e3a8e91351533ca1e28ad971e24daae79d44e1b5a4ee12c420c43bef842ca7b4ddeeaa007f8d34f62a6ae27bde9c9e829155d38db40a973feb9285ead897
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-json@npm:^1.0.0, @swagger-api/apidom-parser-adapter-json@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-json@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/9e091160a28fa45e3bf3d7a4d3548b42dc58f5c1f3ddd72efd8420350d6819696966213181ece1c142b2c15f9e1ec735c8d9c2c20ce48175d4ef23306a611a0f
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-json@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-json@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
+     node-gyp: "npm:latest"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     tree-sitter: "npm:=0.21.1"
+     tree-sitter-json: "npm:=0.24.8"
+     web-tree-sitter: "npm:=0.24.5"
+-  checksum: 10c0/17379da0ed0f0b111303bae1461e8bb403d65cc5bb8c7e15bbf4c1734fe4caacab44360c7e575851752ea143740180849c8242f16c1d1e62295f91d810f993e0
++  checksum: 10c0/fca5de8a4c924b72fdfd0c8a3c647688c0c575cfacbbe5a43d8a3d87a4a4ce3a2014893cba76ec5e0ce0327ee3c0e36b83ec1047efb0ca59f7d6b1206706938e
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/65e97a1b6c8e1097b57c78c671e01970badf50fa26656b5c91dcf1cb34d7dcb4258c7005f548f98b71d9273b0f29e7a8cb21262aa1073547f052d73197bf2004
++  checksum: 10c0/7946783cd11265f45d56acf3406d2173150adeab6ca6cfe41bfe7a8b5f4eed0b9323216cda8f4c47f96794c0fdff30168fb672574f3619655e7491d46729a62c
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/c53be21ea8f16cac40f486ec2dba59def4963fde76f5f006ed3ddb698ae15c604de7ac53bb4ec37edf4dd377d88795a7426f175da40916a06e4be71418336430
++  checksum: 10c0/256030920f5c1c524cc820f2e7a4c340a4cd644cbc9c34232ed1f705fb6f526f91aee1220ffe0b9fa92e3ee5bb83b05030acf863c5be7a21147f0f1b52c05193
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/0366332d8db1e5a24f967b8d4f75e112c65a76c8119ad1157d920a34df8d8eed4551f7a4269ad3b9acf8c571287c3fdf1c7937547bf7c55ce9f2d819752acba2
++  checksum: 10c0/0f765a75f174211bf09abc6ed4b556a539d738a6d53fbdf103c686b5fc61238e515ea8610942c1c74331c6fbe4b6984d840711dc1cac617505e58b4b0e1776e1
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/98ccec43b3f257c2724e56bb462b713e3cfd9619f36db8a8f477257c6aec3b4ef17447e8fa60051c5b02252f0844aa3135687a23e9855fffa685bb49023ebdd0
++  checksum: 10c0/5269c95948aa882f5f54ba0ae758d3d56732ff511f37760dd1bf4889805273e3674aeeb7faaade8996b7de00a49f6494701ee52b52f5a6442467102272d9ac8d
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/82cbe51351e85a4c6dfcbbbe17be511f1a70ef1f541e7ca98a6ed71217f023d85dfe4de2afdb3c5762b1fb9b0fbcb180235a714e0f7f6f84c1617f280de9bd8c
++  checksum: 10c0/056d2c841c0928c0438e23a972f494c96962eda049dc1f677c198ec76da10b5eb244addd2da452a634f3fd0689ae7332ef01c232b667f02644d3402206f42f11
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/efc9357c05388753029dbc79add119f522e7cddba4da1c254620becaf9818137bed1e2ad3276a2651a068c4bef6cc982ad2407cac949a7c197f6355d91f0f067
++  checksum: 10c0/9d0a6e51f854e1f4bbb8bc6079c47aad0665e134af0a76b748662f52587e27f07b5657d1f1fc98c5a22ed055f4cc340353ca8acb7980855b921bfd7f6663dc05
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.0.0, @swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/ab23c1404b7e764c3eaec92f9cc04a6c9ccee9d0978581f223a942c0364db39055d5b93cabd3fda05245fb3218877d4173464e86def1cbca7fb140918c751596
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/810cb0e1384d0da50d096d73a35815658183d7217b2055552838f251ea274417e1614c97b9479b31f32ce9e865157c0063176907b12d86a9e282c977c638e7f0
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@tree-sitter-grammars/tree-sitter-yaml": "npm:=0.7.1"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     tree-sitter: "npm:=0.22.4"
+     web-tree-sitter: "npm:=0.24.5"
+-  checksum: 10c0/53f8448c4cd162e23a61b23a9620f94388b38932d899570e82eb70400021a4634968e384f967f7c157c22006ea830a90bc5800488c6a1100a5505ed0439043e9
++  checksum: 10c0/bc05319a86f1e446738fb2f615d0818dbb9393740eb13c8002501e6f1f701ea1540d7d4f879a5d189496e20f7260920b7783b67cf44b94b027160275e451aaa8
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-reference@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-reference@npm:1.0.0"
++"@swagger-api/apidom-reference@npm:^1.11.0":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-reference@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+-    axios: "npm:^1.12.2"
+-    minimatch: "npm:^7.4.3"
+-    process: "npm:^0.11.10"
++    axios: "npm:^1.16.0"
++    minimatch: "npm:^10.2.1"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+   dependenciesMeta:
+@@ -13752,6 +13795,8 @@
+       optional: true
+     "@swagger-api/apidom-ns-openapi-3-1":
+       optional: true
++    "@swagger-api/apidom-ns-openapi-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-api-design-systems-json":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-api-design-systems-yaml":
+@@ -13776,15 +13821,19 @@
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-json-3-1":
+       optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-2":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1":
+       optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-yaml-1-2":
+       optional: true
+-  checksum: 10c0/64b6bcee7050c23918ea8fdf3981f79481f586c7b1d20563f1c4c8747f91e991541852a5c070d878ce4acb64fc6035d060045adc3f50b006e56b910f5ca397e7
++  checksum: 10c0/aa0536e5461b4b63f0541e2cf547ed9a85059f588e8e35830d3cfc15f4fb72caeed1d90407349bc6df84b65aedbc37e70523ac22e638376c51cc299a0441c068
+   languageName: node
+   linkType: hard
+ 
+@@ -16785,7 +16834,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"axios@npm:^1.0.0, axios@npm:^1.12.0, axios@npm:^1.12.2":
++"axios@npm:^1.0.0, axios@npm:^1.12.0":
+   version: 1.13.6
+   resolution: "axios@npm:1.13.6"
+   dependencies:
+@@ -16793,6 +16842,18 @@
+     form-data: "npm:^4.0.5"
+     proxy-from-env: "npm:^1.1.0"
+   checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
++  languageName: node
++  linkType: hard
++
++"axios@npm:^1.16.0":
++  version: 1.18.1
++  resolution: "axios@npm:1.18.1"
++  dependencies:
++    follow-redirects: "npm:^1.16.0"
++    form-data: "npm:^4.0.5"
++    https-proxy-agent: "npm:^5.0.1"
++    proxy-from-env: "npm:^2.1.0"
++  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
+   languageName: node
+   linkType: hard
+ 
+@@ -18646,7 +18707,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"copy-to-clipboard@npm:^3.2.0, copy-to-clipboard@npm:^3.3.1":
++"copy-to-clipboard@npm:^3.2.0, copy-to-clipboard@npm:^3.3.1, copy-to-clipboard@npm:^3.3.3":
+   version: 3.3.3
+   resolution: "copy-to-clipboard@npm:3.3.3"
+   dependencies:
+@@ -19966,39 +20027,27 @@
+   languageName: node
+   linkType: hard
+ 
+-"dompurify@npm:3.2.7":
+-  version: 3.2.7
+-  resolution: "dompurify@npm:3.2.7"
+-  dependencies:
+-    "@types/trusted-types": "npm:^2.0.7"
+-  dependenciesMeta:
+-    "@types/trusted-types":
+-      optional: true
+-  checksum: 10c0/d41bb31a72f1acdf9b84c56723c549924b05d92a39a15bd8c40bec9007ff80d5fccf844bc53ee12af5b69044f9a7ce24a1e71c267a4f49cf38711379ed8c1363
 -  languageName: node
 -  linkType: hard
 -
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
-@@ -21220,13 +21212,13 @@
+-"dompurify@npm:=3.2.6":
+-  version: 3.2.6
+-  resolution: "dompurify@npm:3.2.6"
++"dompurify@npm:3.4.8":
++  version: 3.4.8
++  resolution: "dompurify@npm:3.4.8"
+   dependencies:
+     "@types/trusted-types": "npm:^2.0.7"
+   dependenciesMeta:
+     "@types/trusted-types":
+       optional: true
+-  checksum: 10c0/c8f8e5b0879a0d93c84a2e5e78649a47d0c057ed0f7850ca3d573d2cca64b84fb1ff85bd4b20980ade69c4e5b80ae73011340f1c2ff375c7ef98bb8268e1d13a
++  checksum: 10c0/8f56a53d0ac80c76068772c9b72721f31fad68cac64a528e2420699ce2bd26b3516e29a5a7bd2205c2732d7114b9859998bf922d20cdb9361c4a05dab8352570
+   languageName: node
+   linkType: hard
+ 
+-"dompurify@npm:^3.1.7, dompurify@npm:^3.3.2":
+-  version: 3.3.3
+-  resolution: "dompurify@npm:3.3.3"
++"dompurify@npm:^3.1.7, dompurify@npm:^3.3.2, dompurify@npm:^3.4.12":
++  version: 3.4.12
++  resolution: "dompurify@npm:3.4.12"
+   dependencies:
+     "@types/trusted-types": "npm:^2.0.7"
+   dependenciesMeta:
+     "@types/trusted-types":
+       optional: true
+-  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
++  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+   languageName: node
+   linkType: hard
+ 
+@@ -21220,13 +21269,13 @@
    linkType: hard
  
  "express-rate-limit@npm:^8.2.2":
@@ -61,7 +1001,7 @@
    languageName: node
    linkType: hard
  
-@@ -21408,9 +21400,9 @@
+@@ -21408,9 +21457,9 @@
    linkType: hard
  
  "fast-uri@npm:^3.0.1":
@@ -74,7 +1014,24 @@
    languageName: node
    linkType: hard
  
-@@ -21802,29 +21794,29 @@
+@@ -21714,6 +21763,16 @@
+   languageName: node
+   linkType: hard
+ 
++"follow-redirects@npm:^1.16.0":
++  version: 1.16.0
++  resolution: "follow-redirects@npm:1.16.0"
++  peerDependenciesMeta:
++    debug:
++      optional: true
++  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
++  languageName: node
++  linkType: hard
++
+ "for-each@npm:^0.3.3":
+   version: 0.3.3
+   resolution: "for-each@npm:0.3.3"
+@@ -21802,29 +21861,29 @@
    linkType: hard
  
  "form-data@npm:^2.5.5":
@@ -113,7 +1070,7 @@
    languageName: node
    linkType: hard
  
-@@ -22822,6 +22814,15 @@
+@@ -22822,6 +22881,15 @@
    dependencies:
      function-bind: "npm:^1.1.2"
    checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
@@ -129,7 +1086,22 @@
    languageName: node
    linkType: hard
  
-@@ -23818,20 +23819,10 @@
+@@ -23596,10 +23664,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"immutable@npm:^3.x.x":
+-  version: 3.8.3
+-  resolution: "immutable@npm:3.8.3"
+-  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
++"immutable@npm:^4.3.9":
++  version: 4.3.9
++  resolution: "immutable@npm:4.3.9"
++  checksum: 10c0/394faa90ac8f2f62824e6c639705efdb8313787d6bc7864e28a48ee36aa2ba4b724eaf54a701ad991c278967a412b09143dd24fd19e3e2b0204eb481a5afa6ef
+   languageName: node
+   linkType: hard
+ 
+@@ -23818,20 +23886,10 @@
    languageName: node
    linkType: hard
  
@@ -154,7 +1126,44 @@
    languageName: node
    linkType: hard
  
-@@ -25246,7 +25237,7 @@
+@@ -25214,14 +25272,14 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-yaml@npm:=4.1.1, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:~4.1.0":
+-  version: 4.1.1
+-  resolution: "js-yaml@npm:4.1.1"
++"js-yaml@npm:=4.3.0, js-yaml@npm:^4.2.0":
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
+   dependencies:
+     argparse: "npm:^2.0.1"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
++  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+   languageName: node
+   linkType: hard
+ 
+@@ -25237,6 +25295,17 @@
+   languageName: node
+   linkType: hard
+ 
++"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:~4.1.0":
++  version: 4.1.1
++  resolution: "js-yaml@npm:4.1.1"
++  dependencies:
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
++  languageName: node
++  linkType: hard
++
+ "js2xmlparser@npm:^4.0.2":
+   version: 4.0.2
+   resolution: "js2xmlparser@npm:4.0.2"
+@@ -25246,7 +25315,7 @@
    languageName: node
    linkType: hard
  
@@ -163,21 +1172,21 @@
    version: 1.1.0
    resolution: "jsbn@npm:1.1.0"
    checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
-@@ -26426,6 +26417,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
-+  languageName: node
-+  linkType: hard
-+
+@@ -26429,6 +26498,13 @@
+   languageName: node
+   linkType: hard
+ 
 +"long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
-   languageName: node
-   linkType: hard
- 
-@@ -27950,7 +27948,7 @@
++  languageName: node
++  linkType: hard
++
+ "longest-streak@npm:^3.0.0":
+   version: 3.1.0
+   resolution: "longest-streak@npm:3.1.0"
+@@ -27950,7 +28026,7 @@
    languageName: node
    linkType: hard
  
@@ -186,7 +1195,67 @@
    version: 2.1.35
    resolution: "mime-types@npm:2.1.35"
    dependencies:
-@@ -31078,22 +31076,21 @@
+@@ -28102,15 +28178,6 @@
+   dependencies:
+     brace-expansion: "npm:^2.0.1"
+   checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
+-  languageName: node
+-  linkType: hard
+-
+-"minimatch@npm:^7.4.3":
+-  version: 7.4.9
+-  resolution: "minimatch@npm:7.4.9"
+-  dependencies:
+-    brace-expansion: "npm:^2.0.2"
+-  checksum: 10c0/8d5406a9697edb9b7ea02697d58cabcb3d3a9a4a02caa1cf57b9ab5ae22c78b2945600661a78f91d1545f77521f97f3cb5f8cb066e58356a121b50e4e60ccdbe
+   languageName: node
+   linkType: hard
+ 
+@@ -28351,13 +28418,13 @@
+   languageName: node
+   linkType: hard
+ 
+-"monaco-editor@npm:^0.55.0":
+-  version: 0.55.1
+-  resolution: "monaco-editor@npm:0.55.1"
++"monaco-editor@npm:0.56.0":
++  version: 0.56.0
++  resolution: "monaco-editor@npm:0.56.0"
+   dependencies:
+-    dompurify: "npm:3.2.7"
++    dompurify: "npm:3.4.8"
+     marked: "npm:14.0.0"
+-  checksum: 10c0/c1a0cf887657b42c8996518bc5ee96bbd39c977f862d2a2b2018427c45f14b0dd25d1452278202056f6b1ead97981282ccacd7d7ad918d8f0ef084159f974a25
++  checksum: 10c0/8ed728880042c5a1f42040f955e017b798fc1602fc59ef7a1f0e4da8f354e928b32cc0dba93ff677c538a37a542be3898210f9d1801f339e3c0f65f9ad3dc73e
+   languageName: node
+   linkType: hard
+ 
+@@ -28797,23 +28864,13 @@
+   languageName: node
+   linkType: hard
+ 
+-"node-domexception@npm:1.0.0, node-domexception@npm:^1.0.0":
++"node-domexception@npm:1.0.0":
+   version: 1.0.0
+   resolution: "node-domexception@npm:1.0.0"
+   checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+   languageName: node
+   linkType: hard
+ 
+-"node-fetch-commonjs@npm:^3.3.2":
+-  version: 3.3.2
+-  resolution: "node-fetch-commonjs@npm:3.3.2"
+-  dependencies:
+-    node-domexception: "npm:^1.0.0"
+-    web-streams-polyfill: "npm:^3.0.3"
+-  checksum: 10c0/87d36ed3e6dcb9dea96783700bc0becf0fdbcdc26c975e16b01a0d3a6e2f420c7e589e765bbfad461ae5377d4c5bd5f6937969a9dd34a0d736a81ac898f5c26a
+-  languageName: node
+-  linkType: hard
+-
+ "node-fetch@npm:2.6.7":
+   version: 2.6.7
+   resolution: "node-fetch@npm:2.6.7"
+@@ -31078,22 +31135,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
@@ -215,7 +1284,43 @@
    languageName: node
    linkType: hard
  
-@@ -33789,12 +33786,12 @@
+@@ -31137,6 +31193,13 @@
+   languageName: node
+   linkType: hard
+ 
++"proxy-from-env@npm:^2.1.0":
++  version: 2.1.0
++  resolution: "proxy-from-env@npm:2.1.0"
++  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
++  languageName: node
++  linkType: hard
++
+ "pseudomap@npm:^1.0.2":
+   version: 1.0.2
+   resolution: "pseudomap@npm:1.0.2"
+@@ -31556,15 +31619,15 @@
+   languageName: node
+   linkType: hard
+ 
+-"react-copy-to-clipboard@npm:5.1.0":
+-  version: 5.1.0
+-  resolution: "react-copy-to-clipboard@npm:5.1.0"
++"react-copy-to-clipboard@npm:5.1.1":
++  version: 5.1.1
++  resolution: "react-copy-to-clipboard@npm:5.1.1"
+   dependencies:
+-    copy-to-clipboard: "npm:^3.3.1"
++    copy-to-clipboard: "npm:^3.3.3"
+     prop-types: "npm:^15.8.1"
+   peerDependencies:
+-    react: ^15.3.0 || 16 || 17 || 18
+-  checksum: 10c0/de70d9f9c2d17cee207888ed791d4a042c300e5ca732503434d49e6745cff56c0d5ebcc82ab86237e9c2248e636d1d031b9f9cf9913ecec61d82a0e5ebc93881
++    react: ">=15.3.0"
++  checksum: 10c0/a46adefbb47508259af135c6de3b29de14a68b3874d94f76d20f079e0b3b399e1038f06a9116216805dce64d90d9d96cdab10af06969dd4b941c4b5d546b6158
+   languageName: node
+   linkType: hard
+ 
+@@ -33789,12 +33852,12 @@
    linkType: hard
  
  "socks@npm:^2.6.2, socks@npm:^2.8.3":
@@ -232,7 +1337,7 @@
    languageName: node
    linkType: hard
  
-@@ -33958,7 +33955,7 @@
+@@ -33958,7 +34021,7 @@
    languageName: node
    linkType: hard
  
@@ -241,7 +1346,160 @@
    version: 1.1.3
    resolution: "sprintf-js@npm:1.1.3"
    checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-@@ -35999,9 +35996,9 @@
+@@ -34669,35 +34732,99 @@
+   languageName: node
+   linkType: hard
+ 
+-"swagger-client@npm:^3.36.0":
+-  version: 3.36.0
+-  resolution: "swagger-client@npm:3.36.0"
++"swagger-client@npm:^3.37.7":
++  version: 3.37.7
++  resolution: "swagger-client@npm:3.37.7"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.22.15"
+     "@scarf/scarf": "npm:=1.4.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-reference": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.0"
++    "@swagger-api/apidom-error": "npm:^1.11.0"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.0"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.0"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.0"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@swagger-api/apidom-reference": "npm:^1.11.0"
+     "@swaggerexpert/cookie": "npm:^2.0.2"
+     deepmerge: "npm:~4.3.0"
+     fast-json-patch: "npm:^3.0.0-1"
+-    js-yaml: "npm:^4.1.0"
++    js-yaml: "npm:^4.2.0"
+     neotraverse: "npm:=0.6.18"
+     node-abort-controller: "npm:^3.1.1"
+-    node-fetch-commonjs: "npm:^3.3.2"
+     openapi-path-templating: "npm:^2.2.1"
+     openapi-server-url-templating: "npm:^1.3.0"
+     ramda: "npm:^0.30.1"
+     ramda-adjunct: "npm:^5.1.0"
+-  checksum: 10c0/a774886ea2f4a0f98733c784a8d0db8ab73a6e43856c411e8562846cd7eee5669772fa509f33a2e8d7fd67ed9073ec7c74d0a937a28534856c496d2423c812b1
++  dependenciesMeta:
++    "@swagger-api/apidom-ns-asyncapi-2":
++      optional: true
++    "@swagger-api/apidom-ns-asyncapi-3":
++      optional: true
++    "@swagger-api/apidom-ns-openapi-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-json":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-yaml-1-2":
++      optional: true
++  checksum: 10c0/2303fbc8dce37bad2d6fa9d13c359ae1e62ac8c194c311c53fe2af996af56fc2e1b886afeb97bd2b0effac72f599a4e939ae78e5b89da0183804f32f598db42d
+   languageName: node
+   linkType: hard
+ 
+ "swagger-ui-react@npm:^5.27.1":
+-  version: 5.30.3
+-  resolution: "swagger-ui-react@npm:5.30.3"
++  version: 5.32.11
++  resolution: "swagger-ui-react@npm:5.32.11"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.27.1"
+     "@scarf/scarf": "npm:=1.4.0"
+@@ -34706,16 +34833,16 @@
+     classnames: "npm:^2.5.1"
+     css.escape: "npm:1.5.1"
+     deep-extend: "npm:0.6.0"
+-    dompurify: "npm:=3.2.6"
++    dompurify: "npm:^3.4.12"
+     ieee754: "npm:^1.2.1"
+-    immutable: "npm:^3.x.x"
++    immutable: "npm:^4.3.9"
+     js-file-download: "npm:^0.4.12"
+-    js-yaml: "npm:=4.1.1"
+-    lodash: "npm:^4.17.21"
++    js-yaml: "npm:=4.3.0"
++    lodash: "npm:^4.18.1"
+     prop-types: "npm:^15.8.1"
+     randexp: "npm:^0.5.3"
+     randombytes: "npm:^2.1.0"
+-    react-copy-to-clipboard: "npm:5.1.0"
++    react-copy-to-clipboard: "npm:5.1.1"
+     react-debounce-input: "npm:=3.3.0"
+     react-immutable-proptypes: "npm:2.2.0"
+     react-immutable-pure-component: "npm:^2.2.0"
+@@ -34728,7 +34855,7 @@
+     reselect: "npm:^5.1.1"
+     serialize-error: "npm:^8.1.0"
+     sha.js: "npm:^2.4.12"
+-    swagger-client: "npm:^3.36.0"
++    swagger-client: "npm:^3.37.7"
+     url-parse: "npm:^1.5.10"
+     xml: "npm:=1.0.1"
+     xml-but-prettier: "npm:^1.0.1"
+@@ -34736,7 +34863,7 @@
+   peerDependencies:
+     react: ">=16.8.0 <20"
+     react-dom: ">=16.8.0 <20"
+-  checksum: 10c0/55ee318fd80dd8b7b8db18f6a4a36c3b84fb7e7ca435c8a5398352edf8f51589c4286c0de47969bd18e7b4751760940c0607dec9800974d7abf007800b8c2b5c
++  checksum: 10c0/f9beee970cbf980ae97c3783f23222cf4f0df773ed5f7e6119af88179baa080ac26120ef4e271de5bc3364495a2b0a5c9afb0b085f34b92bf55033547cf2847a
+   languageName: node
+   linkType: hard
+ 
+@@ -35999,9 +36126,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.24.5":
@@ -254,7 +1512,21 @@
    languageName: node
    linkType: hard
  
-@@ -37294,8 +37291,8 @@
+@@ -36820,13 +36947,6 @@
+   languageName: node
+   linkType: hard
+ 
+-"web-streams-polyfill@npm:^3.0.3":
+-  version: 3.3.3
+-  resolution: "web-streams-polyfill@npm:3.3.3"
+-  checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+-  languageName: node
+-  linkType: hard
+-
+ "web-tree-sitter@npm:=0.24.5":
+   version: 0.24.5
+   resolution: "web-tree-sitter@npm:0.24.5"
+@@ -37294,8 +37414,8 @@
    linkType: hard
  
  "ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
@@ -265,7 +1537,7 @@
    peerDependencies:
      bufferutil: ^4.0.1
      utf-8-validate: ">=5.0.2"
-@@ -37304,7 +37301,7 @@
+@@ -37304,7 +37424,7 @@
        optional: true
      utf-8-validate:
        optional: true

--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,21 +29,939 @@
    languageName: node
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+   languageName: node
+   linkType: hard
+ 
+@@ -13215,528 +13207,579 @@
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ast@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ast@npm:1.0.0"
++"@swagger-api/apidom-ast@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ast@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     unraw: "npm:^3.0.0"
+-  checksum: 10c0/8ef48b93a4fcacb0a114fe8b1bfd8b69997c908014d9fe2dc0287e427313b13478bebb1ac410f569b3492d3724c52e1e7742aeffedb0631f7be37a2598a00f1a
++  checksum: 10c0/e2595f82f8748108e95b09663b89aff6a35d15d3b57bb241b31a0cc0921dd13f1e313605d29471039ae9203d521c7a560e794bcb3bb866b78a656bf62af663b8
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-core@npm:^1.0.0, @swagger-api/apidom-core@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-core@npm:1.0.0"
++"@swagger-api/apidom-core@npm:^1.11.0, @swagger-api/apidom-core@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-core@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     minim: "npm:~0.23.8"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     short-unique-id: "npm:^5.3.2"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/52bcbc47a1d01a22927363ac62dbf31a58709debd7450edf3021f2b07c39019f669ac111c231931159e9e15348e61e17045e300a40b6bd32bfe9a9dec38cc5db
++  checksum: 10c0/397483645435b7d91660bc56300f0c1f8e974cc46494983b507a752af224b9185eea8eb692d7b39c6f1b96f0056fff74203559815a7bf0636131f867ed6a6325
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-error@npm:^1.0.0, @swagger-api/apidom-error@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-error@npm:1.0.0"
++"@swagger-api/apidom-error@npm:^1.11.0, @swagger-api/apidom-error@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-error@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.20.7"
+-  checksum: 10c0/7596bf4fae932e1ae86fd336df9f7c55bf067d33643599c116d89daa3b303e35f5253564020548bdc4efe3bf56d4c5981a76f199c5206e9170d1fad20f1b868e
++  checksum: 10c0/0c5d089d3c58ff46ae91fbd60e4ff328d0a334a6764f65f3d88a00b7a8622010aeaff5c705fdcab42bb51f95c6a053d843383aff9e40e059e86e50786289985c
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-json-pointer@npm:^1.0.0, @swagger-api/apidom-json-pointer@npm:^1.0.0-rc.0, @swagger-api/apidom-json-pointer@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-json-pointer@npm:1.0.0"
++"@swagger-api/apidom-json-pointer@npm:^1.11.0, @swagger-api/apidom-json-pointer@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-json-pointer@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@swaggerexpert/json-pointer": "npm:^2.10.1"
+-  checksum: 10c0/2a8c0fe5556d517e6d0b0db6436a124b680acb4b6a4c619d4782d38d6f41bac50df33ac86ef5be17b9a1d7432b22272bc89ab6170d17d90ef6710ee1b895bd69
++  checksum: 10c0/39cf5e9a1df5ae654ed8851f1f9540899c57e01b027cb2bcd783f2f2cacbb48744f852f83b52d345423ddff413581e05f0e002e22113b132d1105cb9ca80819a
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-api-design-systems@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:1.0.0"
++"@swagger-api/apidom-ns-api-design-systems@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/08ed193d8f3d0e1e94f570df16dc8a3c4e5bc50e9cf80b1a0bccafa0c3c78508d76c473e09f62303f986a923750c88de3c37796356a2bb2e1f2edd0ae226001d
++  checksum: 10c0/7554e3e0208e22596ace36660e3f46bc0e4f4b270a5b6be313b0d5cf774ac8500b3bde076cc35bb00f081df9de2ea8091ef5885f42b59115006ee405e30d7511
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-arazzo-1@npm:^1.0.0, @swagger-api/apidom-ns-arazzo-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-arazzo-1@npm:1.0.0"
++"@swagger-api/apidom-ns-arazzo-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-arazzo-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/1cf83a59d786ea41391b85fd233bc1043703f57166b75c952a13d660593e7c30424e561ea0e0110861e351494971ec9c787ba350389ecf034fc8a60584804468
++  checksum: 10c0/34d4cc020fab5ee5ccfd7d32bad77109b20d13ea9ddaf44e957813850123b7010c80f167402fab6c7070d2fab5274f504eebda2017b85f54697a41b24b158076
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-asyncapi-2@npm:^1.0.0, @swagger-api/apidom-ns-asyncapi-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:1.0.0"
++"@swagger-api/apidom-ns-asyncapi-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/0eadc5fa28ce516fe1308f0380a0663872be89beab68a282ea97bff9ee82373dc89e9e526fc10c4fb8cc486521861a5a61a864d9691ef5e889f129f6c594c56a
++  checksum: 10c0/af775a11bceba7c41fcce50f13ec7baa64194aa6f781842c05b9b7de3ed456831aa6dcfe49323d3ff93eda680014aaacb2bb50478a9956ea4cb49c099cf8bae9
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-asyncapi-3@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-asyncapi-3@npm:1.0.0"
++"@swagger-api/apidom-ns-asyncapi-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-asyncapi-3@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/d3ecece78fe2bd0063f8d58816f3783902a14620a0998ed84a611c47d65b7311bed237dd2cba86b70fa1eee1212dade0c628d53d346543aee22c6f480d17dedc
++  checksum: 10c0/01c7ece4fa8a4e1f81913e9ed018b5439b926874e00882dc79e24556ccbad329cd149184e19f15a4f42f00eba6c4f3b69773b314191760c8000422ddd06a3e79
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-2019-09@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-2019-09@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-2019-09@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-2019-09@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/3710e8add1ef87c280a0527b0b619c6a7d0d4f11864fc87cd42c978575245f5007102ce9be8950aff1d24fa6c61a1b4e3fa94fd602824990b14ef359c0013d20
++  checksum: 10c0/7c4078e81b5fcd869869a576d211ed9bc0186461b7467881c62a82975e2f5945130385a372e7b7e80eb874f43912a4876f6a3352dac7d7491edd702942676a62
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-2020-12@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-2020-12@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-2020-12@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-2020-12@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-2019-09": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2019-09": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/c913a0428d2c719465f3cf8b48df9fa4b55cf07c97a59bd66aa1758c6b784eefaab1f8095d1dd8c71b6bb7853c38a248a0c39329700c0f1c8e0f33eca8102475
++  checksum: 10c0/7dcb997bdcaa6c3f1f5ca0a68eaae13988af8b20aeea1fdce8fc11e874312100369e8ea5b942a55a82e380a22cf0c912d40fcfd316dc2bbbfff2096eadaa6686
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-4@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-draft-4@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/d59644f68069aa83801cf96493876888b3844de04cf5297777adf9d11f5d322acd5774942b6a1398cf6cdf63517b927457db59c2f17fd7e686da420a25dd410b
++  checksum: 10c0/1f0269f0ae1951edca13b6922028bd8e294a8931847e1a4ac1e9f38c4db78e6960714dcc6e691adc091e3f241808fd6af8884615d5fe1c4f800cf38006efca54
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-6@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-draft-6@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/a52f3d1ee0b53ebddcf9e8cc47046b7ccf8c7e1db1d80fd046b53c6453f1ce0f522bcbc723235e60afce29678ea5a846c96407ef9d4e94600baf3f5b38ab6fd1
++  checksum: 10c0/b431973c16b5570b19b555366ace9ca9563705912fa730aadc434272af68117c288863663375723c48ef17bede088a4dbedac85947ec17af413a9bb6dd8b429a
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-json-schema-draft-7@npm:^1.0.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:1.0.0"
++"@swagger-api/apidom-ns-json-schema-draft-7@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.4"
+-  checksum: 10c0/79132c7bb642ac8648243722e60c1165cf1c833f7c7eff46e4e722ff522c6e99c2683603a89d40b70ae22674c30996125119634b7836a67ee857fef870e60359
++  checksum: 10c0/09035f8e569f2073009051876abdc80708e304ecb11b04c9dfe0288fd87084fa99c61c8df134a6cabd9bd3ef2b76cff08156c813dc8087cd3ce8e5809d394d65
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-2@npm:^1.0.0, @swagger-api/apidom-ns-openapi-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-openapi-2@npm:1.0.0"
++"@swagger-api/apidom-ns-openapi-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/55c1b057b40780edd930463506907b84cea49b99b788bc4526249867707fed9d5cb2c1d4a2d52b3782be749901dcba32c1402c3af6bf29caf6b4f49cf0083bf0
++  checksum: 10c0/95ad6eb1026dcd4eaf00ec1fe98461f2ba3a4c2793394fda42bc4d97ef9e0a33e8f94add116f9ba9c02f5feb3ccfc7b8e3b2b430b5b60d299e9f7f92d651c36b
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-3-0@npm:^1.0.0, @swagger-api/apidom-ns-openapi-3-0@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:1.0.0"
++"@swagger-api/apidom-ns-openapi-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/e26ca00cc48ecdd8b135faaa51b59b0e5cfe2cb3eda99c3890b233c85bdef226e197617e7f6206565baece7f2f1922265ffaad569a99af49a15c56e88bdda1d9
++  checksum: 10c0/227f4744c36ad40a0779847a356c33554b0a9ac6f61742a446fec0ba85314c375bea5cfbcbc683d4b2aa0278f5399d84e6fb85c926148397faacd6c0207f1103
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-ns-openapi-3-1@npm:^1.0.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.0.0-rc.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:1.0.0"
++"@swagger-api/apidom-ns-openapi-3-1@npm:^1.11.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     ts-mixer: "npm:^6.0.3"
+-  checksum: 10c0/1a41940f999447ef7b95d8b717934728340dd2fdf87bae067743d7fea59472d1c95d40ec8ab47ab25a4132abe1e560313e895a4a461022ff781e6a784140ebdb
++  checksum: 10c0/9953cc31b75a9632afaacb4690ac1f80f880311b7c7beafc5aaaf357fbb8b68f6a5dc2cbbe5659d43d118687f93641898c7814b8fa25ba2911dbda4f7fccb516
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:1.0.0"
++"@swagger-api/apidom-ns-openapi-3-2@npm:^1.11.0, @swagger-api/apidom-ns-openapi-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-ns-openapi-3-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/22c989382325d2a4174cefd0e73ebb5db13cdb28ceb22a00c9dc64a1c59eaf53a6905cbd2d9fc510c590eef75b9dfb50a92a71a03b9dd453503086531d7c8b24
++    ts-mixer: "npm:^6.0.3"
++  checksum: 10c0/6bd09f33369e50d4681bc5e132073302e5f73bbcaf8c29086e1d5a807ac4f4a4d95871852e980e7446da359cad04edc3f80c6da82f0406ed8bfb3abc67ee2a66
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/9d58a7185d533e940e141ed0b8a54310c944bf60db16a55c2cc313c75c58825433e7982019207c1bb9d6eaa529882220a0b5b65e54ab489111700bf8c3753866
++  checksum: 10c0/a4fe017c2d80daf95b2c4d6a8d52efb9883ae9b9bc5c1e3e4bc885168a1202de5fe43a007139245c6aed8e89078c98ca4ef5a878f5168f125b1a4dbf9ad43802
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/a1c055c98dff15b82affc11f30804f3940072ce3bb38c082f18a858ea002f3cd2a50fb6a350ed58235d38a87a377c26cdb0fb5ee595684b86f7a522e8403d025
++  checksum: 10c0/fade65dd190174e092e8024519d58a4e863a048968b711fc5edc54aedf06ec418b2586bceaa22155f4f822c2d8ce4b61c2f78f22a7c6e220930e6f18aec93bec
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/64522bba83a3c02b6deb8fd756605b013a672ac0faf7ed7f4e817ea8f52385b0ae68150f07fa6e6e4bdee7195cdda21a9a4f78e840188d20bc1af0cc10a20925
++  checksum: 10c0/7ae294ba91238552b0c26727fb6625b1191f6e224bcc47a8a57572935634cb5e892a5c257ff45530ec0fb38dc1a8900a1946c844d29c36fe68480e42f69a1304
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/e44d9e5a80afaf59caf94057555c0bf553650d1ea231c49e4bb041384a9feccd111f0d69f338fd4e9de0f1e18d7072a46f8a30ffc8e2b3d36a817e8444f1c51b
++  checksum: 10c0/9324eec2942c8241d25c814b1fa68649fcd582bc768ab98c34e20265c57d8e28778a50c76e8351d9a0da0f8894c4e113f88bfc44fcae419c323f94d5a785f9cc
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/0eec71a07f486e271c1d7c8972e935d68971c730192737b010780e3b8a5ff325e2d1347533aa5388419f60b274c3e57c5c22c2c4550432fe8aacf43f82f9d322
++  checksum: 10c0/eae58e52cd21d4ffe3630073d72b8c41caa84a26f7140e46c0f5caf9879cf811b40fbdff0f109b3922f5f272930d7b5adc83e47f8974688c006ad74c12485f72
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/dd2a75b3c17e8fa5fa3ecb6ec53529c68129c6dc89053f3d9cfa33df67d20d48804d6d0abafbcb3882b8048ec7422c2ecb26802ed42ddba6eb2f08feb3ff1f1a
++  checksum: 10c0/c7f4c50a124b1738510e53f55cf75a4b9b622aaf37f09fcaf0a74a8bdeef184aa16cd12fcde6a266bad6492879f9db18037d06392e55912a4a5a515ca79c9cb7
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/74582ea8af30be8bfba70ff54b458d72376b321f96a749ddf22317aaa0faf5f7f459c5484db4157ebb4b3dd7683258290251490c523001810223a7cf6ab4fac5
++  checksum: 10c0/3298e3a8e91351533ca1e28ad971e24daae79d44e1b5a4ee12c420c43bef842ca7b4ddeeaa007f8d34f62a6ae27bde9c9e829155d38db40a973feb9285ead897
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-json@npm:^1.0.0, @swagger-api/apidom-parser-adapter-json@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-json@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/9e091160a28fa45e3bf3d7a4d3548b42dc58f5c1f3ddd72efd8420350d6819696966213181ece1c142b2c15f9e1ec735c8d9c2c20ce48175d4ef23306a611a0f
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-json@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-json@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
+     node-gyp: "npm:latest"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     tree-sitter: "npm:=0.21.1"
+     tree-sitter-json: "npm:=0.24.8"
+     web-tree-sitter: "npm:=0.24.5"
+-  checksum: 10c0/17379da0ed0f0b111303bae1461e8bb403d65cc5bb8c7e15bbf4c1734fe4caacab44360c7e575851752ea143740180849c8242f16c1d1e62295f91d810f993e0
++  checksum: 10c0/fca5de8a4c924b72fdfd0c8a3c647688c0c575cfacbbe5a43d8a3d87a4a4ce3a2014893cba76ec5e0ce0327ee3c0e36b83ec1047efb0ca59f7d6b1206706938e
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/65e97a1b6c8e1097b57c78c671e01970badf50fa26656b5c91dcf1cb34d7dcb4258c7005f548f98b71d9273b0f29e7a8cb21262aa1073547f052d73197bf2004
++  checksum: 10c0/7946783cd11265f45d56acf3406d2173150adeab6ca6cfe41bfe7a8b5f4eed0b9323216cda8f4c47f96794c0fdff30168fb672574f3619655e7491d46729a62c
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/c53be21ea8f16cac40f486ec2dba59def4963fde76f5f006ed3ddb698ae15c604de7ac53bb4ec37edf4dd377d88795a7426f175da40916a06e4be71418336430
++  checksum: 10c0/256030920f5c1c524cc820f2e7a4c340a4cd644cbc9c34232ed1f705fb6f526f91aee1220ffe0b9fa92e3ee5bb83b05030acf863c5be7a21147f0f1b52c05193
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/0366332d8db1e5a24f967b8d4f75e112c65a76c8119ad1157d920a34df8d8eed4551f7a4269ad3b9acf8c571287c3fdf1c7937547bf7c55ce9f2d819752acba2
++  checksum: 10c0/0f765a75f174211bf09abc6ed4b556a539d738a6d53fbdf103c686b5fc61238e515ea8610942c1c74331c6fbe4b6984d840711dc1cac617505e58b4b0e1776e1
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/98ccec43b3f257c2724e56bb462b713e3cfd9619f36db8a8f477257c6aec3b4ef17447e8fa60051c5b02252f0844aa3135687a23e9855fffa685bb49023ebdd0
++  checksum: 10c0/5269c95948aa882f5f54ba0ae758d3d56732ff511f37760dd1bf4889805273e3674aeeb7faaade8996b7de00a49f6494701ee52b52f5a6442467102272d9ac8d
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/82cbe51351e85a4c6dfcbbbe17be511f1a70ef1f541e7ca98a6ed71217f023d85dfe4de2afdb3c5762b1fb9b0fbcb180235a714e0f7f6f84c1617f280de9bd8c
++  checksum: 10c0/056d2c841c0928c0438e23a972f494c96962eda049dc1f677c198ec76da10b5eb244addd2da452a634f3fd0689ae7332ef01c232b667f02644d3402206f42f11
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/9d0a6e51f854e1f4bbb8bc6079c47aad0665e134af0a76b748662f52587e27f07b5657d1f1fc98c5a22ed055f4cc340353ca8acb7980855b921bfd7f6663dc05
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+-  checksum: 10c0/efc9357c05388753029dbc79add119f522e7cddba4da1c254620becaf9818137bed1e2ad3276a2651a068c4bef6cc982ad2407cac949a7c197f6355d91f0f067
++  checksum: 10c0/ab23c1404b7e764c3eaec92f9cc04a6c9ccee9d0978581f223a942c0364db39055d5b93cabd3fda05245fb3218877d4173464e86def1cbca7fb140918c751596
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.0.0, @swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.0.0-rc.0":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:1.0.0"
++"@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-ast": "npm:^1.0.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@types/ramda": "npm:~0.30.0"
++    ramda: "npm:~0.30.0"
++    ramda-adjunct: "npm:^5.0.0"
++  checksum: 10c0/810cb0e1384d0da50d096d73a35815658183d7217b2055552838f251ea274417e1614c97b9479b31f32ce9e865157c0063176907b12d86a9e282c977c638e7f0
++  languageName: node
++  linkType: hard
++
++"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.11.3":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:1.11.3"
++  dependencies:
++    "@babel/runtime-corejs3": "npm:^7.26.10"
++    "@swagger-api/apidom-ast": "npm:^1.11.3"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
+     "@tree-sitter-grammars/tree-sitter-yaml": "npm:=0.7.1"
+     "@types/ramda": "npm:~0.30.0"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+     tree-sitter: "npm:=0.22.4"
+     web-tree-sitter: "npm:=0.24.5"
+-  checksum: 10c0/53f8448c4cd162e23a61b23a9620f94388b38932d899570e82eb70400021a4634968e384f967f7c157c22006ea830a90bc5800488c6a1100a5505ed0439043e9
++  checksum: 10c0/bc05319a86f1e446738fb2f615d0818dbb9393740eb13c8002501e6f1f701ea1540d7d4f879a5d189496e20f7260920b7783b67cf44b94b027160275e451aaa8
+   languageName: node
+   linkType: hard
+ 
+-"@swagger-api/apidom-reference@npm:^1.0.0-rc.1":
+-  version: 1.0.0
+-  resolution: "@swagger-api/apidom-reference@npm:1.0.0"
++"@swagger-api/apidom-reference@npm:^1.11.0":
++  version: 1.11.3
++  resolution: "@swagger-api/apidom-reference@npm:1.11.3"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.26.10"
+-    "@swagger-api/apidom-core": "npm:^1.0.0"
+-    "@swagger-api/apidom-error": "npm:^1.0.0"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.0.0-rc.0"
+-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.0.0-rc.0"
++    "@swagger-api/apidom-core": "npm:^1.11.3"
++    "@swagger-api/apidom-error": "npm:^1.11.3"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
+     "@types/ramda": "npm:~0.30.0"
+-    axios: "npm:^1.12.2"
+-    minimatch: "npm:^7.4.3"
+-    process: "npm:^0.11.10"
++    axios: "npm:^1.16.0"
++    minimatch: "npm:^10.2.1"
+     ramda: "npm:~0.30.0"
+     ramda-adjunct: "npm:^5.0.0"
+   dependenciesMeta:
+@@ -13752,6 +13795,8 @@
+       optional: true
+     "@swagger-api/apidom-ns-openapi-3-1":
+       optional: true
++    "@swagger-api/apidom-ns-openapi-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-api-design-systems-json":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-api-design-systems-yaml":
+@@ -13776,15 +13821,19 @@
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-json-3-1":
+       optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-2":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0":
+       optional: true
+     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1":
+       optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2":
++      optional: true
+     "@swagger-api/apidom-parser-adapter-yaml-1-2":
+       optional: true
+-  checksum: 10c0/64b6bcee7050c23918ea8fdf3981f79481f586c7b1d20563f1c4c8747f91e991541852a5c070d878ce4acb64fc6035d060045adc3f50b006e56b910f5ca397e7
++  checksum: 10c0/aa0536e5461b4b63f0541e2cf547ed9a85059f588e8e35830d3cfc15f4fb72caeed1d90407349bc6df84b65aedbc37e70523ac22e638376c51cc299a0441c068
+   languageName: node
+   linkType: hard
+ 
+@@ -16785,14 +16834,15 @@
+   languageName: node
+   linkType: hard
+ 
+-"axios@npm:^1.0.0, axios@npm:^1.12.0, axios@npm:^1.12.2":
+-  version: 1.13.6
+-  resolution: "axios@npm:1.13.6"
++"axios@npm:^1.0.0, axios@npm:^1.12.0, axios@npm:^1.16.0":
++  version: 1.18.1
++  resolution: "axios@npm:1.18.1"
+   dependencies:
+-    follow-redirects: "npm:^1.15.11"
++    follow-redirects: "npm:^1.16.0"
+     form-data: "npm:^4.0.5"
+-    proxy-from-env: "npm:^1.1.0"
+-  checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
++    https-proxy-agent: "npm:^5.0.1"
++    proxy-from-env: "npm:^2.1.0"
++  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
+   languageName: node
+   linkType: hard
+ 
+@@ -18646,7 +18696,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"copy-to-clipboard@npm:^3.2.0, copy-to-clipboard@npm:^3.3.1":
++"copy-to-clipboard@npm:^3.2.0, copy-to-clipboard@npm:^3.3.1, copy-to-clipboard@npm:^3.3.3":
+   version: 3.3.3
+   resolution: "copy-to-clipboard@npm:3.3.3"
+   dependencies:
+@@ -19978,27 +20028,15 @@
+   languageName: node
+   linkType: hard
+ 
+-"dompurify@npm:=3.2.6":
+-  version: 3.2.6
+-  resolution: "dompurify@npm:3.2.6"
+-  dependencies:
+-    "@types/trusted-types": "npm:^2.0.7"
+-  dependenciesMeta:
+-    "@types/trusted-types":
+-      optional: true
+-  checksum: 10c0/c8f8e5b0879a0d93c84a2e5e78649a47d0c057ed0f7850ca3d573d2cca64b84fb1ff85bd4b20980ade69c4e5b80ae73011340f1c2ff375c7ef98bb8268e1d13a
 -  languageName: node
 -  linkType: hard
 -
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
-@@ -21220,13 +21212,13 @@
+-"dompurify@npm:^3.1.7, dompurify@npm:^3.3.2":
+-  version: 3.3.3
+-  resolution: "dompurify@npm:3.3.3"
++"dompurify@npm:^3.1.7, dompurify@npm:^3.3.2, dompurify@npm:^3.4.11":
++  version: 3.4.12
++  resolution: "dompurify@npm:3.4.12"
+   dependencies:
+     "@types/trusted-types": "npm:^2.0.7"
+   dependenciesMeta:
+     "@types/trusted-types":
+       optional: true
+-  checksum: 10c0/097c14a21a3f6cb95beded9ecd255f7c3512c42767b048390c747b0fe35736f6a71e02320fc50a9ac2be645834b463e4760915d595d502a56452daf339d0ea9c
++  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
+   languageName: node
+   linkType: hard
+ 
+@@ -21220,13 +21258,13 @@
    linkType: hard
  
  "express-rate-limit@npm:^8.2.2":
@@ -61,7 +979,7 @@
    languageName: node
    linkType: hard
  
-@@ -21408,9 +21400,9 @@
+@@ -21408,9 +21446,9 @@
    linkType: hard
  
  "fast-uri@npm:^3.0.1":
@@ -74,7 +992,25 @@
    languageName: node
    linkType: hard
  
-@@ -21802,29 +21794,29 @@
+@@ -21704,13 +21742,13 @@
+   languageName: node
+   linkType: hard
+ 
+-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.15.6":
+-  version: 1.15.11
+-  resolution: "follow-redirects@npm:1.15.11"
++"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6, follow-redirects@npm:^1.16.0":
++  version: 1.16.0
++  resolution: "follow-redirects@npm:1.16.0"
+   peerDependenciesMeta:
+     debug:
+       optional: true
+-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
++  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
+   languageName: node
+   linkType: hard
+ 
+@@ -21802,29 +21840,29 @@
    linkType: hard
  
  "form-data@npm:^2.5.5":
@@ -113,23 +1049,24 @@
    languageName: node
    linkType: hard
  
-@@ -22822,6 +22814,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
-+"hasown@npm:^2.0.4":
+@@ -22816,12 +22854,12 @@
+   languageName: node
+   linkType: hard
+ 
+-"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
+-  version: 2.0.2
+-  resolution: "hasown@npm:2.0.2"
++"hasown@npm:^2.0.0, hasown@npm:^2.0.2, hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
-+  dependencies:
-+    function-bind: "npm:^1.1.2"
+   dependencies:
+     function-bind: "npm:^1.1.2"
+-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
    languageName: node
    linkType: hard
  
-@@ -23818,20 +23819,10 @@
+@@ -23818,20 +23856,10 @@
    languageName: node
    linkType: hard
  
@@ -154,7 +1091,55 @@
    languageName: node
    linkType: hard
  
-@@ -25246,7 +25237,7 @@
+@@ -25214,14 +25242,14 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-yaml@npm:=4.1.1, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:~4.1.0":
+-  version: 4.1.1
+-  resolution: "js-yaml@npm:4.1.1"
++"js-yaml@npm:=4.2.0":
++  version: 4.2.0
++  resolution: "js-yaml@npm:4.2.0"
+   dependencies:
+     argparse: "npm:^2.0.1"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
++  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+   languageName: node
+   linkType: hard
+ 
+@@ -25234,6 +25262,28 @@
+   bin:
+     js-yaml: bin/js-yaml.js
+   checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
++  languageName: node
++  linkType: hard
++
++"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:^4.2.0":
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
++  dependencies:
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
++  languageName: node
++  linkType: hard
++
++"js-yaml@npm:~4.1.0":
++  version: 4.1.1
++  resolution: "js-yaml@npm:4.1.1"
++  dependencies:
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+   languageName: node
+   linkType: hard
+ 
+@@ -25246,7 +25296,7 @@
    languageName: node
    linkType: hard
  
@@ -163,21 +1148,22 @@
    version: 1.1.0
    resolution: "jsbn@npm:1.1.0"
    checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
-@@ -26426,6 +26417,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
-+  languageName: node
-+  linkType: hard
-+
-+"long@npm:^5.3.2":
+@@ -26422,10 +26472,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"long@npm:^5.0.0, long@npm:^5.2.1":
+-  version: 5.2.3
+-  resolution: "long@npm:5.2.3"
+-  checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++"long@npm:^5.0.0, long@npm:^5.2.1, long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
    languageName: node
    linkType: hard
  
-@@ -27950,7 +27948,7 @@
+@@ -27950,7 +28000,7 @@
    languageName: node
    linkType: hard
  
@@ -186,7 +1172,45 @@
    version: 2.1.35
    resolution: "mime-types@npm:2.1.35"
    dependencies:
-@@ -31078,22 +31076,21 @@
+@@ -28102,15 +28152,6 @@
+   dependencies:
+     brace-expansion: "npm:^2.0.1"
+   checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
+-  languageName: node
+-  linkType: hard
+-
+-"minimatch@npm:^7.4.3":
+-  version: 7.4.9
+-  resolution: "minimatch@npm:7.4.9"
+-  dependencies:
+-    brace-expansion: "npm:^2.0.2"
+-  checksum: 10c0/8d5406a9697edb9b7ea02697d58cabcb3d3a9a4a02caa1cf57b9ab5ae22c78b2945600661a78f91d1545f77521f97f3cb5f8cb066e58356a121b50e4e60ccdbe
+   languageName: node
+   linkType: hard
+ 
+@@ -28797,20 +28838,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"node-domexception@npm:1.0.0, node-domexception@npm:^1.0.0":
++"node-domexception@npm:1.0.0":
+   version: 1.0.0
+   resolution: "node-domexception@npm:1.0.0"
+   checksum: 10c0/5e5d63cda29856402df9472335af4bb13875e1927ad3be861dc5ebde38917aecbf9ae337923777af52a48c426b70148815e890a5d72760f1b4d758cc671b1a2b
+-  languageName: node
+-  linkType: hard
+-
+-"node-fetch-commonjs@npm:^3.3.2":
+-  version: 3.3.2
+-  resolution: "node-fetch-commonjs@npm:3.3.2"
+-  dependencies:
+-    node-domexception: "npm:^1.0.0"
+-    web-streams-polyfill: "npm:^3.0.3"
+-  checksum: 10c0/87d36ed3e6dcb9dea96783700bc0becf0fdbcdc26c975e16b01a0d3a6e2f420c7e589e765bbfad461ae5377d4c5bd5f6937969a9dd34a0d736a81ac898f5c26a
+   languageName: node
+   linkType: hard
+ 
+@@ -31078,22 +31109,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
@@ -215,7 +1239,43 @@
    languageName: node
    linkType: hard
  
-@@ -33789,12 +33786,12 @@
+@@ -31137,6 +31167,13 @@
+   languageName: node
+   linkType: hard
+ 
++"proxy-from-env@npm:^2.1.0":
++  version: 2.1.0
++  resolution: "proxy-from-env@npm:2.1.0"
++  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
++  languageName: node
++  linkType: hard
++
+ "pseudomap@npm:^1.0.2":
+   version: 1.0.2
+   resolution: "pseudomap@npm:1.0.2"
+@@ -31556,15 +31593,15 @@
+   languageName: node
+   linkType: hard
+ 
+-"react-copy-to-clipboard@npm:5.1.0":
+-  version: 5.1.0
+-  resolution: "react-copy-to-clipboard@npm:5.1.0"
++"react-copy-to-clipboard@npm:5.1.1":
++  version: 5.1.1
++  resolution: "react-copy-to-clipboard@npm:5.1.1"
+   dependencies:
+-    copy-to-clipboard: "npm:^3.3.1"
++    copy-to-clipboard: "npm:^3.3.3"
+     prop-types: "npm:^15.8.1"
+   peerDependencies:
+-    react: ^15.3.0 || 16 || 17 || 18
+-  checksum: 10c0/de70d9f9c2d17cee207888ed791d4a042c300e5ca732503434d49e6745cff56c0d5ebcc82ab86237e9c2248e636d1d031b9f9cf9913ecec61d82a0e5ebc93881
++    react: ">=15.3.0"
++  checksum: 10c0/a46adefbb47508259af135c6de3b29de14a68b3874d94f76d20f079e0b3b399e1038f06a9116216805dce64d90d9d96cdab10af06969dd4b941c4b5d546b6158
+   languageName: node
+   linkType: hard
+ 
+@@ -33789,12 +33826,12 @@
    linkType: hard
  
  "socks@npm:^2.6.2, socks@npm:^2.8.3":
@@ -232,7 +1292,7 @@
    languageName: node
    linkType: hard
  
-@@ -33958,7 +33955,7 @@
+@@ -33958,7 +33995,7 @@
    languageName: node
    linkType: hard
  
@@ -241,7 +1301,159 @@
    version: 1.1.3
    resolution: "sprintf-js@npm:1.1.3"
    checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
-@@ -35999,9 +35996,9 @@
+@@ -34669,35 +34706,99 @@
+   languageName: node
+   linkType: hard
+ 
+-"swagger-client@npm:^3.36.0":
+-  version: 3.36.0
+-  resolution: "swagger-client@npm:3.36.0"
++"swagger-client@npm:^3.37.4":
++  version: 3.37.6
++  resolution: "swagger-client@npm:3.37.6"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.22.15"
+     "@scarf/scarf": "npm:=1.4.0"
+-    "@swagger-api/apidom-core": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-error": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-json-pointer": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.0.0-rc.1"
+-    "@swagger-api/apidom-reference": "npm:^1.0.0-rc.1"
++    "@swagger-api/apidom-core": "npm:^1.11.0"
++    "@swagger-api/apidom-error": "npm:^1.11.0"
++    "@swagger-api/apidom-json-pointer": "npm:^1.11.0"
++    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-2": "npm:^1.11.3"
++    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.11.0"
++    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.11.0"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-json": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "npm:^1.11.3"
++    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.11.3"
++    "@swagger-api/apidom-reference": "npm:^1.11.0"
+     "@swaggerexpert/cookie": "npm:^2.0.2"
+     deepmerge: "npm:~4.3.0"
+     fast-json-patch: "npm:^3.0.0-1"
+-    js-yaml: "npm:^4.1.0"
++    js-yaml: "npm:^4.2.0"
+     neotraverse: "npm:=0.6.18"
+     node-abort-controller: "npm:^3.1.1"
+-    node-fetch-commonjs: "npm:^3.3.2"
+     openapi-path-templating: "npm:^2.2.1"
+     openapi-server-url-templating: "npm:^1.3.0"
+     ramda: "npm:^0.30.1"
+     ramda-adjunct: "npm:^5.1.0"
+-  checksum: 10c0/a774886ea2f4a0f98733c784a8d0db8ab73a6e43856c411e8562846cd7eee5669772fa509f33a2e8d7fd67ed9073ec7c74d0a937a28534856c496d2423c812b1
++  dependenciesMeta:
++    "@swagger-api/apidom-ns-asyncapi-2":
++      optional: true
++    "@swagger-api/apidom-ns-asyncapi-3":
++      optional: true
++    "@swagger-api/apidom-ns-openapi-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-api-design-systems-json":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-arazzo-json-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-json-3":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-json":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-0":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-json-3-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2":
++      optional: true
++    "@swagger-api/apidom-parser-adapter-yaml-1-2":
++      optional: true
++  checksum: 10c0/78f6734db5d9c154a809e6878cb0056d63ffbdca98060cee045a120eed29d6de44c90e13eee626ba6b7bc6d2ef5012e000a7f9de5a3e5ef53b0f18a4e166530a
+   languageName: node
+   linkType: hard
+ 
+ "swagger-ui-react@npm:^5.27.1":
+-  version: 5.30.3
+-  resolution: "swagger-ui-react@npm:5.30.3"
++  version: 5.32.9
++  resolution: "swagger-ui-react@npm:5.32.9"
+   dependencies:
+     "@babel/runtime-corejs3": "npm:^7.27.1"
+     "@scarf/scarf": "npm:=1.4.0"
+@@ -34706,16 +34807,16 @@
+     classnames: "npm:^2.5.1"
+     css.escape: "npm:1.5.1"
+     deep-extend: "npm:0.6.0"
+-    dompurify: "npm:=3.2.6"
++    dompurify: "npm:^3.4.11"
+     ieee754: "npm:^1.2.1"
+     immutable: "npm:^3.x.x"
+     js-file-download: "npm:^0.4.12"
+-    js-yaml: "npm:=4.1.1"
+-    lodash: "npm:^4.17.21"
++    js-yaml: "npm:=4.2.0"
++    lodash: "npm:^4.18.1"
+     prop-types: "npm:^15.8.1"
+     randexp: "npm:^0.5.3"
+     randombytes: "npm:^2.1.0"
+-    react-copy-to-clipboard: "npm:5.1.0"
++    react-copy-to-clipboard: "npm:5.1.1"
+     react-debounce-input: "npm:=3.3.0"
+     react-immutable-proptypes: "npm:2.2.0"
+     react-immutable-pure-component: "npm:^2.2.0"
+@@ -34728,7 +34829,7 @@
+     reselect: "npm:^5.1.1"
+     serialize-error: "npm:^8.1.0"
+     sha.js: "npm:^2.4.12"
+-    swagger-client: "npm:^3.36.0"
++    swagger-client: "npm:^3.37.4"
+     url-parse: "npm:^1.5.10"
+     xml: "npm:=1.0.1"
+     xml-but-prettier: "npm:^1.0.1"
+@@ -34736,7 +34837,7 @@
+   peerDependencies:
+     react: ">=16.8.0 <20"
+     react-dom: ">=16.8.0 <20"
+-  checksum: 10c0/55ee318fd80dd8b7b8db18f6a4a36c3b84fb7e7ca435c8a5398352edf8f51589c4286c0de47969bd18e7b4751760940c0607dec9800974d7abf007800b8c2b5c
++  checksum: 10c0/3987fb028eec6faf05cf9cbb80da7cf25b4d12f14368df90a9df0ef014ea73fe8e89408e6ea3653e8825605dbd82dfa99508fb24a4774f21c86dd7e2628960bf
+   languageName: node
+   linkType: hard
+ 
+@@ -35999,9 +36100,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.24.5":
@@ -254,7 +1466,21 @@
    languageName: node
    linkType: hard
  
-@@ -37294,8 +37291,8 @@
+@@ -36820,13 +36921,6 @@
+   languageName: node
+   linkType: hard
+ 
+-"web-streams-polyfill@npm:^3.0.3":
+-  version: 3.3.3
+-  resolution: "web-streams-polyfill@npm:3.3.3"
+-  checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+-  languageName: node
+-  linkType: hard
+-
+ "web-tree-sitter@npm:=0.24.5":
+   version: 0.24.5
+   resolution: "web-tree-sitter@npm:0.24.5"
+@@ -37294,8 +37388,8 @@
    linkType: hard
  
  "ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
@@ -265,7 +1491,7 @@
    peerDependencies:
      bufferutil: ^4.0.1
      utf-8-validate: ">=5.0.2"
-@@ -37304,7 +37301,7 @@
+@@ -37304,7 +37398,7 @@
        optional: true
      utf-8-validate:
        optional: true

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -6,6 +6,16 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: 5a0ebed9cfa46b374225321d2678be36006e16ef
 backports:
   - cve_ids:
+      - CVE-2026-49978
+    package: dompurify
+    patch_version: 3.2.7, 3.4.12
+    notes: |-
+      [auto] dompurify@3.2.7 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        └─┬ @red-hat-developer-hub/backstage-plugin-lightspeed@2.8.6
+          └─┬ monaco-editor@0.55.1
+            └── dompurify@3.2.7
+  - cve_ids:
       - CVE-2026-13676
     package: fast-uri
     patch_version: 3.1.3

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -6,6 +6,10 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: 5a0ebed9cfa46b374225321d2678be36006e16ef
 backports:
   - cve_ids:
+      - CVE-2026-49978
+    package: dompurify
+    patch_version: 3.4.8, 3.4.12
+  - cve_ids:
       - CVE-2026-13676
     package: fast-uri
     patch_version: 3.1.3


### PR DESCRIPTION
It bumps dompurify to 3.4.7 or higher to fix https://github.com/advisories/GHSA-rp9w-3fw7-7cwq
https://redhat.atlassian.net/browse/RHIDP-15535
