### PR TITLE
fix(e2e): add missing kube config for argocd & topology tests

### DIFF
--- a/workspaces/argocd/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/argocd/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -3,6 +3,20 @@ plugins:
     enabled: true
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
     enabled: true
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage.plugin-kubernetes:
+            mountPoints:
+              - mountPoint: entity.page.kubernetes/cards
+                importName: EntityKubernetesContent
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                      - hasAnnotation: backstage.io/kubernetes-id
+                      - hasAnnotation: backstage.io/kubernetes-namespace
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.45.3__2.4.3
     enabled: true
     pluginConfig:

--- a/workspaces/topology/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/topology/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,6 +1,20 @@
 plugins:
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
     enabled: true
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage.plugin-kubernetes:
+            mountPoints:
+              - mountPoint: entity.page.kubernetes/cards
+                importName: EntityKubernetesContent
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                      - hasAnnotation: backstage.io/kubernetes-id
+                      - hasAnnotation: backstage.io/kubernetes-namespace
   - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
     enabled: true
   - package: ./dynamic-plugins/dist/backstage-community-plugin-topology

--- a/workspaces/topology/e2e-tests/tests/specs/topology.ts
+++ b/workspaces/topology/e2e-tests/tests/specs/topology.ts
@@ -40,7 +40,7 @@ export class Topology {
   }
 
   async verifyMissingTopologyPermission() {
-    await this.uiHelper.verifyHeading("Missing Permission");
+    await this.uiHelper.verifyText("Missing Permission");
     await this.uiHelper.verifyText("kubernetes.clusters.read");
     await this.uiHelper.verifyText("kubernetes.resources.read");
     await expect(this.page.getByLabel("Pod")).toBeHidden();
@@ -66,7 +66,7 @@ export class Topology {
 
     if (allowed) {
       const downloadLogsButton = this.page.getByRole("button", {
-        name: "download logs",
+        name: "download",
       });
       const fileContent = await downloadAndReadFile(
         this.page,
@@ -75,7 +75,7 @@ export class Topology {
       expect(fileContent).not.toBeUndefined();
       expect(fileContent).not.toBe("");
     } else {
-      await this.uiHelper.verifyHeading("Missing Permission");
+      await this.uiHelper.verifyText("Missing Permission");
       await this.uiHelper.verifyText("kubernetes.proxy");
     }
   }


### PR DESCRIPTION
should make argocd and topology e2e tests run properly again