### PR TITLE
fix(coverage): guard instrumented chunks against RHDH zip-bomb detection (RHDHBUGS-3470)

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -73,8 +73,10 @@ E2E_NIGHTLY_MODE="${E2E_NIGHTLY_MODE:-false}"
 # skipped silently (no -coverage images exist).
 #
 # To disable (faster local dev): E2E_COLLECT_COVERAGE=false
-# Disabled by default due to zip bomb detection failures — see RHDHBUGS-3470
-export E2E_COLLECT_COVERAGE="${E2E_COLLECT_COVERAGE:-false}"
+# Zip bomb detection (RHDHBUGS-3470) is handled at image-build time:
+# instrument-plugin.sh restores the original file for any chunk whose
+# instrumented output would exceed RHDH's per-entry size limit.
+export E2E_COLLECT_COVERAGE="${E2E_COLLECT_COVERAGE:-true}"
 
 # Local e2e-test-utils: absolute path to use a local build instead of npm
 E2E_TEST_UTILS_PATH="${E2E_TEST_UTILS_PATH:-}"

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -65,17 +65,13 @@ E2E_NIGHTLY_MODE="${E2E_NIGHTLY_MODE:-false}"
 
 # Coverage collection (Istanbul) — enabled by default
 #
-# For PR checks: Works now. The auto-publish-pr.yaml workflow builds -coverage
-# images (plugin:tag__coverage) that e2e-test-utils will load when available.
-#
-# For nightly/local: Depends on e2e-test-utils automatic image swap logic
-# (PR #95, merged 2026-06-04). Until that lands, coverage collection will be
-# skipped silently (no -coverage images exist).
+# PR checks: auto-publish-pr.yaml builds __coverage images
+# (plugin:tag__coverage) that e2e-test-utils automatically swaps in for
+# frontend plugins. Zip bomb detection (RHDHBUGS-3470) is handled at
+# image-build time: instrument-plugin.sh restores the original file for any
+# chunk whose instrumented output would exceed RHDH's per-entry size limit.
 #
 # To disable (faster local dev): E2E_COLLECT_COVERAGE=false
-# Zip bomb detection (RHDHBUGS-3470) is handled at image-build time:
-# instrument-plugin.sh restores the original file for any chunk whose
-# instrumented output would exceed RHDH's per-entry size limit.
 export E2E_COLLECT_COVERAGE="${E2E_COLLECT_COVERAGE:-true}"
 
 # Local e2e-test-utils: absolute path to use a local build instead of npm

--- a/scripts/instrument-plugin.sh
+++ b/scripts/instrument-plugin.sh
@@ -18,10 +18,25 @@
 #      - Instruments JavaScript with nyc (Istanbul)
 #      - Builds a new coverage image with instrumented files
 #      - Pushes the coverage image with __coverage tag suffix
+#
+# Environment:
+#   MAX_INSTRUMENTED_ENTRY_SIZE  Zip-bomb guard threshold in bytes (default
+#                                15000000). Files whose instrumented output
+#                                exceeds this are restored to their original
+#                                uninstrumented version. See RHDHBUGS-3470.
 
 set -euo pipefail
 
 WORKSPACE="${1:?Usage: $0 <workspace-path>}"
+
+# Zip-bomb guard threshold: must stay below RHDH's install-dynamic-plugins
+# per-entry limit (MAX_ENTRY_SIZE, currently 20 MB by default; the extensions
+# workspace overrides it to 40 MB in its e2e value_file.yaml).
+MAX_INSTRUMENTED_ENTRY_SIZE="${MAX_INSTRUMENTED_ENTRY_SIZE:-15000000}"
+if ! [[ "$MAX_INSTRUMENTED_ENTRY_SIZE" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: MAX_INSTRUMENTED_ENTRY_SIZE must be a number of bytes, got: $MAX_INSTRUMENTED_ENTRY_SIZE" >&2
+  exit 1
+fi
 
 if [[ ! -d "$WORKSPACE" ]]; then
   echo "ERROR: Workspace directory not found: $WORKSPACE" >&2
@@ -192,12 +207,12 @@ while IFS= read -r PROD_IMAGE; do
 
     # Zip-bomb guard (RHDHBUGS-3470): Istanbul inflates large vendor chunks
     # (lodash, d3, MUI, ...) far past RHDH's install-dynamic-plugins per-entry
-    # limit (MAX_ENTRY_SIZE), e.g. topology's 1.7 MB vendor chunk becomes
-    # 44.6 MB and the pod init fails with "Zip bomb detected". Vendor code is
-    # dropped from the coverage report anyway (remap-coverage.cjs skips
-    # node_modules), so restore the original file for any instrumented output
-    # exceeding the threshold — losing nothing the report would have kept.
-    MAX_INSTRUMENTED_ENTRY_SIZE="${MAX_INSTRUMENTED_ENTRY_SIZE:-15000000}"
+    # limit, e.g. topology's 1.7 MB vendor chunk becomes 44.6 MB and the pod
+    # init fails with "Zip bomb detected". Vendor code is dropped from the
+    # coverage report anyway (remap-coverage.cjs skips node_modules), so
+    # restore the original file for any instrumented output exceeding the
+    # threshold — losing nothing the report would have kept.
+    GUARD_FAILED=false
     while IFS= read -r -d '' BIG_FILE; do
       REL="${BIG_FILE#"$WORK_DIR/inst-$BUNDLE/"}"
       ORIG_FILE="$WORK_DIR/orig-$BUNDLE/$REL"
@@ -207,9 +222,16 @@ while IFS= read -r PROD_IMAGE; do
         cp "$ORIG_FILE" "$BIG_FILE"
         echo "  ⚠️  $BUNDLE/$REL instrumented to ${INST_SIZE}B (> ${MAX_INSTRUMENTED_ENTRY_SIZE}B zip-bomb guard) — restored original (${ORIG_SIZE}B); no coverage for this chunk"
       else
-        echo "  ❌ $BUNDLE/$REL exceeds the zip-bomb guard but its original was not found — leaving instrumented (may trip zip bomb detection)"
+        echo "  ❌ $BUNDLE/$REL exceeds the zip-bomb guard but its original was not found - skipping that bundle"
+        GUARD_FAILED=true
       fi
     done < <(find "$WORK_DIR/inst-$BUNDLE" -type f -name '*.js' -size +"${MAX_INSTRUMENTED_ENTRY_SIZE}c" -print0)
+    if [[ "$GUARD_FAILED" == "true" ]]; then
+      # Shipping the oversized file would fail at deploy time (zip bomb), so
+      # drop this bundle's overlay — the image falls back to the base layer's
+      # original (uninstrumented but valid) bundle instead.
+      continue
+    fi
 
     BUNDLE_JS_COUNT=$(count_files_matching "__coverage__" "$WORK_DIR/inst-$BUNDLE")
     if [[ "$BUNDLE_JS_COUNT" -eq 0 ]]; then

--- a/scripts/instrument-plugin.sh
+++ b/scripts/instrument-plugin.sh
@@ -190,6 +190,27 @@ while IFS= read -r PROD_IMAGE; do
       echo "  ⚠️  $UNFIXED_COUNT file(s) in $BUNDLE/ still use new Function(\"return this\") after the fix"
     fi
 
+    # Zip-bomb guard (RHDHBUGS-3470): Istanbul inflates large vendor chunks
+    # (lodash, d3, MUI, ...) far past RHDH's install-dynamic-plugins per-entry
+    # limit (MAX_ENTRY_SIZE), e.g. topology's 1.7 MB vendor chunk becomes
+    # 44.6 MB and the pod init fails with "Zip bomb detected". Vendor code is
+    # dropped from the coverage report anyway (remap-coverage.cjs skips
+    # node_modules), so restore the original file for any instrumented output
+    # exceeding the threshold — losing nothing the report would have kept.
+    MAX_INSTRUMENTED_ENTRY_SIZE="${MAX_INSTRUMENTED_ENTRY_SIZE:-15000000}"
+    while IFS= read -r -d '' BIG_FILE; do
+      REL="${BIG_FILE#"$WORK_DIR/inst-$BUNDLE/"}"
+      ORIG_FILE="$WORK_DIR/orig-$BUNDLE/$REL"
+      if [[ -f "$ORIG_FILE" ]]; then
+        INST_SIZE=$(stat -c%s "$BIG_FILE" 2>/dev/null || stat -f%z "$BIG_FILE")
+        ORIG_SIZE=$(stat -c%s "$ORIG_FILE" 2>/dev/null || stat -f%z "$ORIG_FILE")
+        cp "$ORIG_FILE" "$BIG_FILE"
+        echo "  ⚠️  $BUNDLE/$REL instrumented to ${INST_SIZE}B (> ${MAX_INSTRUMENTED_ENTRY_SIZE}B zip-bomb guard) — restored original (${ORIG_SIZE}B); no coverage for this chunk"
+      else
+        echo "  ❌ $BUNDLE/$REL exceeds the zip-bomb guard but its original was not found — leaving instrumented (may trip zip bomb detection)"
+      fi
+    done < <(find "$WORK_DIR/inst-$BUNDLE" -type f -name '*.js' -size +"${MAX_INSTRUMENTED_ENTRY_SIZE}c" -print0)
+
     BUNDLE_JS_COUNT=$(count_files_matching "__coverage__" "$WORK_DIR/inst-$BUNDLE")
     if [[ "$BUNDLE_JS_COUNT" -eq 0 ]]; then
       echo "  ❌ No __coverage__ found in instrumented $BUNDLE/ - skipping that bundle"

--- a/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
+++ b/workspaces/topology/e2e-tests/tests/specs/topology.spec.ts
@@ -1,3 +1,4 @@
+// Trigger e2e: validate the zip-bomb guard on __coverage images (RHDHBUGS-3470)
 import { test, expect, Page } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { $, WorkspacePaths } from "@red-hat-developer-hub/e2e-test-utils/utils";
 import path from "path";


### PR DESCRIPTION
## Summary
- Fixes [RHDHBUGS-3470](https://redhat.atlassian.net/browse/RHDHBUGS-3470): `__coverage` OCI images trip RHDH's zip bomb detection because Istanbul inflates large vendor chunks ~25x (topology's 1.7 MB vendor chunk → 44.6 MB), exceeding `install-dynamic-plugins`' per-entry `MAX_ENTRY_SIZE` limit and aborting e2e before any test runs.
- Root cause refinement: the oversized chunks are **vendor code** (lodash, d3, MUI, react-topology). `remap-coverage.cjs` already drops `node_modules` entries from the final lcov, so instrumenting them yields zero useful coverage — while being exactly what trips the detector.
- Fix: add a size guard to `scripts/instrument-plugin.sh` — after `nyc instrument`, any file whose instrumented output exceeds `MAX_INSTRUMENTED_ENTRY_SIZE` (default 15 MB, safely below RHDH's limit) is restored to its original uninstrumented version. App-code chunks stay instrumented; no `MAX_ENTRY_SIZE` bump needed, detector stays intact.
- Reverts the mitigation: `E2E_COLLECT_COVERAGE` default back to `true` in `run-e2e.sh` (ticket acceptance criteria).
- Touches the topology spec (comment only) to trigger the PR e2e job on the affected workspace.

## Local verification (against the published topology image)
- `dist/static/4697.*.chunk.js`: instrumented 44,720,109 B → restored original 1,784,283 B
- `dist-scalprum/static/3069.*.chunk.js`: instrumented 44,119,337 B → restored original 1,796,962 B
- 431 JS files remain instrumented (206 dist + 225 dist-scalprum); `remoteEntry.js` still carries `__coverage__`
- Final image: single layer, largest entry 11.2 MB (a sourcemap) — nothing above 15 MB

## Test plan
- [ ] `/publish` to build `__coverage` images with the guard
- [ ] PR e2e (`e2e-ocp-helm`) on topology: no "Zip bomb detected" in `install-dynamic-plugins.log`, tests run, coverage artifacts non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)