### PR TITLE
chore(deps): [release-1.10][orchestrator] bump linkify-it to 5.0.1 or higher

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -40,20 +40,20 @@
    languageName: node
    linkType: hard
  
-@@ -10983,13 +10982,6 @@
-   version: 1.0.2
-   resolution: "@protobufjs/float@npm:1.0.2"
-   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
--  languageName: node
--  linkType: hard
--
+@@ -10986,13 +10985,6 @@
+   languageName: node
+   linkType: hard
+ 
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
-   languageName: node
-   linkType: hard
- 
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
 @@ -11007,10 +10999,10 @@
    languageName: node
    linkType: hard
@@ -121,36 +121,51 @@
    languageName: node
    linkType: hard
  
-@@ -25855,6 +25847,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
+@@ -25858,6 +25850,15 @@
+   languageName: node
+   linkType: hard
+ 
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: "npm:^1.1.2"
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
-   languageName: node
-   linkType: hard
- 
-@@ -29427,6 +29428,13 @@
-   version: 5.2.3
-   resolution: "long@npm:5.2.3"
-   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
 +  languageName: node
 +  linkType: hard
 +
+ "hast-util-from-parse5@npm:^7.0.0":
+   version: 7.1.2
+   resolution: "hast-util-from-parse5@npm:7.1.2"
+@@ -29046,11 +29047,11 @@
+   linkType: hard
+ 
+ "linkify-it@npm:^5.0.0":
+-  version: 5.0.0
+-  resolution: "linkify-it@npm:5.0.0"
++  version: 5.0.2
++  resolution: "linkify-it@npm:5.0.2"
+   dependencies:
+     uc.micro: "npm:^2.0.0"
+-  checksum: 10c0/ff4abbcdfa2003472fc3eb4b8e60905ec97718e11e33cca52059919a4c80cc0e0c2a14d23e23d8c00e5402bc5a885cdba8ca053a11483ab3cc8b3c7a52f88e2d
++  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
+   languageName: node
+   linkType: hard
+ 
+@@ -29430,6 +29431,13 @@
+   languageName: node
+   linkType: hard
+ 
 +"long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
-   languageName: node
-   linkType: hard
- 
++  languageName: node
++  linkType: hard
++
+ "longest-streak@npm:^3.0.0":
+   version: 3.1.0
+   resolution: "longest-streak@npm:3.1.0"
 @@ -33625,22 +33633,21 @@
    linkType: hard
  

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -27,6 +27,10 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-48801
+    package: linkify-it
+    patch_version: 5.0.2
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5


### PR DESCRIPTION
it bump linkify-it to 5.0.1 or higher patching https://github.com/advisories/GHSA-22p9-wv53-3rq4
https://redhat.atlassian.net/browse/RHIDP-15582