### PR TITLE
chore(deps): [release-1.10][lightspeed] bump linkify-it to 5.0.1 or higher

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -29,20 +29,20 @@
    languageName: node
    linkType: hard
  
-@@ -8881,13 +8880,6 @@
-   languageName: node
-   linkType: hard
- 
+@@ -8878,13 +8877,6 @@
+   version: 1.0.2
+   resolution: "@protobufjs/float@npm:1.0.2"
+   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+-  languageName: node
+-  linkType: hard
+-
 -"@protobufjs/inquire@npm:1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
--  languageName: node
--  linkType: hard
--
- "@protobufjs/path@npm:^1.1.2":
-   version: 1.1.2
-   resolution: "@protobufjs/path@npm:1.1.2"
+   languageName: node
+   linkType: hard
+ 
 @@ -21220,13 +21212,13 @@
    linkType: hard
  
@@ -163,6 +163,21 @@
    version: 1.1.0
    resolution: "jsbn@npm:1.1.0"
    checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
+@@ -26085,11 +26076,11 @@
+   linkType: hard
+ 
+ "linkify-it@npm:^5.0.0":
+-  version: 5.0.0
+-  resolution: "linkify-it@npm:5.0.0"
++  version: 5.0.2
++  resolution: "linkify-it@npm:5.0.2"
+   dependencies:
+     uc.micro: "npm:^2.0.0"
+-  checksum: 10c0/ff4abbcdfa2003472fc3eb4b8e60905ec97718e11e33cca52059919a4c80cc0e0c2a14d23e23d8c00e5402bc5a885cdba8ca053a11483ab3cc8b3c7a52f88e2d
++  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
+   languageName: node
+   linkType: hard
+ 
 @@ -26426,6 +26417,13 @@
    version: 5.2.3
    resolution: "long@npm:5.2.3"

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -18,6 +18,10 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-48801
+    package: linkify-it
+    patch_version: 5.0.2
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5


### PR DESCRIPTION
it bump linkify-it to 5.0.1 or higher patching https://github.com/advisories/GHSA-22p9-wv53-3rq4
https://redhat.atlassian.net/browse/RHIDP-15582