### PR TITLE
test(quay): make e2e independent of homepage

### DIFF
--- a/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
+++ b/workspaces/quay/e2e-tests/tests/specs/quay.spec.ts
@@ -62,9 +62,8 @@ test.describe("Test Quay.io plugin", () => {
     const quayClient = new QuayClient();
 
     test.beforeEach(async ({ uiHelper }) => {
-      await uiHelper.clickLink({
-        ariaLabel: "Self-service",
-      });
+      await uiHelper.openCatalogSidebar("Component");
+      await uiHelper.clickButton("Self-service");
       await uiHelper.verifyHeading("Self-service");
     });
 


### PR DESCRIPTION
make the quay e2e tests no longer use the global header, so they don't fail when homepage/header gets borked