### PR TITLE
docs: catalog-only vs overlay-build ownership models

### DIFF
--- a/user-guide/01-getting-started.md
+++ b/user-guide/01-getting-started.md
@@ -51,11 +51,12 @@ rhdh-plugin-export-overlays/
 ├── catalog-entities/          # Catalog Plugin / Collection entities
 │   └── extensions/
 │       ├── plugins/           # Marketplace/catalog Plugin YAML (all models)
-│       ├── packages/          # Generated/copied Package entities in index output
 │       └── collections/
 └── .github/workflows/         # CI/CD automation
 ```
 
+> Package entities live in `workspaces/*/metadata/`, not under `catalog-entities/`. A `packages/` directory appears only in **catalog-index pipeline output** (see [07 - Plugin Catalog Index](./07-plugin-catalog-index.md)).
+>
 > Some plugins only contribute a Plugin YAML under `catalog-entities/extensions/plugins/` and are **not** exported via `workspaces/` (OCI is built externally). See [03 - Plugin Owner Responsibilities](./03-plugin-owner-responsibilities.md#two-ways-a-plugin-can-appear-in-this-repository).
 
 ---

--- a/user-guide/01-getting-started.md
+++ b/user-guide/01-getting-started.md
@@ -34,7 +34,7 @@ rhdh-plugin-export-overlays/
 ├── versions.json              # Target versions (Backstage, Node, CLI)
 ├── workspace-discovery-include # Auto-discovery scope patterns
 ├── workspace-discovery-exclude # Workspaces excluded from auto-discovery
-├── workspaces/                # One folder per source workspace
+├── workspaces/                # One folder per source workspace (overlay export)
 │   └── [workspace-name]/
 │       ├── source.json        # Source repository reference
 │       ├── plugins-list.yaml  # Plugin paths + export args
@@ -48,8 +48,15 @@ rhdh-plugin-export-overlays/
 │       └── smoke-tests/       # Smoke test configuration (optional)
 │           ├── test.env
 │           └── app-config.test.yaml
+├── catalog-entities/          # Catalog Plugin / Collection entities
+│   └── extensions/
+│       ├── plugins/           # Marketplace/catalog Plugin YAML (all models)
+│       ├── packages/          # Generated/copied Package entities in index output
+│       └── collections/
 └── .github/workflows/         # CI/CD automation
 ```
+
+> Some plugins only contribute a Plugin YAML under `catalog-entities/extensions/plugins/` and are **not** exported via `workspaces/` (OCI is built externally). See [03 - Plugin Owner Responsibilities](./03-plugin-owner-responsibilities.md#two-ways-a-plugin-can-appear-in-this-repository).
 
 ---
 
@@ -60,6 +67,8 @@ rhdh-plugin-export-overlays/
 A **workspace** maps to a source repository (or a workspace within a monorepo). Each workspace folder contains all configuration needed to build and publish plugins from that source.
 
 **Example:** `workspaces/backstage/` maps to `https://github.com/backstage/backstage`
+
+Workspaces require a **public** `https://github.com/...` source URL that CI can clone. Overlay export does not currently support private source repositories — for those cases, use catalog-only Plugin metadata (see link above).
 
 ### source.json
 
@@ -260,6 +269,18 @@ Manual PRs should be reserved for situations where automatic discovery does not 
    Create one YAML file per plugin following the Package schema.
 
 5. **Open PR against `main`**
+
+### Catalog-only plugins (external OCI build)
+
+If the plugin OCI image is built and published outside this repository, do **not** add a `workspaces/` entry unless you are also moving export into overlays with a public cloneable source.
+
+Instead:
+
+1. Add or update the Plugin entity under `catalog-entities/extensions/plugins/`
+2. Keep title, description, support level, links, and configuration guidance accurate
+3. Open a PR against `main`
+
+Owner obligations for that path are documented in [03 - Plugin Owner Responsibilities](./03-plugin-owner-responsibilities.md#two-ways-a-plugin-can-appear-in-this-repository).
 
 ---
 

--- a/user-guide/03-plugin-owner-responsibilities.md
+++ b/user-guide/03-plugin-owner-responsibilities.md
@@ -6,31 +6,47 @@ As a plugin owner, you are responsible for maintaining the health and compatibil
 
 ## Ownership Model
 
+### Two ways a plugin can appear in this repository
+
+Not every plugin is built and exported through overlays. Ownership responsibilities depend on which model applies:
+
+| Model | What lives in overlays | OCI build / publish | Typical when |
+|-------|------------------------|---------------------|--------------|
+| **A. Source + overlay build** | `workspaces/<name>/` (`source.json`, `plugins-list.yaml`, `metadata/*.yaml`, optional patches) **and** a Plugin entity under `catalog-entities/extensions/plugins/` (usually with `packages:` / OCI refs) | Built and published by overlay CI / midstream export | Source is on a **public** GitHub repo that CI can clone (`https://github.com/...` only today) |
+| **B. Catalog metadata only** | Plugin entity YAML under `catalog-entities/extensions/plugins/` only — **no** `workspaces/` export config | Built and published **outside** this repository (owner’s own pipeline / registry) | Source or build stays outside overlays (including private source trees); overlays only need marketplace/catalog listing metadata |
+
+> **Important:** Overlay export does **not** clone private source repositories. If the plugin cannot be built from a public GitHub URL via `source.json`, use **Model B** and keep OCI production in your own pipeline. Maintain the catalog Plugin YAML here so the plugin can still appear in the plugin catalog index.
+
+Model A is the default path described in the rest of this guide (metadata sync, version bumps, patches, `/publish`, `/smoketest`). Model B owners skip workspace/export maintenance and focus on catalog YAML accuracy (title, description, support level, links, configuration guidance).
+
 ### Who is a Plugin Owner?
 
 You are a plugin owner if you:
 
-1. **Maintain** the source plugin in upstream repositories (backstage/backstage, backstage/community-plugins, rhdh-plugins, etc.)
-2. **Created** or **modified** the overlay configuration for your plugin
+1. **Maintain** the plugin source (in a public GitHub repo such as backstage/backstage, backstage/community-plugins, redhat-developer/rhdh-plugins, or another public plugin repo) **and/or** maintain its catalog Plugin YAML in this repository
+2. **Created** or **modified** the overlay workspace configuration **or** the catalog-only Plugin entity for your plugin
 3. Are **assigned** as maintainer by your organization
 
 ### Responsibilities Overview
 
-| Area | Frequency | Criticality |
-|------|-----------|-------------|
-| Metadata synchronization | Every release | 🔴 High |
-| Backstage version updates | When compatibility signals appear | 🔴 High |
-| Patch maintenance | As needed | 🟡 Medium |
-| Test validation | Every PR | 🔴 High |
-| Deprecation communication | As needed | 🟡 Medium |
+| Area | Applies to | Frequency | Criticality |
+|------|------------|-----------|-------------|
+| Metadata synchronization (source ↔ workspace) | Model A | Every release | 🔴 High |
+| Catalog Plugin YAML accuracy | Model A and B | When listing/docs/support info changes | 🔴 High |
+| Backstage version updates | Model A (Model B: keep external build compatible) | When compatibility signals appear | 🔴 High |
+| Patch maintenance | Model A | As needed | 🟡 Medium |
+| Test validation (`/publish`, `/smoketest`) | Model A | Every PR | 🔴 High |
+| Deprecation communication | Model A and B | As needed | 🟡 Medium |
 
 ---
 
 ## Core Responsibilities
 
+> The subsections below focus on **Model A** (source + overlay build). For **Model B**, keep the Plugin YAML under `catalog-entities/extensions/plugins/` accurate and up to date; do not add a `workspaces/` entry unless you are moving the plugin onto the overlay export path with a public cloneable source.
+
 ### 1. Keep Metadata Synchronized
 
-Your plugin exists in **two places** that must stay in sync:
+For **Model A**, your plugin exists in **two places** that must stay in sync:
 
 | Location | Files | Owner Updates |
 |----------|-------|---------------|
@@ -123,6 +139,8 @@ Notify downstream users when:
 
 ## Maintenance Checklist
 
+### Model A (source + overlay build)
+
 Use this checklist when updating your plugin (triggered by a compatibility signal, a new upstream release, or a platform version bump):
 
 ```markdown
@@ -138,6 +156,7 @@ Use this checklist when updating your plugin (triggered by a compatibility signa
 - [ ] Verified `spec.packageName` matches source `package.json:name`
 - [ ] Reviewed and updated `appConfigExamples` if configuration changed
 - [ ] Updated metadata links (source, issues, docs) if needed
+- [ ] Updated catalog Plugin YAML under `catalog-entities/extensions/plugins/` if listing text changed
 
 ### Patch Check
 - [ ] Verified all patches apply cleanly to current source
@@ -149,6 +168,17 @@ Use this checklist when updating your plugin (triggered by a compatibility signa
 - [ ] `/publish` completed successfully
 - [ ] `/smoketest` passed or manual testing completed
 - [ ] PR merged
+```
+
+### Model B (catalog metadata only)
+
+```markdown
+## Catalog-only Plugin Maintenance - [Plugin Name] - [Date]
+
+- [ ] Confirmed OCI images are still built and published by the external pipeline
+- [ ] Updated `catalog-entities/extensions/plugins/<plugin>.yaml` (title, description, support level, links, tags)
+- [ ] Reviewed configuration / install guidance in the Plugin YAML against current external docs
+- [ ] Opened PR against this repository; no `workspaces/` changes required
 ```
 
 ---
@@ -165,6 +195,8 @@ spec:
   # Add deprecation notice
 ```
 
+Apply this on workspace Package metadata (**Model A**) and/or the catalog Plugin entity under `catalog-entities/extensions/plugins/` (**Model A and B**).
+
 ### 2. Communicate to Users
 
 - Open an issue documenting the deprecation
@@ -173,12 +205,13 @@ spec:
 
 ### 3. Remove After Grace Period
 
-When the grace period ends, remove the workspace entirely:
+When the grace period ends:
 
-- Delete the workspace folder (including `source.json`, `plugins-list.yaml`, metadata files, and any patches)
+- **Model A:** Delete the workspace folder entirely (including `source.json`, `plugins-list.yaml`, metadata files, and any patches), and remove or update the related catalog Plugin YAML
+- **Model B:** Remove or update the catalog Plugin YAML under `catalog-entities/extensions/plugins/`
 - Document removal in release notes
 
-> **Important:** Simply commenting out entries in `plugins-list.yaml` or removing metadata files while keeping the workspace folder is not sufficient. If the workspace folder and `source.json` remain, automatic discovery will detect the plugin again and propose re-adding it. To permanently remove a plugin, delete the entire workspace directory.
+> **Important (Model A):** Simply commenting out entries in `plugins-list.yaml` or removing metadata files while keeping the workspace folder is not sufficient. If the workspace folder and `source.json` remain, automatic discovery will detect the plugin again and propose re-adding it. To permanently remove a plugin, delete the entire workspace directory.
 
 ---
 

--- a/user-guide/07-plugin-catalog-index.md
+++ b/user-guide/07-plugin-catalog-index.md
@@ -8,6 +8,8 @@ The **plugin catalog index** is the collection of community and supported plugin
 
 The catalog index generation pipeline reads workspace metadata, queries container registries, and produces a self-contained directory of catalog entities and an `index.json` file. This directory is then packaged as an OCI image and pushed to a container registry, where RHDH consumes it.
 
+Plugin entities under `catalog-entities/extensions/plugins/` can describe plugins that are exported via `workspaces/` **or** plugins whose OCI images are built elsewhere (catalog metadata only). Package bootstrap and registry verification in this pipeline are driven by workspace Package metadata / package lists — catalog-only Plugin YAMLs contribute listing metadata to the index, not an overlay export. See [03 - Plugin Owner Responsibilities](./03-plugin-owner-responsibilities.md#two-ways-a-plugin-can-appear-in-this-repository).
+
 ### High-Level Flow
 
 ```mermaid

--- a/user-guide/README.md
+++ b/user-guide/README.md
@@ -24,17 +24,19 @@ This guide covers the essential workflows for using the **rhdh-plugin-export-ove
 |------|---------|
 | `versions.json` | Target Backstage version, Node version, CLI version |
 | `plugins-regexps` | Auto-discovery scope patterns |
-| `workspaces/[name]/source.json` | Source repo URL, ref, and Backstage version |
+| `workspaces/[name]/source.json` | Source repo URL, ref, and Backstage version (Model A: overlay build) |
 | `workspaces/[name]/plugins-list.yaml` | Plugin paths and export arguments |
 | `workspaces/[name]/metadata/*.yaml` | Package entity definitions |
 | `workspaces/[name]/patches/*.patch` | Unified diff patches |
 | `workspaces/[name]/plugins/[plugin]/` | Plugin-specific overlays |
+| `catalog-entities/extensions/plugins/*.yaml` | Plugin catalog listing entities (Model A and Model B / catalog-only) |
 
 ### Common Workflows
 
 | Task | Start Here |
 |------|-----------|
-| Add a new plugin | [01 - Getting Started](./01-getting-started.md#adding-a-new-plugin) |
+| Add a new plugin (overlay export) | [01 - Getting Started](./01-getting-started.md#adding-a-new-plugin) |
+| Catalog-only plugin (external OCI build) | [03 - Plugin Owner Responsibilities](./03-plugin-owner-responsibilities.md#two-ways-a-plugin-can-appear-in-this-repository) |
 | Update plugin version | [05 - Version Updates](./05-version-updates.md) |
 | Fix build failure | [02 - Export Tools](./02-export-tools.md#troubleshooting) |
 | Sync metadata | [04 - Metadata Synchronization](./04-metadata-synchronization.md) |


### PR DESCRIPTION
## Summary
- Document two plugin participation models in overlays: **source + overlay build** (public GitHub `workspaces/`) vs **catalog metadata only** (`catalog-entities/extensions/plugins/` when OCI is built externally)
- Clarify that private-source export via `source.json` is not supported; catalog-only is the supported path when build stays outside overlays
- Cross-link from getting started, user-guide index, and catalog-index docs (no named private plugins)

## Why
Follow-up from discussion on plugin-owner responsibilities: owners asked how private / externally built plugins fit. We should describe the **handling model**, not call out specific plugins.

## Test plan
- [ ] Review wording in `user-guide/03-plugin-owner-responsibilities.md` (primary)
- [ ] Skim cross-links in `01`, `README`, `07`
- [ ] Confirm wiki sync (if any) picks up the same paths after merge


Made with [Cursor](https://cursor.com)

## Related
- [RHIDP-15775](https://redhat.atlassian.net/browse/RHIDP-15775)
