### PR TITLE
fix(lightspeed-e2e): disable Segment telemetry plugin

### DIFF
--- a/workspaces/lightspeed/e2e-tests/tests/config/dynamic-plugins-nightly.yaml
+++ b/workspaces/lightspeed/e2e-tests/tests/config/dynamic-plugins-nightly.yaml
@@ -1,3 +1,6 @@
 # Lightspeed is already in dynamic-plugins.default.yaml from the catalog index.
 # Do not add workspace metadata plugins here — nightly would duplicate OCI entries.
-plugins: []
+# Disable Segment telemetry (avoids outbound analytics requests that slow RHDH).
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
+    disabled: true

--- a/workspaces/lightspeed/e2e-tests/tests/config/dynamic-plugins.yaml
+++ b/workspaces/lightspeed/e2e-tests/tests/config/dynamic-plugins.yaml
@@ -1,0 +1,10 @@
+# Disable Segment telemetry (avoids outbound analytics requests that slow RHDH).
+# Lightspeed packages are listed so PR/local still get metadata injection + OCI resolution
+# (providing only this file would skip auto-generation from metadata).
+plugins:
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
+    disabled: true
+  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-lightspeed
+    disabled: false
+  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-lightspeed-backend
+    disabled: false

--- a/workspaces/lightspeed/e2e-tests/tests/specs/lightspeed.spec.ts
+++ b/workspaces/lightspeed/e2e-tests/tests/specs/lightspeed.spec.ts
@@ -117,7 +117,7 @@ test.describe("Lightspeed UI", () => {
 
   test.describe("Chatbot display modes", () => {
     test.beforeEach(async () => {
-      await page.goto("/");
+      await page.goto("/catalog");
     });
 
     test("overlay mode keeps RHDH visible with chat controls", async () => {

--- a/workspaces/lightspeed/e2e-tests/tests/support/test-helper.ts
+++ b/workspaces/lightspeed/e2e-tests/tests/support/test-helper.ts
@@ -30,9 +30,9 @@ export const lightspeedDeployConfig = {
   appConfig: "tests/config/app-config-rhdh.yaml",
   secrets: "tests/config/rhdh-secrets.yaml",
   valueFile: "tests/config/value_file.yaml",
-  ...(isNightlyMode()
-    ? { dynamicPlugins: "tests/config/dynamic-plugins-nightly.yaml" }
-    : {}),
+  dynamicPlugins: isNightlyMode()
+    ? "tests/config/dynamic-plugins-nightly.yaml"
+    : "tests/config/dynamic-plugins.yaml",
 };
 
 async function patchOpenAiAllowedModels(rhdh: RHDHDeployment): Promise<void> {


### PR DESCRIPTION
## Summary
- Disable `analytics-provider-segment` in Lightspeed e2e dynamic-plugins configs (nightly and local/PR) to stop outbound telemetry requests that can slow RHDH.
- Always select the appropriate `dynamicPlugins` file from `test-helper.ts` so both modes pick up the override.

**Resolves:**
https://redhat.atlassian.net/browse/RHIDP-15506

## Test plan
- [ ] Redeploy Lightspeed e2e and confirm install-dynamic-plugins logs show `Skipping disabled dynamic plugin ...analytics-provider-segment`
- [ ] Smoke local/PR path (`yarn test` without nightly env) still loads Lightspeed
- [ ] Smoke nightly path (`E2E_NIGHTLY_MODE=true`) still loads Lightspeed from catalog defaults
