### PR TITLE
fix(e2e): re-enable, stabilize failswitch rerun against flaky public httpbin

### DIFF
--- a/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
@@ -1,14 +1,11 @@
-import { writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { OrchestratorPage } from "@red-hat-developer-hub/e2e-test-utils/pages";
 import { OrchestratorPO } from "../support/pages/orchestrator-po.js";
 import {
+  ensureE2eHttpbin,
   patchHttpbin,
   restartAndWait,
   cleanupAfterTest,
-  runOc,
 } from "../support/utils/test-helpers.js";
 
 type EnsureDataIndexOrSkip = (
@@ -178,64 +175,4 @@ export function registerOrchestratorCoreWorkflowTests(
       await orchestrator.validateWorkflowAllRuns();
     });
   });
-}
-
-/** Minimal in-cluster /get mock so recovery does not depend on public httpbin.org. */
-function ensureE2eHttpbin(ns: string): void {
-  const manifest = `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: e2e-httpbin
-  namespace: ${ns}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: e2e-httpbin
-  template:
-    metadata:
-      labels:
-        app: e2e-httpbin
-    spec:
-      containers:
-        - name: httpbin
-          image: registry.access.redhat.com/ubi9/python-311@sha256:a0bdb55576fc5b8d6704279307817828ef027e1065533ceba133fe9516003a6c
-          command:
-            - python3
-            - -c
-            - |
-              from http.server import HTTPServer, BaseHTTPRequestHandler
-              class H(BaseHTTPRequestHandler):
-                def do_GET(self):
-                  b=b'{"args":{},"headers":{},"origin":"e2e","url":"http://e2e-httpbin/get"}'
-                  self.send_response(200); self.send_header("Content-Type","application/json"); self.send_header("Content-Length",str(len(b))); self.end_headers(); self.wfile.write(b)
-                def log_message(self,*_): pass
-              HTTPServer(("0.0.0.0",8080),H).serve_forever()
-          ports:
-            - containerPort: 8080
-          readinessProbe:
-            httpGet:
-              path: /get
-              port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: e2e-httpbin
-  namespace: ${ns}
-spec:
-  selector:
-    app: e2e-httpbin
-  ports:
-    - port: 80
-      targetPort: 8080
-`;
-  const file = join(tmpdir(), `e2e-httpbin-${ns}.yaml`);
-  writeFileSync(file, manifest);
-  runOc(["apply", "-f", file], 60_000);
-  runOc(
-    ["-n", ns, "rollout", "status", "deployment/e2e-httpbin", "--timeout=180s"],
-    210_000,
-  );
 }

--- a/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
@@ -1,3 +1,6 @@
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "@red-hat-developer-hub/e2e-test-utils/test";
 import { OrchestratorPage } from "@red-hat-developer-hub/e2e-test-utils/pages";
 import { OrchestratorPO } from "../support/pages/orchestrator-po.js";
@@ -5,6 +8,7 @@ import {
   patchHttpbin,
   restartAndWait,
   cleanupAfterTest,
+  runOc,
 } from "../support/utils/test-helpers.js";
 
 type EnsureDataIndexOrSkip = (
@@ -106,18 +110,19 @@ export function registerOrchestratorCoreWorkflowTests(
       await orchestrator.validateCurrentWorkflowStatus("Completed");
     });
 
-    // FIXME: This test is flaky, needs to be fixed. tracked here https://redhat.atlassian.net/browse/RHDHBUGS-3431
     // eslint-disable-next-line playwright/expect-expect
-    test.fixme("Rerun Failswitch from failure point", async ({}, testInfo) => {
+    test("Rerun Failswitch from failure point", async ({}, testInfo) => {
       // 4 minutes: pod restarts + 60s sleep + failure/recovery time
       test.setTimeout(240_000);
       const ns = testInfo.project.name;
 
       test.skip(!ns, "NAME_SPACE not set");
 
-      const originalHttpbin = "https://httpbin.org/";
+      // Avoid flaky public httpbin.org (503s during retrigger). Use in-cluster mock + local fail URL.
+      const originalHttpbin = `http://e2e-httpbin.${ns}.svc.cluster.local/`;
       try {
-        patchHttpbin(ns!, "https://foobar.org/");
+        ensureE2eHttpbin(ns!);
+        patchHttpbin(ns!, "http://127.0.0.1:1/");
         restartAndWait(ns!);
 
         await orchestratorPo.openFailswitchWorkflowFromSidebar();
@@ -173,4 +178,64 @@ export function registerOrchestratorCoreWorkflowTests(
       await orchestrator.validateWorkflowAllRuns();
     });
   });
+}
+
+/** Minimal in-cluster /get mock so recovery does not depend on public httpbin.org. */
+function ensureE2eHttpbin(ns: string): void {
+  const manifest = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2e-httpbin
+  namespace: ${ns}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: e2e-httpbin
+  template:
+    metadata:
+      labels:
+        app: e2e-httpbin
+    spec:
+      containers:
+        - name: httpbin
+          image: registry.access.redhat.com/ubi9/python-311@sha256:a0bdb55576fc5b8d6704279307817828ef027e1065533ceba133fe9516003a6c
+          command:
+            - python3
+            - -c
+            - |
+              from http.server import HTTPServer, BaseHTTPRequestHandler
+              class H(BaseHTTPRequestHandler):
+                def do_GET(self):
+                  b=b'{"args":{},"headers":{},"origin":"e2e","url":"http://e2e-httpbin/get"}'
+                  self.send_response(200); self.send_header("Content-Type","application/json"); self.send_header("Content-Length",str(len(b))); self.end_headers(); self.wfile.write(b)
+                def log_message(self,*_): pass
+              HTTPServer(("0.0.0.0",8080),H).serve_forever()
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /get
+              port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-httpbin
+  namespace: ${ns}
+spec:
+  selector:
+    app: e2e-httpbin
+  ports:
+    - port: 80
+      targetPort: 8080
+`;
+  const file = join(tmpdir(), `e2e-httpbin-${ns}.yaml`);
+  writeFileSync(file, manifest);
+  runOc(["apply", "-f", file], 60_000);
+  runOc(
+    ["-n", ns, "rollout", "status", "deployment/e2e-httpbin", "--timeout=180s"],
+    210_000,
+  );
 }

--- a/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/specs/orchestrator-workflow-core.tests.ts
@@ -109,8 +109,8 @@ export function registerOrchestratorCoreWorkflowTests(
 
     // eslint-disable-next-line playwright/expect-expect
     test("Rerun Failswitch from failure point", async ({}, testInfo) => {
-      // 4 minutes: pod restarts + 60s sleep + failure/recovery time
-      test.setTimeout(240_000);
+      // 8 minutes: ensureE2eHttpbin (cold pull) + two patch/restart cycles + 60s sleep + UI
+      test.setTimeout(480_000);
       const ns = testInfo.project.name;
 
       test.skip(!ns, "NAME_SPACE not set");

--- a/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
@@ -1,6 +1,69 @@
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runOc } from "./workflow-deployment-helpers.js";
 
 type EnvEntry = { name: string; value: string };
+
+/** Minimal in-cluster /get mock so recovery does not depend on public httpbin.org. */
+export function ensureE2eHttpbin(ns: string): void {
+  const manifest = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2e-httpbin
+  namespace: ${ns}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: e2e-httpbin
+  template:
+    metadata:
+      labels:
+        app: e2e-httpbin
+    spec:
+      containers:
+        - name: httpbin
+          image: registry.access.redhat.com/ubi9/python-311@sha256:a0bdb55576fc5b8d6704279307817828ef027e1065533ceba133fe9516003a6c
+          command:
+            - python3
+            - -c
+            - |
+              from http.server import HTTPServer, BaseHTTPRequestHandler
+              class H(BaseHTTPRequestHandler):
+                def do_GET(self):
+                  b=b'{"args":{},"headers":{},"origin":"e2e","url":"http://e2e-httpbin/get"}'
+                  self.send_response(200); self.send_header("Content-Type","application/json"); self.send_header("Content-Length",str(len(b))); self.end_headers(); self.wfile.write(b)
+                def log_message(self,*_): pass
+              HTTPServer(("0.0.0.0",8080),H).serve_forever()
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /get
+              port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-httpbin
+  namespace: ${ns}
+spec:
+  selector:
+    app: e2e-httpbin
+  ports:
+    - port: 80
+      targetPort: 8080
+`;
+  const file = join(tmpdir(), `e2e-httpbin-${ns}.yaml`);
+  writeFileSync(file, manifest);
+  runOc(["apply", "-f", file], 60_000);
+  runOc(
+    ["-n", ns, "rollout", "status", "deployment/e2e-httpbin", "--timeout=180s"],
+    210_000,
+  );
+}
 
 export function getHttpbinValue(ns: string): string | undefined {
   try {

--- a/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/support/utils/cluster-helpers.ts
@@ -1,12 +1,17 @@
-import { writeFileSync } from "node:fs";
+import { unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runOc } from "./workflow-deployment-helpers.js";
 
 type EnvEntry = { name: string; value: string };
 
+const K8S_NAMESPACE_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
 /** Minimal in-cluster /get mock so recovery does not depend on public httpbin.org. */
 export function ensureE2eHttpbin(ns: string): void {
+  if (!K8S_NAMESPACE_RE.test(ns)) {
+    throw new Error(`invalid kubernetes namespace for e2e-httpbin: ${ns}`);
+  }
   const manifest = `
 apiVersion: apps/v1
 kind: Deployment
@@ -58,7 +63,15 @@ spec:
 `;
   const file = join(tmpdir(), `e2e-httpbin-${ns}.yaml`);
   writeFileSync(file, manifest);
-  runOc(["apply", "-f", file], 60_000);
+  try {
+    runOc(["apply", "-f", file], 60_000);
+  } finally {
+    try {
+      unlinkSync(file);
+    } catch {
+      // best-effort cleanup of temp manifest
+    }
+  }
   runOc(
     ["-n", ns, "rollout", "status", "deployment/e2e-httpbin", "--timeout=180s"],
     210_000,

--- a/workspaces/orchestrator/e2e-tests/tests/support/utils/test-helpers.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/support/utils/test-helpers.ts
@@ -21,6 +21,7 @@ export {
   logOrchestratorDeployFailureDiagnostics,
 } from "./workflow-deployment-helpers.js";
 export {
+  ensureE2eHttpbin,
   patchHttpbin,
   restartAndWait,
   cleanupAfterTest,


### PR DESCRIPTION
Replace foobar.org/httpbin.org fixtures with a local fail URL and in-cluster mock so retrigger no longer fails with 500 when public httpbin returns 503. Re-enables [RHDHBUGS-3453](https://redhat.atlassian.net/browse/RHDHBUGS-3453) coverage on release-1.10.