### PR TITLE
[release-1.10][Orchestrator]:  CVE-2026-59869 js-yaml fix for Orchestrator

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -40,20 +40,20 @@
    languageName: node
    linkType: hard
  
-@@ -10983,13 +10982,6 @@
-   version: 1.0.2
-   resolution: "@protobufjs/float@npm:1.0.2"
-   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
--  languageName: node
--  linkType: hard
--
+@@ -10986,13 +10985,6 @@
+   languageName: node
+   linkType: hard
+ 
 -"@protobufjs/inquire@npm:^1.1.0":
 -  version: 1.1.0
 -  resolution: "@protobufjs/inquire@npm:1.1.0"
 -  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
-   languageName: node
-   linkType: hard
- 
+-  languageName: node
+-  linkType: hard
+-
+ "@protobufjs/path@npm:^1.1.2":
+   version: 1.1.2
+   resolution: "@protobufjs/path@npm:1.1.2"
 @@ -11007,10 +10999,10 @@
    languageName: node
    linkType: hard
@@ -137,7 +137,58 @@
    languageName: node
    linkType: hard
  
-@@ -29427,6 +29428,13 @@
+@@ -28137,25 +28138,25 @@
+   linkType: hard
+ 
+ "js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1, js-yaml@npm:^3.8.3":
+-  version: 3.14.2
+-  resolution: "js-yaml@npm:3.14.2"
++  version: 3.15.0
++  resolution: "js-yaml@npm:3.15.0"
+   dependencies:
+     argparse: "npm:^1.0.7"
+     esprima: "npm:^4.0.0"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
++  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+   languageName: node
+   linkType: hard
+ 
+-"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:~4.1.0":
+-  version: 4.1.1
+-  resolution: "js-yaml@npm:4.1.1"
++"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0":
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
+   dependencies:
+     argparse: "npm:^2.0.1"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
++  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+   languageName: node
+   linkType: hard
+ 
+@@ -28168,6 +28169,17 @@
+   bin:
+     js-yaml: bin/js-yaml.js
+   checksum: 10c0/3ae3e71d2d462b97c04a2f3f1c621ad749462e3bef7fb83e6d2fbb1e6024035ea3078e853b84a015a083b7ce5806e14e3c7fd0df0fa2e0a844d45cc414ddfae7
++  languageName: node
++  linkType: hard
++
++"js-yaml@npm:~4.1.0":
++  version: 4.1.1
++  resolution: "js-yaml@npm:4.1.1"
++  dependencies:
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+   languageName: node
+   linkType: hard
+ 
+@@ -29427,6 +29439,13 @@
    version: 5.2.3
    resolution: "long@npm:5.2.3"
    checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
@@ -151,7 +202,7 @@
    languageName: node
    linkType: hard
  
-@@ -33625,22 +33633,21 @@
+@@ -33625,22 +33644,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3":
@@ -182,7 +233,7 @@
    languageName: node
    linkType: hard
  
-@@ -38727,9 +38734,9 @@
+@@ -38727,9 +38745,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.2.3, undici@npm:^7.24.0":

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -27,6 +27,27 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-59869
+    package: js-yaml
+    patch_version: 3.0.2, 3.15.0, 4.1.0, 4.1.1, 4.3.0
+    notes: |-
+      [auto] js-yaml@3.0.2 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.6.4
+          └─┬ js-yaml-cli@0.6.0
+            └── js-yaml@3.0.2
+      js-yaml@4.1.0 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ app-legacy@0.0.3
+          └─┬ @backstage/plugin-api-docs@0.13.5
+            └─┬ swagger-ui-react@5.30.0
+              └── js-yaml@4.1.0
+      js-yaml@4.1.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ @backstage/repo-tools@0.17.0
+          └─┬ @microsoft/api-documenter@7.28.8
+            └── js-yaml@4.1.1
+  - cve_ids:
       - CVE-2026-45740
     package: protobufjs
     patch_version: 7.6.5
@@ -48,5 +69,6 @@ backports:
           └─┬ @backstage/cli-module-build@0.1.0
             └─┬ @module-federation/enhanced@0.21.6
               └─┬ @module-federation/dts-plugin@0.21.6
-                └─┬ isomorphic-ws@5.0.0
-                  └── ws@8.18.0
+                ├─┬ isomorphic-ws@5.0.0
+                │ └── ws@8.18.0
+                └── ws@8.18.0


### PR DESCRIPTION
Partial bump to js-yaml.
Remaining unpatched versions are coming from: 
* repo-tools (dev dependency)
* app-legacy (not productized)
* @red-hat-developer-hub/backstage-plugin-orchestrator-common which is used to generate apis but shows up as a direct dependency (see [changelog](https://github.com/redhat-developer/rhdh-plugins/blob/460877ee877164bd7d8da6688cb57ab6f5e248b3/workspaces/orchestrator/plugins/orchestrator-common/CHANGELOG.md?plain=1#L134))

Fixes CVE-2026-59869
https://redhat.atlassian.net/browse/RHIDP-15469