### PR TITLE
Update `servicenow` workspace to commit `820afb8` for backstage `1.52.0` on branch `main`

### DIFF
--- a/workspaces/servicenow/metadata/backstage-community-plugin-servicenow-backend.yaml
+++ b/workspaces/servicenow/metadata/backstage-community-plugin-servicenow-backend.yaml
@@ -16,8 +16,8 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage-community/plugin-servicenow-backend"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-servicenow-backend:bs_1.52.0__1.13.0
-  version: 1.13.0
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-servicenow-backend:bs_1.52.0__1.13.1
+  version: 1.13.1
   backstage:
     role: backend-plugin
     supportedVersions: 1.52.0

--- a/workspaces/servicenow/metadata/backstage-community-plugin-servicenow.yaml
+++ b/workspaces/servicenow/metadata/backstage-community-plugin-servicenow.yaml
@@ -16,8 +16,8 @@ metadata:
   tags: []
 spec:
   packageName: "@backstage-community/plugin-servicenow"
-  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-servicenow:bs_1.52.0__1.13.0
-  version: 1.13.0
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-servicenow:bs_1.52.0__1.13.2
+  version: 1.13.2
   backstage:
     role: frontend-plugin
     supportedVersions: 1.52.0

--- a/workspaces/servicenow/plugins-list.yaml
+++ b/workspaces/servicenow/plugins-list.yaml
@@ -1,2 +1,2 @@
 plugins/servicenow:
-plugins/servicenow-backend:
+plugins/servicenow-backend: --embed-package @backstage-community/plugin-servicenow-common

--- a/workspaces/servicenow/source.json
+++ b/workspaces/servicenow/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/backstage/community-plugins","repo-ref":"f0ccaf121aa8eec824ad712947a8b5c14ecde5e5","repo-flat":false,"repo-backstage-version":"1.52.0"}
+{"repo":"https://github.com/backstage/community-plugins","repo-ref":"820afb80df0942d143c0b46e866d08785c4d395a","repo-flat":false,"repo-backstage-version":"1.52.0"}

--- a/workspaces/servicenow/source.json
+++ b/workspaces/servicenow/source.json
@@ -1,1 +1,1 @@
-{"repo":"https://github.com/backstage/community-plugins","repo-ref":"820afb80df0942d143c0b46e866d08785c4d395a","repo-flat":false,"repo-backstage-version":"1.52.0"}
+{"repo":"https://github.com/backstage/community-plugins","repo-ref":"42bb1bd7036b7791fb40c3492654b12b10b165aa","repo-flat":false,"repo-backstage-version":"1.52.0"}


### PR DESCRIPTION
## Summary
- update `workspaces/servicenow/source.json` to `repo-ref` `820afb80df0942d143c0b46e866d08785c4d395a` from npm `gitHead` for `@backstage-community/plugin-servicenow@1.13.2`
- bump ServiceNow frontend metadata to `version: 1.13.2` and OCI target `bs_1.52.0__1.13.2`
- bump ServiceNow backend metadata to `version: 1.13.1` and OCI target `bs_1.52.0__1.13.1`

## Test plan
- [x] verify diff includes only ServiceNow workspace metadata + source files
- [x] run pre-commit hook via `git commit` (passed)
- [ ] comment `/publish` on this PR and confirm generated image tags
- [ ] verify frontend tag exists: `ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-servicenow:bs_1.52.0__1.13.2`
- [ ] verify backend tag exists: `ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-servicenow-backend:bs_1.52.0__1.13.1`

Made with [Cursor](https://cursor.com)