### PR TITLE
chore(fullsend): bump reusable-dispatch shim to v0.32.0

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -44,7 +44,7 @@ jobs:
     if: >-
       github.event_name != 'issue_comment'
       || github.event.comment.user.type != 'Bot'
-    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@807037ff09a6b5d18fbc339d06e57752af9cd522 # v0.30.0
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@3cfa255ab4cc8190670585ea42da529119251632 # v0.32.0
     with:
       event_action: ${{ github.event.action }}
       install_mode: per-repo


### PR DESCRIPTION
## Summary

- Bumps the fullsend reusable-dispatch workflow from v0.30.0 to v0.32.0
- Adds the `harness-dispatch` job which enables CEL-based custom agent triggers (ADR 0061)
- Required for the e2e-fix agent (PR #2635) to be dispatched via its `e2e-fix-agent` label trigger
- No new required inputs — the only addition is an optional `OTEL_EXPORTER_OTLP_TRACES_HEADERS` secret

## Why

v0.30.0 only has hardcoded bash routing for three labels (`ready-for-triage`, `ready-to-code`, `ready-for-review`). Custom agent triggers registered in `.fullsend/config.yaml` with CEL expressions are evaluated by the `harness-dispatch` job, which was added in v0.31.0.

## Test plan

- [ ] Verify existing agents (code, fix, review) continue to work via `/fs-*` commands
- [ ] Verify e2e-fix agent triggers when `e2e-fix-agent` label is added to an issue

Assisted-by: Claude Code