### PR TITLE
chore(deps): [release-1.10][lightspeed] bump js-cookie, js-yaml, brace-expansion, tar, and multer

### DIFF
--- a/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
+++ b/workspaces/lightspeed/patches/0-cve-yarn-lock.patch
@@ -59,7 +59,118 @@
    languageName: node
    linkType: hard
  
-@@ -21397,9 +21389,9 @@
+@@ -12019,15 +12011,15 @@
+   languageName: node
+   linkType: hard
+ 
+-"@segment/analytics-core@npm:1.8.1":
+-  version: 1.8.1
+-  resolution: "@segment/analytics-core@npm:1.8.1"
++"@segment/analytics-core@npm:1.8.3":
++  version: 1.8.3
++  resolution: "@segment/analytics-core@npm:1.8.3"
+   dependencies:
+     "@lukeed/uuid": "npm:^2.0.0"
+     "@segment/analytics-generic-utils": "npm:1.2.0"
+     dset: "npm:^3.1.4"
+     tslib: "npm:^2.4.1"
+-  checksum: 10c0/b842ea655b3c703059c0ab453d486127c4587fb372cd398f8543b7ce04d970301a0621bcd40c59d596ce0bbad6b8e36c87f25d3c0599eecf65890e1ae155fa36
++  checksum: 10c0/ae1a807a093b6e20a429e80b95fc3869ddcf7e8c4e37751d607476835df82a331583c092bee4f7f0116ae9a3f550d687fa5478165c8c2583177249aa628eb2e1
+   languageName: node
+   linkType: hard
+ 
+@@ -12041,20 +12033,30 @@
+   linkType: hard
+ 
+ "@segment/analytics-next@npm:^1.76.0":
+-  version: 1.79.0
+-  resolution: "@segment/analytics-next@npm:1.79.0"
++  version: 1.84.1
++  resolution: "@segment/analytics-next@npm:1.84.1"
+   dependencies:
+     "@lukeed/uuid": "npm:^2.0.0"
+-    "@segment/analytics-core": "npm:1.8.1"
++    "@segment/analytics-core": "npm:1.8.3"
+     "@segment/analytics-generic-utils": "npm:1.2.0"
++    "@segment/analytics-page-tools": "npm:1.0.0"
+     "@segment/analytics.js-video-plugins": "npm:^0.2.1"
+     "@segment/facade": "npm:^3.4.9"
+     dset: "npm:^3.1.4"
+-    js-cookie: "npm:3.0.1"
++    js-cookie: "npm:^3.0.7"
+     node-fetch: "npm:^2.6.7"
+     tslib: "npm:^2.4.1"
+     unfetch: "npm:^4.1.0"
+-  checksum: 10c0/49413e549af8aef20e62486b1e3117526fa55f87dcf290ff19eadc14067c494b5aedeb280c607d7cbfe9fd1911e54c5aad655029566e31d392a0432ee1b6235e
++  checksum: 10c0/fb10b9ed649055bdf72e0cc365de7f7906fa77f4c4a0ca7e0ce440b7b0821a5c2ef232c9f6d3a5dfcd252520b5f660db11c00a8cec1cc356b34e8db588002f3f
++  languageName: node
++  linkType: hard
++
++"@segment/analytics-page-tools@npm:1.0.0":
++  version: 1.0.0
++  resolution: "@segment/analytics-page-tools@npm:1.0.0"
++  dependencies:
++    tslib: "npm:^2.4.1"
++  checksum: 10c0/4f9fa9489c7a299501bbbf646f6b791de97932dd55a5486e9aa8b19d182b632991defabb33b8c2914f719876591871cef85b94ee1fe1158851b21d3bd88a229a
+   languageName: node
+   linkType: hard
+ 
+@@ -14587,10 +14589,10 @@
+   languageName: node
+   linkType: hard
+ 
+-"@types/js-cookie@npm:^2.2.6":
+-  version: 2.2.7
+-  resolution: "@types/js-cookie@npm:2.2.7"
+-  checksum: 10c0/29196c6829982b5efa79117122a7d62cf4bc2f6397ce8eac1539319ff5dce3b44b2d86f2ac064f2ed3488fb24439358f24af6914fde5c5c4bab9a85728a13a6f
++"@types/js-cookie@npm:^3.0.0":
++  version: 3.0.6
++  resolution: "@types/js-cookie@npm:3.0.6"
++  checksum: 10c0/173afaf5ea9d86c22395b9d2a00b6adb0006dcfef165d6dcb0395cdc32f5a5dcf9c3c60f97194119963a15849b8f85121e1ae730b03e40bc0c29b84396ba22f9
+   languageName: node
+   linkType: hard
+ 
+@@ -17284,30 +17286,30 @@
+   linkType: hard
+ 
+ "brace-expansion@npm:^1.1.7":
+-  version: 1.1.11
+-  resolution: "brace-expansion@npm:1.1.11"
++  version: 1.1.16
++  resolution: "brace-expansion@npm:1.1.16"
+   dependencies:
+     balanced-match: "npm:^1.0.0"
+     concat-map: "npm:0.0.1"
+-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
++  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+   languageName: node
+   linkType: hard
+ 
+ "brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
+-  version: 2.0.3
+-  resolution: "brace-expansion@npm:2.0.3"
++  version: 2.1.2
++  resolution: "brace-expansion@npm:2.1.2"
+   dependencies:
+     balanced-match: "npm:^1.0.0"
+-  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
++  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+   languageName: node
+   linkType: hard
+ 
+ "brace-expansion@npm:^5.0.2, brace-expansion@npm:^5.0.5":
+-  version: 5.0.5
+-  resolution: "brace-expansion@npm:5.0.5"
++  version: 5.0.8
++  resolution: "brace-expansion@npm:5.0.8"
+   dependencies:
+     balanced-match: "npm:^4.0.2"
+-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
++  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+   languageName: node
+   linkType: hard
+ 
+@@ -21397,9 +21399,9 @@
    linkType: hard
  
  "fast-uri@npm:^3.0.1":
@@ -72,7 +183,7 @@
    languageName: node
    linkType: hard
  
-@@ -21791,29 +21783,29 @@
+@@ -21791,29 +21793,29 @@
    linkType: hard
  
  "form-data@npm:^2.5.5":
@@ -111,37 +222,103 @@
    languageName: node
    linkType: hard
  
-@@ -22811,6 +22803,15 @@
-   dependencies:
-     function-bind: "npm:^1.1.2"
-   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-+  languageName: node
-+  linkType: hard
-+
+@@ -22814,6 +22816,15 @@
+   languageName: node
+   linkType: hard
+ 
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: "npm:^1.1.2"
 +  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
++  languageName: node
++  linkType: hard
++
+ "hast-util-from-parse5@npm:^7.0.0":
+   version: 7.1.2
+   resolution: "hast-util-from-parse5@npm:7.1.2"
+@@ -25146,20 +25157,13 @@
+   version: 3.7.7
+   resolution: "js-base64@npm:3.7.7"
+   checksum: 10c0/3c905a7e78b601e4751b5e710edd0d6d045ce2d23eb84c9df03515371e1b291edc72808dc91e081cb9855aef6758292a2407006f4608ec3705373dd8baf2f80f
+-  languageName: node
+-  linkType: hard
+-
+-"js-cookie@npm:3.0.1":
+-  version: 3.0.1
+-  resolution: "js-cookie@npm:3.0.1"
+-  checksum: 10c0/a7dab91286c49610fb198bcc0d78fbafe9be869cf3cea6f7eaea515abdfdc9d347982fe22316e34666b479a0701119482d46faa3a350a3a3404eb954405edf72
    languageName: node
    linkType: hard
  
-@@ -26408,6 +26409,13 @@
+-"js-cookie@npm:^2.2.1":
+-  version: 2.2.1
+-  resolution: "js-cookie@npm:2.2.1"
+-  checksum: 10c0/ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
++"js-cookie@npm:^3.0.0, js-cookie@npm:^3.0.7":
++  version: 3.0.8
++  resolution: "js-cookie@npm:3.0.8"
++  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
    languageName: node
    linkType: hard
  
+@@ -25193,7 +25197,7 @@
+   languageName: node
+   linkType: hard
+ 
+-"js-yaml@npm:=4.1.1, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1, js-yaml@npm:~4.1.0":
++"js-yaml@npm:=4.1.1, js-yaml@npm:~4.1.0":
+   version: 4.1.1
+   resolution: "js-yaml@npm:4.1.1"
+   dependencies:
+@@ -25205,17 +25209,28 @@
+   linkType: hard
+ 
+ "js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1, js-yaml@npm:^3.8.3":
+-  version: 3.14.1
+-  resolution: "js-yaml@npm:3.14.1"
++  version: 3.15.0
++  resolution: "js-yaml@npm:3.15.0"
+   dependencies:
+     argparse: "npm:^1.0.7"
+     esprima: "npm:^4.0.0"
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
++  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
+   languageName: node
+   linkType: hard
+ 
++"js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
++  dependencies:
++    argparse: "npm:^2.0.1"
++  bin:
++    js-yaml: bin/js-yaml.js
++  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
++  languageName: node
++  linkType: hard
++
+ "js2xmlparser@npm:^4.0.2":
+   version: 4.0.2
+   resolution: "js2xmlparser@npm:4.0.2"
+@@ -26405,6 +26420,13 @@
+   version: 5.2.3
+   resolution: "long@npm:5.2.3"
+   checksum: 10c0/6a0da658f5ef683b90330b1af76f06790c623e148222da9d75b60e266bbf88f803232dd21464575681638894a84091616e7f89557aa087fd14116c0f4e0e43d9
++  languageName: node
++  linkType: hard
++
 +"long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
-+  languageName: node
-+  linkType: hard
-+
- "longest-streak@npm:^3.0.0":
-   version: 3.1.0
-   resolution: "longest-streak@npm:3.1.0"
-@@ -27929,7 +27937,7 @@
+   languageName: node
+   linkType: hard
+ 
+@@ -27929,7 +27951,7 @@
    languageName: node
    linkType: hard
  
@@ -150,7 +327,25 @@
    version: 2.1.35
    resolution: "mime-types@npm:2.1.35"
    dependencies:
-@@ -31057,22 +31065,21 @@
+@@ -28487,14 +28509,14 @@
+   linkType: hard
+ 
+ "multer@npm:^2.0.2, multer@npm:^2.1.1":
+-  version: 2.1.1
+-  resolution: "multer@npm:2.1.1"
++  version: 2.2.0
++  resolution: "multer@npm:2.2.0"
+   dependencies:
+     append-field: "npm:^1.0.0"
+     busboy: "npm:^1.6.0"
+     concat-stream: "npm:^2.0.0"
+     type-is: "npm:^1.6.18"
+-  checksum: 10c0/2ec4e02833b20f403cfb879d4b64d2a9070d902b9deae7aef18a6faadb707d7665385456cf540aa8a6dadfe3d4c5fc8e0e7b0675b94e1077048b1125426deee6
++  checksum: 10c0/7aa366d89042427347b6ab8e4a203405d7fe942e4a3095648a14526fcf3691d98ffc2da62abf85d8aca0a341f828168eb197b33cfdcfcce29d6ef593a5625591
+   languageName: node
+   linkType: hard
+ 
+@@ -31057,22 +31079,21 @@
    linkType: hard
  
  "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
@@ -179,7 +374,55 @@
    languageName: node
    linkType: hard
  
-@@ -35985,9 +35992,9 @@
+@@ -32089,15 +32110,15 @@
+   linkType: hard
+ 
+ "react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0":
+-  version: 17.5.1
+-  resolution: "react-use@npm:17.5.1"
++  version: 17.6.1
++  resolution: "react-use@npm:17.6.1"
+   dependencies:
+-    "@types/js-cookie": "npm:^2.2.6"
++    "@types/js-cookie": "npm:^3.0.0"
+     "@xobotyi/scrollbar-width": "npm:^1.9.5"
+     copy-to-clipboard: "npm:^3.3.1"
+     fast-deep-equal: "npm:^3.1.3"
+     fast-shallow-equal: "npm:^1.0.0"
+-    js-cookie: "npm:^2.2.1"
++    js-cookie: "npm:^3.0.0"
+     nano-css: "npm:^5.6.2"
+     react-universal-interface: "npm:^0.6.2"
+     resize-observer-polyfill: "npm:^1.5.1"
+@@ -32109,7 +32130,7 @@
+   peerDependencies:
+     react: "*"
+     react-dom: "*"
+-  checksum: 10c0/3d6a8f46539b32698d31600239e72b5c23376a5343d0d687c6520e14532ed7f5c72c9b99d222be4eeacb0401ce3ae763d5648d0476440c8b4a6afbd56dc98bfa
++  checksum: 10c0/8b3babd9f7db14624e172d22c2fb30f091d785e97d0aed84e47e52a3ca8dbdc0c094ab797bbd0e754ff2f92be82357c7a46e08dbc85244edfefa21475f760cdf
+   languageName: node
+   linkType: hard
+ 
+@@ -34869,15 +34890,15 @@
+   linkType: hard
+ 
+ "tar@npm:^7.5.6":
+-  version: 7.5.13
+-  resolution: "tar@npm:7.5.13"
++  version: 7.5.22
++  resolution: "tar@npm:7.5.22"
+   dependencies:
+     "@isaacs/fs-minipass": "npm:^4.0.0"
+     chownr: "npm:^3.0.0"
+     minipass: "npm:^7.1.2"
+     minizlib: "npm:^3.1.0"
+     yallist: "npm:^5.0.0"
+-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
++  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
+   languageName: node
+   linkType: hard
+ 
+@@ -35985,9 +36006,9 @@
    linkType: hard
  
  "undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.24.5":
@@ -192,7 +435,7 @@
    languageName: node
    linkType: hard
  
-@@ -37280,8 +37287,8 @@
+@@ -37280,8 +37301,8 @@
    linkType: hard
  
  "ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.8.0":
@@ -203,7 +446,7 @@
    peerDependencies:
      bufferutil: ^4.0.1
      utf-8-validate: ">=5.0.2"
-@@ -37290,7 +37297,7 @@
+@@ -37290,7 +37311,7 @@
        optional: true
      utf-8-validate:
        optional: true

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -6,6 +6,10 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: fce5805c8f48e4d677f7b160396a9d191fe42f25
 backports:
   - cve_ids:
+      - CVE-2026-13149
+    package: brace-expansion
+    patch_version: 1.1.16, 2.1.2, 5.0.8
+  - cve_ids:
       - CVE-2026-48068
     package: "@grpc/grpc-js"
     patch_version: 1.14.4

--- a/workspaces/lightspeed/patches/cve-backports.yaml
+++ b/workspaces/lightspeed/patches/cve-backports.yaml
@@ -33,10 +33,111 @@ backports:
     package: ip-address
     patch_version: 10.2.0
   - cve_ids:
+      - CVE-2026-46625
+    package: js-cookie
+    patch_version: 3.0.8
+  - cve_ids:
+      - CVE-2026-59869
+    package: js-yaml
+    patch_version: 3.15.0, 4.1.1, 4.3.0
+    notes: |-
+      [auto] js-yaml@4.1.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        ├─┬ @backstage/repo-tools@0.17.0
+        │ └─┬ @microsoft/api-documenter@7.28.6
+        │   └── js-yaml@4.1.1
+        └─┬ app-legacy@0.0.28
+          └─┬ @backstage/plugin-api-docs@0.13.5
+            └─┬ swagger-ui-react@5.30.3
+              └── js-yaml@4.1.1
+  - cve_ids:
+      - CVE-2026-5038
+      - CVE-2026-5079
+    package: multer
+    patch_version: 2.2.0
+  - cve_ids:
       - CVE-2026-45740
       - CVE-2026-59877
     package: protobufjs
     patch_version: 7.6.5
+  - cve_ids:
+      - CVE-2026-59873
+      - CVE-2026-59874
+    package: tar
+    patch_version: 6.2.1, 7.5.22
+    notes: |-
+      [auto] tar@6.2.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/lightspeed@1.0.0
+        ├─┬ @backstage/cli-defaults@0.1.0
+        │ ├─┬ @backstage/cli-module-auth@0.1.0
+        │ │ └─┬ keytar@7.9.0
+        │ │   └─┬ node-gyp@10.2.0
+        │ │     └── tar@6.2.1
+        │ └─┬ @backstage/cli-module-build@0.1.2
+        │   └─┬ node-stdlib-browser@1.3.1
+        │     └─┬ crypto-browserify@3.12.1
+        │       └─┬ browserify-cipher@1.0.1
+        │         └─┬ evp_bytestokey@1.0.3
+        │           └─┬ node-gyp@10.2.0
+        │             └── tar@6.2.1
+        ├─┬ @backstage/repo-tools@0.17.0
+        │ └─┬ chokidar@3.6.0
+        │   └─┬ fsevents@2.3.3
+        │     └─┬ node-gyp@10.2.0
+        │       └── tar@6.2.1
+        ├─┬ @playwright/test@1.58.2
+        │ └─┬ playwright@1.58.2
+        │   └─┬ node-gyp@10.2.0
+        │     └── tar@6.2.1
+        ├─┬ @red-hat-developer-hub/backstage-plugin-lightspeed-backend@2.8.7
+        │ └─┬ @backstage/backend-test-utils@1.11.1
+        │   └─┬ testcontainers@11.11.0
+        │     └─┬ ssh-remote-port-forward@1.0.4
+        │       └─┬ ssh2@1.16.0
+        │         ├─┬ cpu-features@0.0.10
+        │         │ └─┬ node-gyp@10.2.0
+        │         │   └── tar@6.2.1
+        │         └─┬ nan@2.22.0
+        │           └─┬ node-gyp@10.2.0
+        │             └── tar@6.2.1
+        ├─┬ app-legacy@0.0.28
+        │ └─┬ @backstage/plugin-api-docs@0.13.5
+        │   └─┬ swagger-ui-react@5.30.3
+        │     └─┬ swagger-client@3.36.0
+        │       └─┬ @swagger-api/apidom-reference@1.0.0
+        │         ├─┬ @swagger-api/apidom-parser-adapter-json@1.0.0
+        │         │ ├─┬ node-gyp@10.2.0
+        │         │ │ └── tar@6.2.1
+        │         │ ├─┬ tree-sitter-json@0.24.8
+        │         │ │ ├─┬ node-addon-api@8.5.0
+        │         │ │ │ └─┬ node-gyp@10.2.0
+        │         │ │ │   └── tar@6.2.1
+        │         │ │ └─┬ node-gyp@10.2.0
+        │         │ │   └── tar@6.2.1
+        │         │ └─┬ tree-sitter@0.21.1
+        │         │   └─┬ node-gyp@10.2.0
+        │         │     └── tar@6.2.1
+        │         └─┬ @swagger-api/apidom-parser-adapter-yaml-1-2@1.0.0
+        │           └─┬ node-gyp@10.2.0
+        │             └── tar@6.2.1
+        ├─┬ backend@0.0.59
+        │ ├─┬ @backstage/plugin-scaffolder-backend@3.2.0
+        │ │ └─┬ isolated-vm@6.0.2
+        │ │   └─┬ node-gyp@10.2.0
+        │ │     └── tar@6.2.1
+        │ ├─┬ better-sqlite3@12.2.0
+        │ │ └─┬ node-gyp@10.2.0
+        │ │   └── tar@6.2.1
+        │ └─┬ node-gyp@10.2.0
+        │   ├─┬ make-fetch-happen@13.0.1
+        │   │ └─┬ cacache@18.0.4
+        │   │   └── tar@6.2.1
+        │   └── tar@6.2.1
+        └─┬ node-gyp@9.4.1
+          ├─┬ make-fetch-happen@10.2.1
+          │ └─┬ cacache@16.1.3
+          │   └── tar@6.2.1
+          └── tar@6.2.1
   - cve_ids:
       - CVE-2026-12151
       - CVE-2026-6734


### PR DESCRIPTION
It bumps the following dependencies:

1. **js-cookie** to 3.0.8 for patching https://github.com/advisories/GHSA-qjx8-664m-686j -- [RHIDP-15065](https://issues.redhat.com/browse/RHIDP-15065)
1. **js-yaml** to 3.15.0, 4.3.0 for patching https://github.com/advisories/GHSA-52cp-r559-cp3m -- [RHIDP-15469](https://issues.redhat.com/browse/RHIDP-15469)
1. **brace-expansion** to 1.1.16, 2.1.2, 5.0.8 (or higher) for patching https://github.com/advisories/GHSA-3jxr-9vmj-r5cp -- [RHIDP-15243](https://issues.redhat.com/browse/RHIDP-15243) 
-- removed from manifest
1. **tar** to 7.5.19 (or higher) for patching https://github.com/advisories/GHSA-8x88-c5mf-7j5w, https://github.com/advisories/GHSA-23hp-3jrh-7fpw -- [RHIDP-15400](https://issues.redhat.com/browse/RHIDP-15400) and [RHIDP-15401](https://issues.redhat.com/browse/RHIDP-15401)
1. **multer** to 2.2.0 for patching https://github.com/advisories/GHSA-72gw-mp4g-v24j
