### PR TITLE
fix: treat skipped jobs as success in update-versions completion check

### DIFF
--- a/.github/workflows/pr-actions.yaml
+++ b/.github/workflows/pr-actions.yaml
@@ -464,7 +464,7 @@ jobs:
             });
             const success = jobs.data.jobs
               .filter(j => j.name.startsWith('Update versions on PR'))
-              .every(j => j.conclusion === 'success');
+              .every(j => j.conclusion === 'success' || j.conclusion === 'skipped');
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- The `update-versions` completion job in `pr-actions.yaml` checks all `Update versions on PR` jobs for success, but when `versions.json` already matches the base branch, the `Comment PRs` and `Auto-publish updated PRs` jobs are correctly skipped (no work to do). The `skipped` conclusion was treated as failure, causing a false negative commit status.
- The `update-commit` completion job (line 535) already handles this correctly with `|| j.conclusion === 'skipped'` — this aligns the `update-versions` one (line 467) to match.
- This was causing PR [#2812](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2812) to show a failing `update-versions` check despite all real checks passing.

## Test plan
- [ ] Comment `/update-versions` on a PR where `versions.json` already matches the base branch — should now report success instead of failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)