### PR TITLE
testing RHDHBUGS-3399 retryAllProps on release-1.10 nightly

### DIFF
--- a/workspaces/orchestrator/e2e-tests/tests/specs/retry-workflow.tests.ts
+++ b/workspaces/orchestrator/e2e-tests/tests/specs/retry-workflow.tests.ts
@@ -31,6 +31,7 @@ export function registerRetryWorkflowTests(): void {
       await page.unroute("**/api/retry-test/**");
     });
 
+    // RHDHBUGS-3399: nightly probe — verify retries with chart DPDY form-widgets ({{inherit}}).
     test("retryAllProps: 503 responses retry with delay 1500 and backoff 2 (three waits)", async ({
       page,
       uiHelper,


### PR DESCRIPTION
## Summary
- Test PR to re-run `e2e-ocp-helm-nightly` on `release-1.10` for [RHDHBUGS-3399](https://redhat.atlassian.net/browse/RHDHBUGS-3399).
- Confirms whether orchestrator `retryAllProps` stays green with current chart DPDY form-widgets (`{{inherit}}`), vs the earlier failures when retries were missing.

## Context
Investigation found the Jira `$${backend.baseUrl}` symptom is a red herring (schema template text); the real failure mode was `allPropsHits === 1` (no retries). Recent nightlies already pass this case on charts ≥ `1.10-151-CI`.

## Test plan
- [ ] Comment `/test e2e-ocp-helm-nightly` on this PR
- [ ] Confirm `[orchestrator] … retryAllProps` is ✓ in the build log
- [ ] Close without merge after validation (probe-only)


Made with [Cursor](https://cursor.com)