### PR TITLE
fix(fullsend): use registered mint slug for e2e-fix agent

### DIFF
--- a/.fullsend/rhdh/harness/e2e-fix.yaml
+++ b/.fullsend/rhdh/harness/e2e-fix.yaml
@@ -13,7 +13,7 @@ image: ghcr.io/redhat-developer/rhdh-fullsend-code:latest
 policy: rhdh/policies/e2e-fix.yaml
 
 role: coder
-slug: rhdh-e2e-fix
+slug: fullsend-ai-coder
 
 trigger: |
   event.entity.kind == "work_item"


### PR DESCRIPTION
## Summary
- The e2e-fix agent dispatch fails with `"role not allowed"` because the custom slug `rhdh-e2e-fix` is not registered on the fullsend mint service
- Switch to `fullsend-ai-coder` (same slug the upstream code agent uses) which is already registered

## Context
- Failed run: https://github.com/redhat-developer/rhdh-plugin-export-overlays/actions/runs/30282134814/job/90031157523
- Error: `minting status token: calling mint service: mint returned HTTP 403: {"error":"role not allowed"}`

## Test plan
- [ ] Re-trigger the e2e-fix-agent label on an issue and verify the agent dispatches successfully

Assisted-by: Claude Code