### PR TITLE
chore(deps): [release-1.9][orchestrator] update js-yaml brace-expansion @grpc/grpc-js protobufjs multer dompurify tar linkify-it

### DIFF
--- a/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
+++ b/workspaces/orchestrator/patches/0-cve-yarn-lock.patch
@@ -1,6 +1,45 @@
 --- yarn.lock
 +++ yarn.lock
-@@ -10112,27 +10112,26 @@
+@@ -7218,12 +7218,12 @@
+   linkType: hard
+ 
+ "@grpc/grpc-js@npm:^1.10.9":
+-  version: 1.12.2
+-  resolution: "@grpc/grpc-js@npm:1.12.2"
+-  dependencies:
+-    "@grpc/proto-loader": ^0.7.13
++  version: 1.14.4
++  resolution: "@grpc/grpc-js@npm:1.14.4"
++  dependencies:
++    "@grpc/proto-loader": ^0.8.0
+     "@js-sdsl/ordered-map": ^4.4.2
+-  checksum: ee51317f92ec5331931b68bf3a4e485a6f7a715609b8aaa29573b3a2b211d5f37c48cda084e25e2bf21142925f8ec9ca49a9e613cbbe06b73785150825d171df
++  checksum: c4b4a4d81f566b483e08bac6ea31f55e63c3befb249d54bd071ece3d156b6b7af4aaaef6bbf8d0e8ee0cb6d86eac304766d5e1f684fde772f248b85f0f2d61f1
+   languageName: node
+   linkType: hard
+ 
+@@ -7241,6 +7241,20 @@
+   languageName: node
+   linkType: hard
+ 
++"@grpc/proto-loader@npm:^0.8.0":
++  version: 0.8.1
++  resolution: "@grpc/proto-loader@npm:0.8.1"
++  dependencies:
++    lodash.camelcase: ^4.3.0
++    long: ^5.0.0
++    protobufjs: ^7.5.5
++    yargs: ^17.7.2
++  bin:
++    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
++  checksum: 9e9804004208d041c33326b416af52628beca2669459f4cf6a90364a845e095d8b2d5922bece497e32ca668434dabca918cc4cb803e933c2024cbacb60b1bfd1
++  languageName: node
++  linkType: hard
++
+ "@headlessui/react@npm:^1.7.15":
+   version: 1.7.19
+   resolution: "@headlessui/react@npm:1.7.19"
+@@ -10112,27 +10126,26 @@
    languageName: node
    linkType: hard
  
@@ -40,7 +79,7 @@
    languageName: node
    linkType: hard
  
-@@ -10143,13 +10142,6 @@
+@@ -10143,13 +10156,6 @@
    languageName: node
    linkType: hard
  
@@ -54,7 +93,7 @@
  "@protobufjs/path@npm:^1.1.2":
    version: 1.1.2
    resolution: "@protobufjs/path@npm:1.1.2"
-@@ -10164,10 +10156,10 @@
+@@ -10164,10 +10170,10 @@
    languageName: node
    linkType: hard
  
@@ -69,7 +108,7 @@
    languageName: node
    linkType: hard
  
-@@ -15803,10 +15795,10 @@
+@@ -15803,10 +15809,10 @@
    languageName: node
    linkType: hard
  
@@ -84,7 +123,7 @@
    languageName: node
    linkType: hard
  
-@@ -16112,14 +16104,14 @@
+@@ -16112,14 +16118,14 @@
    linkType: hard
  
  "@types/request@npm:^2.47.1, @types/request@npm:^2.48.8":
@@ -103,7 +142,35 @@
    languageName: node
    linkType: hard
  
-@@ -21249,14 +21241,14 @@
+@@ -18405,21 +18411,21 @@
+   linkType: hard
+ 
+ "brace-expansion@npm:^1.1.7":
+-  version: 1.1.11
+-  resolution: "brace-expansion@npm:1.1.11"
++  version: 1.1.16
++  resolution: "brace-expansion@npm:1.1.16"
+   dependencies:
+     balanced-match: ^1.0.0
+     concat-map: 0.0.1
+-  checksum: faf34a7bb0c3fcf4b59c7808bc5d2a96a40988addf2e7e09dfbb67a2251800e0d14cd2bfc1aa79174f2f5095c54ff27f46fb1289fe2d77dac755b5eb3434cc07
++  checksum: 11ab2d5b39d61bc0d0de9240a5d08a5f210a5650885ca4876271ef5996b4c5d172d697b501d673fe099ab721aa8bf0348507ad23a6148e169856209d2f9cab94
+   languageName: node
+   linkType: hard
+ 
+ "brace-expansion@npm:^2.0.1":
+-  version: 2.0.1
+-  resolution: "brace-expansion@npm:2.0.1"
++  version: 2.1.3
++  resolution: "brace-expansion@npm:2.1.3"
+   dependencies:
+     balanced-match: ^1.0.0
+-  checksum: a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
++  checksum: 2e5f91dd3a00e4d815a5bb1a5487386e62034d0314a57e2fa7a5f99a6edd7ec30c78ff59bdf40a5faaa58d77f8c3dee1a978dd1d6e6c6d6d6adc2321f603cb21
+   languageName: node
+   linkType: hard
+ 
+@@ -21249,14 +21255,14 @@
    linkType: hard
  
  "dompurify@npm:^3.2.3, dompurify@npm:^3.2.4":
@@ -121,7 +188,7 @@
    languageName: node
    linkType: hard
  
-@@ -23352,30 +23344,30 @@
+@@ -23352,30 +23358,30 @@
    languageName: node
    linkType: hard
  
@@ -162,23 +229,32 @@
    languageName: node
    linkType: hard
  
-@@ -24435,6 +24427,15 @@
+@@ -23932,7 +23938,7 @@
    languageName: node
    linkType: hard
  
+-"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7, glob@npm:^10.4.1, glob@npm:^10.4.5":
++"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.4.1, glob@npm:^10.4.5":
+   version: 10.5.0
+   resolution: "glob@npm:10.5.0"
+   dependencies:
+@@ -24432,6 +24438,15 @@
+   dependencies:
+     function-bind: ^1.1.2
+   checksum: e8516f776a15149ca6c6ed2ae3110c417a00b62260e222590e54aa367cbcd6ed99122020b37b7fbdf05748df57b265e70095d7bf35a47660587619b15ffb93db
++  languageName: node
++  linkType: hard
++
 +"hasown@npm:^2.0.4":
 +  version: 2.0.4
 +  resolution: "hasown@npm:2.0.4"
 +  dependencies:
 +    function-bind: ^1.1.2
 +  checksum: 4bd8f916b629e06324853593ffbdd45e200022952a85ad0c967f3bd4c2e4c7e1f9a9766fbe6186f60bd394e0afc73e719730caa1da15cd9bd832b7cdf53fd26c
-+  languageName: node
-+  linkType: hard
-+
- "hast-util-parse-selector@npm:^2.0.0":
-   version: 2.2.5
-   resolution: "hast-util-parse-selector@npm:2.2.5"
-@@ -26578,10 +26579,10 @@
+   languageName: node
+   linkType: hard
+ 
+@@ -26578,10 +26593,10 @@
    languageName: node
    linkType: hard
  
@@ -193,26 +269,131 @@
    languageName: node
    linkType: hard
  
-@@ -27940,6 +27941,13 @@
+@@ -26642,25 +26657,25 @@
+   linkType: hard
+ 
+ "js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1, js-yaml@npm:^3.8.3":
+-  version: 3.14.2
+-  resolution: "js-yaml@npm:3.14.2"
++  version: 3.15.0
++  resolution: "js-yaml@npm:3.15.0"
+   dependencies:
+     argparse: ^1.0.7
+     esprima: ^4.0.0
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: 626fc207734a3452d6ba84e1c8c226240e6d431426ed94d0ab043c50926d97c509629c08b1d636f5d27815833b7cfd225865631da9fb33cb957374490bf3e90b
++  checksum: 0209830c3ce51cec4c2cefee4b2b68c547b56b36920004efbf7c6a91ae7eee784bf64341738ef1acffa975d16e7882e9b69234b9a4411f455b72b33d4d74771e
    languageName: node
    linkType: hard
  
+ "js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0":
+-  version: 4.1.1
+-  resolution: "js-yaml@npm:4.1.1"
++  version: 4.3.0
++  resolution: "js-yaml@npm:4.3.0"
+   dependencies:
+     argparse: ^2.0.1
+   bin:
+     js-yaml: bin/js-yaml.js
+-  checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
++  checksum: 1268fb22ae8504646cedc0823c18816d4af056029578e855b9a4d3e19bcafc3e9ba9e391f70dea4a29b023bb09f23639766071199cb89e853266b90a6ec25f9a
+   languageName: node
+   linkType: hard
+ 
+@@ -27556,11 +27571,11 @@
+   linkType: hard
+ 
+ "linkify-it@npm:^5.0.0":
+-  version: 5.0.0
+-  resolution: "linkify-it@npm:5.0.0"
++  version: 5.0.2
++  resolution: "linkify-it@npm:5.0.2"
+   dependencies:
+     uc.micro: ^2.0.0
+-  checksum: b0b86cadaf816b64c947a83994ceaad1c15f9fe7e079776ab88699fb71afd7b8fc3fd3d0ae5ebec8c92c1d347be9ba257b8aef338c0ebf81b0d27dcf429a765a
++  checksum: 3ac965e7df2c8788dc5c4c3009aab745f0288dcbc8776ab5bf4317b106c7b7b84fd0f502565d81f9c07f61fa0f0a4150893a6af9d86c36af985aac115bb5c293
+   languageName: node
+   linkType: hard
+ 
+@@ -27937,6 +27952,13 @@
+   version: 5.2.3
+   resolution: "long@npm:5.2.3"
+   checksum: 885ede7c3de4facccbd2cacc6168bae3a02c3e836159ea4252c87b6e34d40af819824b2d4edce330bfb5c4d6e8ce3ec5864bdcf9473fa1f53a4f8225860e5897
++  languageName: node
++  linkType: hard
++
 +"long@npm:^5.3.2":
 +  version: 5.3.2
 +  resolution: "long@npm:5.3.2"
 +  checksum: be215816b563f4ca27ad3677678b53415bc489f9e3466414e54d2d85f5f8e86768547fa58493bacfb363ffc57a664debc83403ccc2178aef0c40aca28bad47c9
-+  languageName: node
-+  linkType: hard
-+
- "longest-streak@npm:^3.0.0":
-   version: 3.1.0
-   resolution: "longest-streak@npm:3.1.0"
-@@ -32080,22 +32088,21 @@
+   languageName: node
    linkType: hard
  
- "protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0":
+@@ -29249,13 +29271,12 @@
+   languageName: node
+   linkType: hard
+ 
+-"minizlib@npm:^3.0.1":
+-  version: 3.0.1
+-  resolution: "minizlib@npm:3.0.1"
++"minizlib@npm:^3.1.0":
++  version: 3.1.0
++  resolution: "minizlib@npm:3.1.0"
+   dependencies:
+-    minipass: ^7.0.4
+-    rimraf: ^5.0.5
+-  checksum: da0a53899252380475240c587e52c824f8998d9720982ba5c4693c68e89230718884a209858c156c6e08d51aad35700a3589987e540593c36f6713fe30cd7338
++    minipass: ^7.1.2
++  checksum: a15e6f0128f514b7d41a1c68ce531155447f4669e32d279bba1c1c071ef6c2abd7e4d4579bb59ccc2ed1531346749665968fdd7be8d83eb6b6ae2fe1f3d370a7
+   languageName: node
+   linkType: hard
+ 
+@@ -29286,15 +29307,6 @@
+   languageName: node
+   linkType: hard
+ 
+-"mkdirp@npm:^3.0.1":
+-  version: 3.0.1
+-  resolution: "mkdirp@npm:3.0.1"
+-  bin:
+-    mkdirp: dist/cjs/src/bin.js
+-  checksum: 972deb188e8fb55547f1e58d66bd6b4a3623bf0c7137802582602d73e6480c1c2268dcbafbfb1be466e00cc7e56ac514d7fd9334b7cf33e3e2ab547c16f83a8d
+-  languageName: node
+-  linkType: hard
+-
+ "mock-json-schema@npm:^1.0.7":
+   version: 1.1.1
+   resolution: "mock-json-schema@npm:1.1.1"
+@@ -29433,17 +29445,14 @@
+   linkType: hard
+ 
+ "multer@npm:^2.0.2":
+-  version: 2.0.2
+-  resolution: "multer@npm:2.0.2"
++  version: 2.2.0
++  resolution: "multer@npm:2.2.0"
+   dependencies:
+     append-field: ^1.0.0
+     busboy: ^1.6.0
+     concat-stream: ^2.0.0
+-    mkdirp: ^0.5.6
+-    object-assign: ^4.1.1
+     type-is: ^1.6.18
+-    xtend: ^4.0.2
+-  checksum: 187f3539b3d5b7f80a289288fc21d3e4116ab9ed21ac9b9ceb25272c7344d215e9572f7e7ed01edb876afddf24661b06578f2c0fc67f36655ebb51a13ccf83dc
++  checksum: ed283b3d7ef2a0d1b1d7d6b1688116ca370ba4cfdb0d3f7bb29bd0fdac42199bff87f580b109c559838e38f5af698f77fcf86550ec9240d330405c87912f75c4
+   languageName: node
+   linkType: hard
+ 
+@@ -32079,23 +32088,22 @@
+   languageName: node
+   linkType: hard
+ 
+-"protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0":
 -  version: 7.5.4
 -  resolution: "protobufjs@npm:7.5.4"
++"protobufjs@npm:^7.0.0, protobufjs@npm:^7.2.5, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.5":
 +  version: 7.6.5
 +  resolution: "protobufjs@npm:7.6.5"
    dependencies:
@@ -238,7 +419,7 @@
    languageName: node
    linkType: hard
  
-@@ -33075,15 +33082,15 @@
+@@ -33075,15 +33083,15 @@
    linkType: hard
  
  "react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0, react-use@npm:^17.5.0":
@@ -258,7 +439,7 @@
      nano-css: ^5.6.2
      react-universal-interface: ^0.6.2
      resize-observer-polyfill: ^1.5.1
-@@ -33095,7 +33102,7 @@
+@@ -33095,7 +33103,7 @@
    peerDependencies:
      react: "*"
      react-dom: "*"
@@ -267,7 +448,46 @@
    languageName: node
    linkType: hard
  
-@@ -37123,9 +37130,9 @@
+@@ -33816,17 +33824,6 @@
+   languageName: node
+   linkType: hard
+ 
+-"rimraf@npm:^5.0.5":
+-  version: 5.0.10
+-  resolution: "rimraf@npm:5.0.10"
+-  dependencies:
+-    glob: ^10.3.7
+-  bin:
+-    rimraf: dist/esm/bin.mjs
+-  checksum: 50e27388dd2b3fa6677385fc1e2966e9157c89c86853b96d02e6915663a96b7ff4d590e14f6f70e90f9b554093aa5dbc05ac3012876be558c06a65437337bc05
+-  languageName: node
+-  linkType: hard
+-
+ "ripemd160@npm:=2.0.1":
+   version: 2.0.1
+   resolution: "ripemd160@npm:2.0.1"
+@@ -35843,16 +35840,15 @@
+   linkType: hard
+ 
+ "tar@npm:^7.0.0":
+-  version: 7.4.3
+-  resolution: "tar@npm:7.4.3"
++  version: 7.5.22
++  resolution: "tar@npm:7.5.22"
+   dependencies:
+     "@isaacs/fs-minipass": ^4.0.0
+     chownr: ^3.0.0
+     minipass: ^7.1.2
+-    minizlib: ^3.0.1
+-    mkdirp: ^3.0.1
++    minizlib: ^3.1.0
+     yallist: ^5.0.0
+-  checksum: 8485350c0688331c94493031f417df069b778aadb25598abdad51862e007c39d1dd5310702c7be4a6784731a174799d8885d2fde0484269aea205b724d7b2ffa
++  checksum: e1434f40954410d191ab6d89017bfd40c24869cfd319d19dd74f84db13cbea15370a22bc9b8ecd699d05c2777ec6297f35dac318ed4829b6e776a7cb4f1f7c68
+   languageName: node
+   linkType: hard
+ 
+@@ -37123,9 +37119,9 @@
    linkType: hard
  
  "undici@npm:^7.2.3, undici@npm:^7.22.0":

--- a/workspaces/orchestrator/patches/cve-backports.yaml
+++ b/workspaces/orchestrator/patches/cve-backports.yaml
@@ -6,6 +6,15 @@ patch_file: 0-cve-yarn-lock.patch
 repo_ref: 5605d5631ecfec72f6d2eaa9c5c2e8a5a51b8b6a
 backports:
   - cve_ids:
+      - CVE-2026-48068
+      - CVE-2026-48069
+    package: "@grpc/grpc-js"
+    patch_version: 1.14.4
+  - cve_ids:
+      - CVE-2026-13149
+    package: brace-expansion
+    patch_version: 1.1.16, 2.1.3
+  - cve_ids:
       - CVE-2026-41240
     package: dompurify
     patch_version: 3.2.6, 3.4.11
@@ -34,9 +43,135 @@ backports:
     package: js-cookie
     patch_version: 3.0.8
   - cve_ids:
+      - CVE-2026-59869
+    package: js-yaml
+    patch_version: 3.0.2, 3.13.1, 3.15.0, 4.1.0, 4.3.0
+    notes: |-
+      [auto] js-yaml@3.0.2 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.4.5
+          └─┬ js-yaml-cli@0.6.0
+            └── js-yaml@3.0.2
+      js-yaml@3.13.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ @backstage/repo-tools@0.16.0
+          └─┬ @microsoft/api-documenter@7.25.21
+            └── js-yaml@3.13.1
+      js-yaml@4.1.0 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ app@0.0.3
+          └─┬ @backstage/plugin-api-docs@0.13.1
+            └─┬ swagger-ui-react@5.30.0
+              └── js-yaml@4.1.0
+  - cve_ids:
+      - CVE-2026-48801
+    package: linkify-it
+    patch_version: 3.0.3, 5.0.2
+    notes: |-
+      [auto] linkify-it@3.0.3 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        └─┬ app@0.0.3
+          └─┬ @backstage/plugin-api-docs@0.13.1
+            └─┬ graphiql@3.1.1
+              └─┬ markdown-it@12.3.2
+                └── linkify-it@3.0.3
+  - cve_ids:
+      - CVE-2026-5038
+      - CVE-2026-5079
+    package: multer
+    patch_version: 2.2.0
+  - cve_ids:
       - CVE-2026-45740
+      - CVE-2026-59877
     package: protobufjs
     patch_version: 7.6.5
+  - cve_ids:
+      - CVE-2026-59873
+      - CVE-2026-59874
+    package: tar
+    patch_version: 6.2.1, 7.5.22
+    notes: |-
+      [auto] tar@6.2.1 is still in CVE affected range; verify dev-only
+      └─┬ @internal/orchestrator@1.0.0
+        ├─┬ @backstage/cli@0.34.5
+        │ ├─┬ chokidar@3.6.0
+        │ │ └─┬ fsevents@2.3.3
+        │ │   └─┬ node-gyp@10.2.0
+        │ │     └── tar@6.2.1
+        │ ├─┬ node-stdlib-browser@1.3.1
+        │ │ └─┬ crypto-browserify@3.12.1
+        │ │   └─┬ browserify-cipher@1.0.1
+        │ │     └─┬ evp_bytestokey@1.0.3
+        │ │       └─┬ node-gyp@10.2.0
+        │ │         └── tar@6.2.1
+        │ └── tar@6.2.1
+        ├─┬ @backstage/e2e-test-utils@0.1.1
+        │ └─┬ @playwright/test@1.56.1
+        │   └─┬ playwright@1.56.1
+        │     └─┬ node-gyp@10.2.0
+        │       └── tar@6.2.1
+        ├─┬ @backstage/repo-tools@0.16.0
+        │ └── tar@6.2.1
+        ├─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki@1.0.7
+        │ └─┬ @backstage/backend-test-utils@1.10.0
+        │   └─┬ testcontainers@10.13.2
+        │     └─┬ ssh-remote-port-forward@1.0.4
+        │       └─┬ ssh2@1.16.0
+        │         ├─┬ cpu-features@0.0.10
+        │         │ └─┬ node-gyp@10.2.0
+        │         │   └── tar@6.2.1
+        │         └─┬ nan@2.22.0
+        │           └─┬ node-gyp@10.2.0
+        │             └── tar@6.2.1
+        ├─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-backend@8.6.8
+        │ ├─┬ @backstage/backend-defaults@0.13.1
+        │ │ └── tar@6.2.1
+        │ ├─┬ @backstage/plugin-scaffolder-backend@3.0.1
+        │ │ ├─┬ isolated-vm@5.0.3
+        │ │ │ └─┬ node-gyp@10.2.0
+        │ │ │   └── tar@6.2.1
+        │ │ └── tar@6.2.1
+        │ └─┬ @backstage/plugin-scaffolder-node@0.12.1
+        │   └── tar@6.2.1
+        ├─┬ app@0.0.3
+        │ ├─┬ @backstage-community/plugin-rbac@1.33.2
+        │ │ └─┬ @janus-idp/shared-react@2.14.0
+        │ │   └─┬ @backstage/plugin-kubernetes-common@0.8.3
+        │ │     └─┬ @kubernetes/client-node@0.20.0
+        │ │       └── tar@6.2.1
+        │ └─┬ @backstage/plugin-api-docs@0.13.1
+        │   └─┬ swagger-ui-react@5.30.0
+        │     └─┬ swagger-client@3.36.0
+        │       └─┬ @swagger-api/apidom-reference@1.0.0-rc.1
+        │         ├─┬ @swagger-api/apidom-parser-adapter-json@1.0.0-rc.1
+        │         │ ├─┬ node-gyp@10.2.0
+        │         │ │ └── tar@6.2.1
+        │         │ ├─┬ tree-sitter-json@0.24.8
+        │         │ │ ├─┬ node-addon-api@8.5.0
+        │         │ │ │ └─┬ node-gyp@10.2.0
+        │         │ │ │   └── tar@6.2.1
+        │         │ │ └─┬ node-gyp@10.2.0
+        │         │ │   └── tar@6.2.1
+        │         │ └─┬ tree-sitter@0.21.1
+        │         │   └─┬ node-gyp@10.2.0
+        │         │     └── tar@6.2.1
+        │         └─┬ @swagger-api/apidom-parser-adapter-yaml-1-2@1.0.0-rc.1
+        │           └─┬ node-gyp@10.2.0
+        │             └── tar@6.2.1
+        ├─┬ backend@0.0.0
+        │ ├─┬ better-sqlite3@12.4.1
+        │ │ └─┬ node-gyp@10.2.0
+        │ │   └── tar@6.2.1
+        │ └─┬ node-gyp@10.3.1
+        │   ├─┬ make-fetch-happen@13.0.1
+        │   │ └─┬ cacache@18.0.4
+        │   │   └── tar@6.2.1
+        │   └── tar@6.2.1
+        └─┬ node-gyp@9.4.1
+          ├─┬ make-fetch-happen@10.2.1
+          │ └─┬ cacache@16.1.3
+          │   └── tar@6.2.1
+          └── tar@6.2.1
   - cve_ids:
       - CVE-2026-6734
       - CVE-2026-9697


### PR DESCRIPTION
Performs the following updates: 

**Full patches**:

**js-yaml** (3.15.0 and 4.3.0): addresses [CVE-2026-59869](https://access.redhat.com/security/cve/CVE-2026-59869)  and fixes  [RHIDP-15470](https://issues.redhat.com/browse/RHIDP-15470)

- 	`yarn up -R js-yaml`
- 	cannot update devDependencies `@backstage/repo-tools@0.16.0->@microsoft/api-documenter -> js-yaml@3.13.1`
- 	cannot update devDependencies `js-yaml-cli@0.6.0->js-yaml@3.0.2`
- not running `yarn up -R swagger-ui-react` to minimize `yarn.lock` diff (only affects a subtree of `app@0.0.3 -> ./packages/app`)

**brace-expansion** (1.1.16, 2.1.2, 5.0.7): addresses [CVE-2026-13149](https://access.redhat.com/security/cve/CVE-2026-13149)and fixes  [RHIDP-15244](https://issues.redhat.com/browse/RHIDP-15244)

- `yarn up -R brace-expansion `

**@grpc/grpc-js** (1.9.16, 1.10.12, 1.11.4, 1.12.7, 1.13.5, and 1.14.4): addresses [CVE-2026-48068](https://access.redhat.com/security/cve/CVE-2026-48068) [CVE-2026-48069](https://access.redhat.com/security/cve/CVE-2026-48069) and fixes [RHIDP-15777](https://issues.redhat.com/browse/RHIDP-15777) [RHIDP-15780](https://issues.redhat.com/browse/RHIDP-15780) [RHIDP-15800](https://issues.redhat.com/browse/RHIDP-15800) 

- 	`yarn up -R @grpc/grpc-js`

**protobuf-js** (7.6.5 and 8.6.6): addresses [CVE-2026-59877](https://access.redhat.com/security/cve/CVE-2026-59877) and fixes [RHIDP-15680](https://issues.redhat.com/browse/RHIDP-15680)  

- 	`yarn up -R protobufjs`

**multer** (2.2.0): addresses [CVE-2026-5038](https://access.redhat.com/security/cve/CVE-2026-5038) [CVE-2026-5079](https://access.redhat.com/security/cve/CVE-2026-5079) and fixes [RHIDP-15785](https://issues.redhat.com/browse/RHIDP-15785) [RHIDP-15788](https://issues.redhat.com/browse/RHIDP-15788) 

- 	`yarn up -R multer`

<del>**dompurify**(3.4.12): addresses [CVE-2026-41240](https://access.redhat.com/security/cve/CVE-2026-41240) [CVE-2026-49978](https://access.redhat.com/security/cve/CVE-2026-49978) and fixes [RHIDP-13315](https://issues.redhat.com/browse/RHIDP-13315) [RHIDP-15534](https://issues.redhat.com/browse/RHIDP-15534)</del>

- 	<del>`yarn up -R dompurify`</del>
excluding dompurify to minimize yarn.lock diff (only affect a subtree of app@0.0.3 -> ./packages/app)

**Partial fixes:**

**tar** (bump v7.x to 7.5.22): addresses [CVE-2026-59874](https://access.redhat.com/security/cve/CVE-2026-59874) [CVE-2026-59873](https://access.redhat.com/security/cve/CVE-2026-59873) and fixes [RHIDP-15402](https://issues.redhat.com/browse/RHIDP-15402) [RHIDP-15399](https://issues.redhat.com/browse/RHIDP-15399)

- 	updated all v7 to 7.5.22
- 	all v6 cannot be updated

**linkify-it** (5.0.2): addresses [CVE-2026-48801](https://access.redhat.com/security/cve/CVE-2026-48801) and fixes [RHIDP-15581](https://issues.redhat.com/browse/RHIDP-15581)

- 	`yarn up -R linkify-it`
- 	cannot update `graphiql@3.1.1->markdown-it@12.3.2->linkify-it@3.0.3 under app@0.0.3 -> ./packages/app`