### PR TITLE
Promote app-defaults plugins to tech-preview and enable OOTB (RHIDP-15482)

### DIFF
--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -7,6 +7,7 @@
 #
 # Package support level should only be "generally-available" as of 2.1
 #    Tech-preview entries are commented out until promoted to generally-available
+#    Exception: app-auth / app-integrations (RHIDP-15482) — TP but enabled OOTB for NFS auth
 #    Community plugins have been removed https://redhat.atlassian.net/browse/RHIDP-13262
 packages:
   # should only include GA (or TP with a path to GA) content here
@@ -27,6 +28,12 @@ packages:
     support: "generally-available"
   - package: '@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights'
     support: "generally-available"
+  # NFS OOTB auth prerequisites (RHIDP-15482 / RHDHPLAN-846). TP until security scans
+  # complete for GA; must stay enabled or non-guest authentication will not work.
+  - package: '@red-hat-developer-hub/backstage-plugin-app-auth'
+    support: "tech-preview"
+  - package: '@red-hat-developer-hub/backstage-plugin-app-integrations'
+    support: "tech-preview"
   # - package: '@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions'
   #   support: "tech-preview"
   - package: '@red-hat-developer-hub/backstage-plugin-homepage'

--- a/rhdh-supported-packages.txt
+++ b/rhdh-supported-packages.txt
@@ -9,6 +9,9 @@ adoption-insights/plugins/analytics-module-adoption-insights
 
 analytics/plugins/analytics-provider-segment
 
+app-defaults/plugins/app-auth
+app-defaults/plugins/app-integrations
+
 backstage/plugins/catalog-backend-module-github
 backstage/plugins/catalog-backend-module-github-org
 backstage/plugins/catalog-backend-module-ldap

--- a/workspaces/app-defaults/metadata/red-hat-developer-hub-backstage-plugin-app-auth.yaml
+++ b/workspaces/app-defaults/metadata/red-hat-developer-hub-backstage-plugin-app-auth.yaml
@@ -22,7 +22,7 @@ spec:
     role: frontend-plugin
     supportedVersions: 1.52.0
   author: Red Hat
-  support: dev-preview
+  support: tech-preview
   lifecycle: active
   partOf:
     - app-auth

--- a/workspaces/app-defaults/metadata/red-hat-developer-hub-backstage-plugin-app-integrations.yaml
+++ b/workspaces/app-defaults/metadata/red-hat-developer-hub-backstage-plugin-app-integrations.yaml
@@ -22,7 +22,7 @@ spec:
     role: frontend-plugin
     supportedVersions: 1.52.0
   author: Red Hat
-  support: dev-preview
+  support: tech-preview
   lifecycle: active
   partOf:
     - app-integrations


### PR DESCRIPTION
## Summary

- Bump `app-auth` and `app-integrations` Package metadata from `dev-preview` to `tech-preview`
- Add both packages to `rhdh-supported-packages.txt` (Supported Plugins / Konflux path)
- Enable both under `default.packages.yaml` `packages.enabled` so OOTB NFS auth works beyond guest

**Why tech-preview (not GA):** GA needs Konflux security scanning, which is not wired yet. TP is enough for DPDY inclusion per PM guidance.

**Why enabled while TP:** These plugins carry the auth/SignInPage and SCM integration setup extracted from the legacy frontend. Without them enabled by default, customers only get guest auth after the NFS hard cut-over ([RHDHPLAN-846](https://redhat.atlassian.net/browse/RHDHPLAN-846) / [RHIDP-15077](https://redhat.atlassian.net/browse/RHIDP-15077)). This is an intentional exception to the 2.1 “GA-only in `default.packages.yaml`” header; comments in that file document it. Promote to GA in a follow-up once security scans land.

Keeps delivery **dynamic** (not statically baked) so custom SignInPage / SCMAuth setups remain replaceable.

Jira: https://redhat.atlassian.net/browse/RHIDP-15482

## Test plan

- [ ] `/publish` on this PR
- [ ] `/smoketest` after publish
- [ ] Confirm app-defaults E2E still passes (auth + integrations on app-next)
- [ ] Reviewer ack of TP-in-`enabled:` exception for NFS OOTB auth
- [ ] After merge: midstream sync + Konflux onboarding (Pyxis → KRD → PipelineRuns) per [ONBOARD_KONFLUX](https://gitlab.cee.redhat.com/rhidp/rhdh-plugin-catalog/-/blob/rhdh-1-rhel-9/docs/ONBOARD_KONFLUX.adoc)


Made with [Cursor](https://cursor.com)