### PR TITLE
fix(fullsend): allow code agent to target release branches

### DIFF
--- a/.fullsend/rhdh/harness/code.yaml
+++ b/.fullsend/rhdh/harness/code.yaml
@@ -7,6 +7,8 @@ host_files:
     dest: /sandbox/workspace/.env.d/rhdh-toolchain.env
   - src: rhdh/env/yarn-proxy.env
     dest: /sandbox/workspace/.env.d/yarn-proxy.env
+runner_env:
+  CODE_ALLOWED_TARGET_BRANCHES: "main,release-1.9,release-1.10"
 skills:
   - skills/e2e-failure-analysis
   - skills/playwright-trace


### PR DESCRIPTION
## Summary

- Add `CODE_ALLOWED_TARGET_BRANCHES: "main,release-1.9,release-1.10"` to the code agent harness
- Without this, the upstream post-script only allows the repo default branch (`main`), causing nightly e2e-fix runs on release branches to fail: `agent requested branch 'release-1.10' but allowed branches are: main`

## Context

Observed in [this CI run](https://github.com/redhat-developer/rhdh-plugin-export-overlays/actions/runs/30392788207/job/90388347894) — the code agent successfully analyzed and fixed the issue but the post-script rejected the branch.

**Note:** This list needs updating when new release branches are cut (the upstream post-script uses exact comma-separated match, not glob).

## Test plan

- [ ] Verify code agent can create PRs targeting `release-1.10`
- [ ] Verify code agent can still create PRs targeting `main`

Assisted-by: Claude Code