### PR TITLE
fix(ci): install dependencies without running lifecycle scripts (S6505)

### DIFF
--- a/.github/workflows/sync-user-guide-to-wiki.yaml
+++ b/.github/workflows/sync-user-guide-to-wiki.yaml
@@ -33,7 +33,7 @@ jobs:
       
       - name: Install dependencies
         working-directory: .github/workflows/github-script
-        run: npm ci
+        run: npm ci --ignore-scripts
       
       - name: Sync user guide to wiki
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install js-yaml
+          npm install --ignore-scripts js-yaml
 
       - name: Get branch name
         id: branch

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -185,7 +185,7 @@ RESOLUTIONS="\"@playwright/test\": \"${PLAYWRIGHT_VERSION}\""
 if [[ -n "$E2E_TEST_UTILS_PATH" ]]; then
     echo "[INFO] Using local e2e-test-utils: $E2E_TEST_UTILS_PATH"
     echo "[INFO] Building local e2e-test-utils..."
-    (cd "$E2E_TEST_UTILS_PATH" && yarn install --immutable && yarn build)
+    (cd "$E2E_TEST_UTILS_PATH" && yarn install --immutable --mode=skip-build && yarn build)
     RESOLUTIONS+=", \"@red-hat-developer-hub/e2e-test-utils\": \"file:${E2E_TEST_UTILS_PATH}\""
 elif [[ -n "$E2E_TEST_UTILS_VERSION" ]]; then
     echo "[INFO] Pinning e2e-test-utils to version: $E2E_TEST_UTILS_VERSION"
@@ -214,7 +214,7 @@ for ws in "${E2E_WORKSPACES[@]}"; do
 done
 
 echo "[INFO] Installing dependencies (@playwright/test pinned to $PLAYWRIGHT_VERSION)..."
-YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install --mode=skip-build
 
 # ── Generate root playwright.config.ts ────────────────────────────────────────
 # Extracts project definitions directly from workspace configs via sed instead of

--- a/scripts/e2e-code-quality.sh
+++ b/scripts/e2e-code-quality.sh
@@ -58,7 +58,7 @@ for WORKSPACE in "$@"; do
   echo "========================================"
 
   echo "Installing dependencies..."
-  if ! (cd "$E2E_DIR" && yarn install --immutable 2>&1); then
+  if ! (cd "$E2E_DIR" && yarn install --immutable --mode=skip-build 2>&1); then
     report_error "yarn install failed for ${WORKSPACE}"
     RESULTS="${RESULTS}| ${WORKSPACE} | FAIL (install) | FAIL (install) | FAIL (install) |\n"
     FAILED=1


### PR DESCRIPTION
## Why

SonarCloud's S6505 flags installs that let dependency lifecycle scripts run. The
repo carries several open alerts for it, and because they stay open they get
re-posted as review comments on pull requests that have nothing to do with them
— which is how this came up.

## What changed

Five installs now skip dependency lifecycle scripts:

| File | Line | Change |
|---|---|---|
| `run-e2e.sh` | 188 | `yarn install --immutable --mode=skip-build` |
| `run-e2e.sh` | 217 | `yarn install --mode=skip-build` |
| `scripts/e2e-code-quality.sh` | 61 | `yarn install --immutable --mode=skip-build` |
| `.github/workflows/sync-user-guide-to-wiki.yaml` | 36 | `npm ci --ignore-scripts` |
| `.github/workflows/update-wiki.yml` | 36 | `npm install --ignore-scripts js-yaml` |

Each was checked rather than changed on sight. The e2e installs' only notable
dependency is `@playwright/test`, which has no postinstall — `scripts: {}` on
1.59.1, same for `playwright` and `playwright-core` — and browsers are installed
explicitly at `run-e2e.sh:304`. The explicit `yarn build` at :188 is a project
script and still runs; `--mode=skip-build` only skips dependency build scripts.
The wiki workflows install `@actions/github-script` and `js-yaml`, neither with
any script.

## Deliberately left alone

**`npx playwright install chromium`** (`run-e2e.sh:304`) is also flagged.
Switching it to `yarn playwright` looked correct until the generated root turned
out to be a workspaces root with no direct dependencies — `@playwright/test`
comes from the child workspaces, so Yarn 4 may not resolve the binary there.
Verifying that needs the full e2e pipeline against a cluster, so it is left for
someone who can run it rather than changed on a guess.

**`.github/workflows/native-smoke.yaml:94`** keeps plain `yarn install`; the
comment there already records why `--mode=skip-build` breaks it (better-sqlite3
compiles a native binding during install). That alert wants dismissing in the
code scanning UI, not fixing.

## Testing

The changes are install flags, so the real verification is CI: the e2e and
code-quality jobs exercise three of them, and the two wiki workflows run on
their own triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)