### PR TITLE
chore: bump e2e-test-utils to 2.1.5

### DIFF
--- a/workspaces/acr/e2e-tests/package.json
+++ b/workspaces/acr/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/acr/e2e-tests/yarn.lock
+++ b/workspaces/acr/e2e-tests/yarn.lock
@@ -282,9 +282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -307,7 +307,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -551,7 +551,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/adoption-insights/e2e-tests/package.json
+++ b/workspaces/adoption-insights/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "1.57.0",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/adoption-insights/e2e-tests/yarn.lock
+++ b/workspaces/adoption-insights/e2e-tests/yarn.lock
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -379,7 +379,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -765,7 +765,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:1.57.0"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/analytics/e2e-tests/package.json
+++ b/workspaces/analytics/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/analytics/e2e-tests/yarn.lock
+++ b/workspaces/analytics/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -577,7 +577,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/app-defaults/e2e-tests/package.json
+++ b/workspaces/app-defaults/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/app-defaults/e2e-tests/yarn.lock
+++ b/workspaces/app-defaults/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -567,7 +567,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/argocd/e2e-tests/package.json
+++ b/workspaces/argocd/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/argocd/e2e-tests/yarn.lock
+++ b/workspaces/argocd/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -572,7 +572,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/backstage/e2e-tests/package.json
+++ b/workspaces/backstage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/backstage/e2e-tests/yarn.lock
+++ b/workspaces/backstage/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -626,7 +626,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/bulk-import/e2e-tests/package.json
+++ b/workspaces/bulk-import/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "^1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/bulk-import/e2e-tests/yarn.lock
+++ b/workspaces/bulk-import/e2e-tests/yarn.lock
@@ -361,9 +361,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -386,7 +386,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -991,7 +991,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:^1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/extensions/e2e-tests/package.json
+++ b/workspaces/extensions/e2e-tests/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "dotenv": "17.4.1",
     "eslint": "10.2.0",

--- a/workspaces/extensions/e2e-tests/yarn.lock
+++ b/workspaces/extensions/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1021,7 +1021,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:17.4.1"
     eslint: "npm:10.2.0"

--- a/workspaces/github/e2e-tests/package.json
+++ b/workspaces/github/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/github/e2e-tests/yarn.lock
+++ b/workspaces/github/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1187,7 +1187,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/global-header/e2e-tests/package.json
+++ b/workspaces/global-header/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/global-header/e2e-tests/yarn.lock
+++ b/workspaces/global-header/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1246,7 +1246,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/homepage/e2e-tests/package.json
+++ b/workspaces/homepage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/homepage/e2e-tests/yarn.lock
+++ b/workspaces/homepage/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1312,7 +1312,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/intelligent-assistant/e2e-tests/package.json
+++ b/workspaces/intelligent-assistant/e2e-tests/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.3",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/intelligent-assistant/e2e-tests/yarn.lock
+++ b/workspaces/intelligent-assistant/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.3":
-  version: 2.1.3
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.3"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/67c4f8765dee22f6e475a046dac82c90563657e299505c88959e8cd32d7e3ef9cfc21ebec6b8cf7b6529afb4ce43d3c1f70ab0b64b09c0a7868cb3322ce449fc
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1262,7 +1262,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.3"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/keycloak/e2e-tests/package.json
+++ b/workspaces/keycloak/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/keycloak/e2e-tests/yarn.lock
+++ b/workspaces/keycloak/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1482,7 +1482,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/orchestrator/e2e-tests/package.json
+++ b/workspaces/orchestrator/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "dotenv": "16.6.1",
     "eslint": "10.2.0",

--- a/workspaces/orchestrator/e2e-tests/yarn.lock
+++ b/workspaces/orchestrator/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1771,7 +1771,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:16.6.1"
     eslint: "npm:10.2.0"

--- a/workspaces/quay/e2e-tests/package.json
+++ b/workspaces/quay/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quay/e2e-tests/yarn.lock
+++ b/workspaces/quay/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/quickstart/e2e-tests/package.json
+++ b/workspaces/quickstart/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quickstart/e2e-tests/yarn.lock
+++ b/workspaces/quickstart/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1955,7 +1955,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/rbac/e2e-tests/package.json
+++ b/workspaces/rbac/e2e-tests/package.json
@@ -26,7 +26,7 @@
     "@backstage-community/plugin-rbac-common": "1.26.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/rbac/e2e-tests/yarn.lock
+++ b/workspaces/rbac/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1933,7 +1933,7 @@ __metadata:
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/roadie-backstage-plugins/e2e-tests/package.json
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10c0/508d04453b2da29989c9e62bb5ecc01a9bd26411afb978d30c65c4cf575fef647b2109ebfc98e7a9a2140410286a868277bbfbbccd73e4a89dd3fce73ef901f6
+  checksum: 10c0/e297f55ac43725a169fb1ec34073a13001b4cb3b294aabe55c2607ff8c103cab1dd20306f724b09d9b69c0d67eb9353280a9434ff0296805ae8cb682e2f70fef
   languageName: node
   linkType: hard
 
@@ -1936,7 +1936,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scorecard/e2e-tests/package.json
+++ b/workspaces/scorecard/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scorecard/e2e-tests/yarn.lock
+++ b/workspaces/scorecard/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tekton/e2e-tests/package.json
+++ b/workspaces/tekton/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tekton/e2e-tests/yarn.lock
+++ b/workspaces/tekton/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -2097,7 +2097,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/theme/e2e-tests/package.json
+++ b/workspaces/theme/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/theme/e2e-tests/yarn.lock
+++ b/workspaces/theme/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -2106,7 +2106,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/topology/e2e-tests/package.json
+++ b/workspaces/topology/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "2.1.4",
+    "@red-hat-developer-hub/e2e-test-utils": "2.1.5",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/topology/e2e-tests/yarn.lock
+++ b/workspaces/topology/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.4"
+"@red-hat-developer-hub/e2e-test-utils@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:2.1.5"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/8c2da6bde09acaa60a2782e4a75461c0761bad7822b9b92077f68125b6a195f220a0e61203b10f67ae30a5265cba67ca4be9f7f505ff48b3f18780422d7defb4
+  checksum: 10/fa4ab219c54e1422f085f69952e17c97d11b5dbaf39624a4dd0f7e2d35a25861cc819c0609a49ad5e54ca4a3ee4cbc72ee93b41f24e17be4afe07a47d1e987d9
   languageName: node
   linkType: hard
 
@@ -2133,7 +2133,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.4"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:2.1.5"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
## Summary

- Bumps `@red-hat-developer-hub/e2e-test-utils` from 2.1.3/2.1.4 to 2.1.5 across all 24 workspace e2e-tests.
- [e2e-test-utils v2.1.5](https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/137) retains Playwright traces on all test runs (not just failures), enabling the [fullsend e2e-triage agent](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2980) to compare passing and failing traces for more accurate root cause analysis.

## Test plan

- [x] All 24 workspace pre-commit checks pass (eslint, prettier, typecheck)
- [x] `yarn install` completed successfully for all workspaces

Assisted-by: Claude Code