### PR TITLE
[release-1.10] chore: bump e2e-test-utils to 1.10.1

### DIFF
--- a/workspaces/acr/e2e-tests/package.json
+++ b/workspaces/acr/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/acr/e2e-tests/yarn.lock
+++ b/workspaces/acr/e2e-tests/yarn.lock
@@ -282,9 +282,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -307,7 +307,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -551,7 +551,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/adoption-insights/e2e-tests/package.json
+++ b/workspaces/adoption-insights/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "1.57.0",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/adoption-insights/e2e-tests/yarn.lock
+++ b/workspaces/adoption-insights/e2e-tests/yarn.lock
@@ -354,9 +354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -379,7 +379,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -765,7 +765,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:1.57.0"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/analytics/e2e-tests/package.json
+++ b/workspaces/analytics/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/analytics/e2e-tests/yarn.lock
+++ b/workspaces/analytics/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -577,7 +577,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/argocd/e2e-tests/package.json
+++ b/workspaces/argocd/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/argocd/e2e-tests/yarn.lock
+++ b/workspaces/argocd/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -572,7 +572,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/backstage/e2e-tests/package.json
+++ b/workspaces/backstage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/backstage/e2e-tests/yarn.lock
+++ b/workspaces/backstage/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -626,7 +626,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/bulk-import/e2e-tests/package.json
+++ b/workspaces/bulk-import/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@playwright/test": "^1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.2",
     "eslint-plugin-check-file": "^3.3.1",

--- a/workspaces/bulk-import/e2e-tests/yarn.lock
+++ b/workspaces/bulk-import/e2e-tests/yarn.lock
@@ -333,9 +333,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -358,7 +358,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -922,7 +922,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.39.2"
     "@playwright/test": "npm:^1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:^24.10.1"
     eslint: "npm:^9.39.2"
     eslint-plugin-check-file: "npm:^3.3.1"

--- a/workspaces/extensions/e2e-tests/package.json
+++ b/workspaces/extensions/e2e-tests/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "dotenv": "17.4.1",
     "eslint": "10.2.0",

--- a/workspaces/extensions/e2e-tests/yarn.lock
+++ b/workspaces/extensions/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1021,7 +1021,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:17.4.1"
     eslint: "npm:10.2.0"

--- a/workspaces/github/e2e-tests/package.json
+++ b/workspaces/github/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/github/e2e-tests/yarn.lock
+++ b/workspaces/github/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1187,7 +1187,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/global-header/e2e-tests/package.json
+++ b/workspaces/global-header/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/global-header/e2e-tests/yarn.lock
+++ b/workspaces/global-header/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1246,7 +1246,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/homepage/e2e-tests/package.json
+++ b/workspaces/homepage/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/homepage/e2e-tests/yarn.lock
+++ b/workspaces/homepage/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1312,7 +1312,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/keycloak/e2e-tests/package.json
+++ b/workspaces/keycloak/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/keycloak/e2e-tests/yarn.lock
+++ b/workspaces/keycloak/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1482,7 +1482,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/lightspeed/e2e-tests/package.json
+++ b/workspaces/lightspeed/e2e-tests/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/lightspeed/e2e-tests/yarn.lock
+++ b/workspaces/lightspeed/e2e-tests/yarn.lock
@@ -263,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -288,7 +288,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1415,7 +1415,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/orchestrator/e2e-tests/package.json
+++ b/workspaces/orchestrator/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "dotenv": "16.6.1",
     "eslint": "10.2.0",

--- a/workspaces/orchestrator/e2e-tests/yarn.lock
+++ b/workspaces/orchestrator/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1771,7 +1771,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     dotenv: "npm:16.6.1"
     eslint: "npm:10.2.0"

--- a/workspaces/quay/e2e-tests/package.json
+++ b/workspaces/quay/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quay/e2e-tests/yarn.lock
+++ b/workspaces/quay/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1937,7 +1937,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/quickstart/e2e-tests/package.json
+++ b/workspaces/quickstart/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/quickstart/e2e-tests/yarn.lock
+++ b/workspaces/quickstart/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1955,7 +1955,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/rbac/e2e-tests/package.json
+++ b/workspaces/rbac/e2e-tests/package.json
@@ -26,7 +26,7 @@
     "@backstage-community/plugin-rbac-common": "1.26.0",
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/rbac/e2e-tests/yarn.lock
+++ b/workspaces/rbac/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1933,7 +1933,7 @@ __metadata:
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/roadie-backstage-plugins/e2e-tests/package.json
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
+++ b/workspaces/roadie-backstage-plugins/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10c0/bf7b56c3eb75a2ba1da29dfc25d8da4c742b8d1287f6fd0626ea253afaeba7c36a5523044015b932ab8713c24f7746712d239666b84b19dd52c4646208d56a0e
+  checksum: 10c0/dc79ec1a5d2ac2ec0fb41ce02f2b42c32ccc2203e32fe1d6f51b0bce84b061a72805817b32bbdb6d4df3c542efd27e8f417d3f79b780c524154acfcf32c199fc
   languageName: node
   linkType: hard
 
@@ -1936,7 +1936,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
+++ b/workspaces/scaffolder-backend-module-kubernetes/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/scorecard/e2e-tests/package.json
+++ b/workspaces/scorecard/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/scorecard/e2e-tests/yarn.lock
+++ b/workspaces/scorecard/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -1960,7 +1960,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tech-radar/e2e-tests/package.json
+++ b/workspaces/tech-radar/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tech-radar/e2e-tests/yarn.lock
+++ b/workspaces/tech-radar/e2e-tests/yarn.lock
@@ -291,9 +291,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -316,7 +316,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -2104,7 +2104,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/tekton/e2e-tests/package.json
+++ b/workspaces/tekton/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/tekton/e2e-tests/yarn.lock
+++ b/workspaces/tekton/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -2097,7 +2097,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/theme/e2e-tests/package.json
+++ b/workspaces/theme/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/theme/e2e-tests/yarn.lock
+++ b/workspaces/theme/e2e-tests/yarn.lock
@@ -289,9 +289,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -314,7 +314,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -2106,7 +2106,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"

--- a/workspaces/topology/e2e-tests/package.json
+++ b/workspaces/topology/e2e-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.59.1",
-    "@red-hat-developer-hub/e2e-test-utils": "1.10.0",
+    "@red-hat-developer-hub/e2e-test-utils": "1.10.1",
     "@types/node": "25.5.2",
     "eslint": "10.2.0",
     "eslint-plugin-check-file": "3.3.1",

--- a/workspaces/topology/e2e-tests/yarn.lock
+++ b/workspaces/topology/e2e-tests/yarn.lock
@@ -284,9 +284,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/e2e-test-utils@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.0"
+"@red-hat-developer-hub/e2e-test-utils@npm:1.10.1":
+  version: 1.10.1
+  resolution: "@red-hat-developer-hub/e2e-test-utils@npm:1.10.1"
   dependencies:
     "@axe-core/playwright": "npm:4.11.1"
     "@backstage-community/plugin-rbac-common": "npm:1.26.0"
@@ -309,7 +309,7 @@ __metadata:
     zx: "npm:8.8.5"
   peerDependencies:
     "@playwright/test": ^1.57.0
-  checksum: 10/3c2698b9adae628170ff6e885dab0ae1a6608761973fd225ae45fc9ec3ce7545bdb6d414b3bb8ffdea1d279f44180f3e0ac61f9adf9e98ff5f02236ab5efdda4
+  checksum: 10/98db5c49a11a2d2e5b1b4e4ac28b3ea93c71c4240e4df01ba779e2c3db70fc90517efee681f489dac7202bd86dcfef5b516219b5331c39cde3d72918a1187941
   languageName: node
   linkType: hard
 
@@ -2133,7 +2133,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.59.1"
-    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.0"
+    "@red-hat-developer-hub/e2e-test-utils": "npm:1.10.1"
     "@types/node": "npm:25.5.2"
     eslint: "npm:10.2.0"
     eslint-plugin-check-file: "npm:3.3.1"


### PR DESCRIPTION
## Summary

- Bumps `@red-hat-developer-hub/e2e-test-utils` from 1.10.0 to 1.10.1 across all 23 workspace e2e-tests on `release-1.10`.
- [e2e-test-utils v1.10.1](https://github.com/redhat-developer/rhdh-e2e-test-utils/pull/138) retains Playwright traces on all test runs (not just failures), enabling the [fullsend e2e-triage agent](https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2980) to compare passing and failing traces for more accurate root cause analysis.

## Test plan

- [x] All 23 workspace pre-commit checks pass (eslint, prettier, typecheck)
- [x] `yarn install` completed successfully for all workspaces
- [x] Verified no workspace left with old version

Assisted-by: Claude Code