### PR TITLE
chore(intelligent-assistant): remove lightspeed e2e workarounds (RHIDP-15904)

### DIFF
--- a/workspaces/intelligent-assistant/e2e-tests/tests/config/app-config-rhdh.yaml
+++ b/workspaces/intelligent-assistant/e2e-tests/tests/config/app-config-rhdh.yaml
@@ -25,16 +25,6 @@ backend:
       - "'unsafe-eval'"
       - https://cdn.jsdelivr.net
 
-# Clears the default lightspeed frontend routes/mountPoints so they don't conflict
-# with the renamed intelligent-assistant plugin (same import names, different routes).
-# TODO: Remove after https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2806
-# removes lightspeed from the default catalog index.
-dynamicPlugins:
-  frontend:
-    red-hat-developer-hub.backstage-plugin-lightspeed:
-      dynamicRoutes: []
-      mountPoints: []
-
 intelligent-assistant:
   notebooks:
     enabled: true

--- a/workspaces/intelligent-assistant/e2e-tests/tests/config/dynamic-plugins-nightly.yaml
+++ b/workspaces/intelligent-assistant/e2e-tests/tests/config/dynamic-plugins-nightly.yaml
@@ -1,3 +1,0 @@
-# Intelligent-assistant is already in dynamic-plugins.default.yaml from the catalog index.
-# Do not add workspace metadata plugins here — nightly would duplicate OCI entries.
-plugins: []

--- a/workspaces/intelligent-assistant/e2e-tests/tests/support/test-helper.ts
+++ b/workspaces/intelligent-assistant/e2e-tests/tests/support/test-helper.ts
@@ -11,19 +11,6 @@ import path from "path";
 export const lightspeedNamespace =
   process.env.RHDH_NAMESPACE ?? "intelligent-assistant";
 
-function isNightlyMode(): boolean {
-  if (process.env.GIT_PR_NUMBER) {
-    return false;
-  }
-  if (
-    process.env.E2E_NIGHTLY_MODE === "true" ||
-    process.env.E2E_NIGHTLY_MODE === "1"
-  ) {
-    return true;
-  }
-  return process.env.JOB_NAME?.includes("periodic-") ?? false;
-}
-
 export const lightspeedDeployConfig = {
   auth: "keycloak" as const,
   version: process.env.RHDH_VERSION ?? "1.11",
@@ -31,9 +18,6 @@ export const lightspeedDeployConfig = {
   appConfig: "tests/config/app-config-rhdh.yaml",
   secrets: "tests/config/rhdh-secrets.yaml",
   valueFile: "tests/config/value_file.yaml",
-  ...(isNightlyMode()
-    ? { dynamicPlugins: "tests/config/dynamic-plugins-nightly.yaml" }
-    : {}),
 };
 
 async function patchOpenAiAllowedModels(rhdh: RHDHDeployment): Promise<void> {


### PR DESCRIPTION
## Summary

- Remove the `dynamic-plugins-nightly.yaml` workaround that forced `plugins: []` in nightly mode to avoid duplicating OCI entries already present in the default catalog index
- Remove the `isNightlyMode()` function and nightly dynamic-plugins conditional from `test-helper.ts` — the framework now correctly auto-generates plugin config from metadata in all modes
- Remove the `dynamicPlugins.frontend.red-hat-developer-hub.backstage-plugin-lightspeed` route/mountPoint override from `app-config-rhdh.yaml` that was preventing naming conflicts with the old lightspeed plugin

All three workarounds were added during the lightspeed → intelligent-assistant rename and are no longer needed now that #2806 removed the lightspeed workspace from the default catalog index.

## Test plan

- [ ] `/test e2e-tests` — verify intelligent-assistant e2e tests pass without the workarounds
- [ ] `/publish` + `/smoketest` — confirm plugins load correctly in nightly-equivalent mode


Made with [Cursor](https://cursor.com)