### PR TITLE
chore(quickstart): re-enable Intelligent Assistant e2e assertions (RHIDP-15911)

### DIFF
--- a/workspaces/quickstart/e2e-tests/tests/specs/quick-start.spec.ts
+++ b/workspaces/quickstart/e2e-tests/tests/specs/quick-start.spec.ts
@@ -45,19 +45,15 @@ test.describe("Test Quick Start plugin", () => {
     await uiHelper.clickButtonByText("Explore plugins");
     await expect(page).toHaveURL(/\/extensions/);
 
-    // TODO(RHDHBUGS): Re-enable after next RHDH image ships with updated
-    // quickstart translations. The baked-in plugin's titleKey resolves to
-    // "Lightspeed" via old translations; once the catalog index rebuilds,
-    // titleKey will resolve to "Intelligent Assistant".
-    // await uiHelper.clickButtonByText("Set up Intelligent Assistant");
-    // await uiHelper.verifyTextVisible(
-    //   "Connect Intelligent Assistant to a supported large language model",
-    // );
-    // await uiHelper.verifyButtonURL(
-    //   "Learn more",
-    //   "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/",
-    //   { exact: false },
-    // );
+    await uiHelper.clickButtonByText("Set up Intelligent Assistant");
+    await uiHelper.verifyTextVisible(
+      "Connect Intelligent Assistant to a supported large language model",
+    );
+    await uiHelper.verifyButtonURL(
+      "Learn more",
+      "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/",
+      { exact: false },
+    );
     await uiHelper.verifyText("20% progress");
 
     await uiHelper.clickButton("Hide");
@@ -91,15 +87,13 @@ test.describe("Test Quick Start plugin", () => {
     await uiHelper.clickButtonByText("View Learning Paths");
     await uiHelper.verifyHeading("Learning Paths");
 
-    // TODO(RHDHBUGS): Re-enable after next RHDH image ships with updated
-    // quickstart translations (see comment in guest/admin test above).
-    // await uiHelper.clickButtonByText("Get started with Intelligent Assistant");
-    // await uiHelper.verifyTextVisible("Troubleshoot issues, generate code");
-    // await uiHelper.verifyButtonURL(
-    //   "Learn more",
-    //   "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/",
-    //   { exact: false },
-    // );
+    await uiHelper.clickButtonByText("Get started with Intelligent Assistant");
+    await uiHelper.verifyTextVisible("Troubleshoot issues, generate code");
+    await uiHelper.verifyButtonURL(
+      "Learn more",
+      "https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/",
+      { exact: false },
+    );
     await uiHelper.verifyText("60% progress");
   });
 });


### PR DESCRIPTION
## Summary

- Re-enable the "Set up Intelligent Assistant" and "Get started with Intelligent Assistant" step assertions in `quick-start.spec.ts` that were commented out in #2807
- Remove the `TODO(RHDHBUGS)` comments — the prerequisite (RHDH image with updated quickstart translations) has been met now that #2806 removed the lightspeed workspace from the default catalog index

## Context

During the lightspeed to intelligent-assistant rename (#2807), the quickstart e2e test assertions for the IA steps were commented out because the baked-in plugin's `titleKey` (e.g. `steps.setupLightspeed.title`) resolved to "Lightspeed" via old translations. The tests expected "Intelligent Assistant" and would fail until the image rebuilt.

Now that #2806 is merged and the catalog index has been rebuilt, the translations resolve correctly.

## Test plan

- [ ] `/test e2e-tests` — verify quickstart e2e tests pass with the assertions re-enabled
- [ ] Assertions verify the correct button text ("Set up Intelligent Assistant", "Get started with Intelligent Assistant") and documentation URLs


Made with [Cursor](https://cursor.com)