### PR TITLE
chore: fix ref to...

### DIFF
--- a/catalog-entities/extensions/plugins/home-page.yaml
+++ b/catalog-entities/extensions/plugins/home-page.yaml
@@ -77,8 +77,8 @@ spec:
       includes:
         - dynamic-plugins.default.yaml
       plugins:
-        # Frontend plugin
-        - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-homepage
+         # Frontend plugin
+        - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage:bs_1.52.0__0.4.0
           enabled: true
           pluginConfig:
             dynamicPlugins:

--- a/catalog-entities/extensions/plugins/home-page.yaml
+++ b/catalog-entities/extensions/plugins/home-page.yaml
@@ -77,7 +77,7 @@ spec:
       includes:
         - dynamic-plugins.default.yaml
       plugins:
-         # Frontend plugin
+        # Frontend plugin
         - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage:bs_1.52.0__0.4.0
           enabled: true
           pluginConfig:


### PR DESCRIPTION
### What does this PR do?

chore: fix ref to red-hat-developer-hub-backstage-plugin-homepage wrapper - use oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage:bs_1.52.0__0.4.0 instead ([RHDHPLAN-225](https://redhat.atlassian.net/browse/RHDHPLAN-225))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.